### PR TITLE
Typeclass Instances for the Quotient Polynomial

### DIFF
--- a/CompPoly/Univariate/Equiv.lean
+++ b/CompPoly/Univariate/Equiv.lean
@@ -100,7 +100,7 @@ lemma coeff_toPoly {p : CPolynomial Q} {n : ℕ} : p.toPoly.coeff n = p.coeff n 
   intros i acc h
   have i_lt_p : i < p.size := by linarith [i.is_lt]
   have : p.zipIdx[i] = (p[i], ↑i) := by simp [Array.getElem_zipIdx]
-  rw [this, Polynomial.coeff_add, coeff_C_mul, coeff_X_pow, mul_ite, mul_one, mul_zero, h]
+  rw [this, coeff_add, coeff_C_mul, coeff_X_pow, mul_ite, mul_one, mul_zero, h]
   rcases (Nat.lt_trichotomy i n) with hlt | rfl | hgt
   · have h1 : ¬ (n < i) := by linarith
     have h2 : ¬ (n = i) := by linarith
@@ -145,7 +145,7 @@ theorem toPoly_toImpl {p : Q[X]} : p.toImpl.toPoly = p := by
 /-- `toPoly` preserves addition. -/
 theorem toPoly_add {p q : CPolynomial Q} : (addRaw p q).toPoly = p.toPoly + q.toPoly := by
   ext n
-  rw [Polynomial.coeff_add, coeff_toPoly, coeff_toPoly, coeff_toPoly, add_coeff?]
+  rw [coeff_add, coeff_toPoly, coeff_toPoly, coeff_toPoly, add_coeff?]
 
 /-- Trimming doesn't change the `toPoly` image. -/
 lemma toPoly_trim [LawfulBEq R] {p : CPolynomial R} : p.trim.toPoly = p.toPoly := by


### PR DESCRIPTION
This pull request adds the following typeclass(es) for QuotientPolynomialC:
- [x] `AddCommGroup`
- [x] `Semiring`
- [x] `CommSemiring`
- [x] `Ring`
- [x] `CommRing`

This is related to the conversation on #33 pointing out that the only interesting algebraic structure on `CPolynomial R` will probably be a commutative semigroup