### PR TITLE
docs: fix broken link in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,13 @@ If you are interested in contributing but unsure where to begin, please get in t
 
 ### Style Guide
 
-CompPoly aims to align closely with the established conventions of the Lean community, particularly those used in `mathlib` and `cslib`. Please follow the [mathlib Style Guide](https://leanprover-community.github.io/contribute/style.html). This covers naming conventions, proof style, formatting, and more. Adhering to this style guide ensures consistency across the library, making it easier for everyone to read, understand, and maintain the code. Our [linting script](scripts/lint-style.sh) helps enforce some aspects of the style guide and runs in the CI. **Please ensure your code passes the linter checks.**
+CompPoly aims to align closely with the established conventions of the Lean community, particularly those used in `mathlib` and `cslib`. Please follow the mathlib Style Guide:
+
+* The [style guide](https://leanprover-community.github.io/contribute/style.html)
+* A guide on the [naming convention](https://leanprover-community.github.io/contribute/naming.html)
+* The [documentation style](https://leanprover-community.github.io/contribute/doc.html)
+
+Adhering to this style guide ensures consistency across the library, making it easier for everyone to read, understand, and maintain the code. Our [linting script](scripts/lint-style.sh) helps enforce some aspects of the style guide and runs in the CI. **Please ensure your code passes the linter checks.**
 
 #### Citation Standards
 


### PR DESCRIPTION
Fixed broken link in Contributing.md to point to correct documentation (Mathlib moved it all to github.io)