### PR TITLE
ExtTreeMapLemmas version

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,7 +6,7 @@ package CompPoly where version := v!"0.1.0"
 
 require "leanprover-community" / mathlib @ git "v4.26.0"
 
-require ExtTreeMapLemmas from git "https://github.com/Verified-zkEVM/ExtTreeMapLemmas"
+require ExtTreeMapLemmas from git "https://github.com/Verified-zkEVM/ExtTreeMapLemmas"@"v4.26.0"
 
 @[default_target]
 lean_lib CompPoly


### PR DESCRIPTION
There are now different version tags for ExtTreeMapLemmas, pinning the correct version here just to mitigate any weird build errors when going back and forth between 4.27.0 and 4.26.0