### PR TITLE
Issue 55 - CommRing instance for CMvPolynomial, resolution of circular dependency

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -12,6 +12,7 @@ import CompPoly.Multilinear.Basic
 import CompPoly.Multilinear.Equiv
 import CompPoly.Multivariate.CMvMonomial
 import CompPoly.Multivariate.CMvPolynomial
+import CompPoly.Multivariate.Operations
 import CompPoly.Multivariate.CMvPolynomialEvalLemmas
 import CompPoly.Multivariate.Restrict
 import CompPoly.Multivariate.VarsDegrees

--- a/CompPoly/Multivariate/MvPolyEquiv.lean
+++ b/CompPoly/Multivariate/MvPolyEquiv.lean
@@ -398,7 +398,7 @@ instance {n : ℕ} : CommSemiring (CPoly.CMvPolynomial n R) where
   npow_succ := by intro n x; simp [npowRecAuto, npowRec]
   mul_comm := by aesop (add safe apply _root_.mul_comm)
 
-section CommRingBridge
+section CommRing
 
 variable {n : ℕ} {R : Type} [CommRing R] [BEq R] [LawfulBEq R]
 
@@ -421,7 +421,7 @@ lemma map_sub (a b : CMvPolynomial n R) :
   unfold Sub.sub Lawful.instSub Lawful.sub
   rw [map_add, map_neg, sub_eq_add_neg]
 
-instance : CommRing (CPoly.CMvPolynomial n R) where
+instance : CommRing (CMvPolynomial n R) where
   neg_add_cancel a := by
     apply fromCMvPolynomial_injective
     simp [map_neg, map_add, map_zero]
@@ -432,7 +432,7 @@ instance : CommRing (CPoly.CMvPolynomial n R) where
   zsmul_succ' := fun _ _ => rfl
   zsmul_neg' := fun _ _ => rfl
 
-end CommRingBridge
+end CommRing
 
 noncomputable def polyRingEquiv :
   RingEquiv (CPoly.CMvPolynomial n R) (MvPolynomial (Fin n) R) where

--- a/CompPoly/Multivariate/Operations.lean
+++ b/CompPoly/Multivariate/Operations.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Frantisek Silvasi, Julian Sutherland, Andrei Burdușa, Derek Sorensen
+Authors: Frantisek Silvasi, Julian Sutherland, Andrei Burdușa, Derek Sorensen, Dimitris Mitsios
 -/
 import CompPoly.Multivariate.MvPolyEquiv
 

--- a/CompPoly/Multivariate/Operations.lean
+++ b/CompPoly/Multivariate/Operations.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2025 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frantisek Silvasi, Julian Sutherland, Andrei Burdușa, Derek Sorensen
+-/
+import CompPoly.Multivariate.MvPolyEquiv
+
+/-!
+# Computable multivariate polynomials (extended operations)
+
+Operations on `CMvPolynomial` that depend on ring instances from `MvPolyEquiv.lean`,
+such as monomial orders, leading terms, restriction, variable renaming, and substitution.
+
+The core type and basic operations (`CMvPolynomial`, `C`, `X`, `coeff`, `eval`, etc.)
+are in `CMvPolynomial.lean`. The `CommSemiring` and `CommRing` instances are in
+`MvPolyEquiv.lean`.
+
+## Main definitions
+
+* `MonomialOrder`: Typeclass for comparing monomials.
+* `leadingMonomial`, `leadingCoeff`: Leading term according to a monomial order.
+* `rename`: Rename variables using a function `Fin n → Fin m`.
+* `aeval`: Algebra evaluation.
+* `bind₁`: Substitution of polynomials for variables.
+-/
+namespace CPoly
+
+open Std
+
+variable {R : Type}
+
+namespace CMvPolynomial
+
+/-- Monomial ordering typeclass for `n` variables.
+
+  Provides a way to compare monomials for determining leading terms.
+-/
+class MonomialOrder (n : ℕ) where
+  compare : CMvMonomial n → CMvMonomial n → Ordering
+  -- TODO: Add ordering axioms (transitivity, etc.)
+
+/-- Degree of a monomial according to a monomial order.
+
+  Returns the degree of a monomial as determined by the ordering.
+  The exact meaning depends on the specific monomial order implementation
+  (e.g., total degree for graded orders, weighted degree, etc.).
+-/
+def MonomialOrder.degree {n : ℕ} [MonomialOrder n] (m : CMvMonomial n) : ℕ :=
+  sorry
+
+/-- Leading monomial of a polynomial according to a monomial order.
+
+  Returns `none` for the zero polynomial.
+-/
+def leadingMonomial {n : ℕ} {R : Type} [Zero R] [MonomialOrder n]
+    (p : CMvPolynomial n R) : Option (CMvMonomial n) :=
+  sorry
+
+/-- Leading coefficient of a polynomial according to a monomial order.
+
+  Returns `0` for the zero polynomial.
+-/
+def leadingCoeff {n : ℕ} {R : Type} [Zero R] [MonomialOrder n]
+    (p : CMvPolynomial n R) : R :=
+  sorry
+
+/-- Algebra evaluation: evaluates polynomial in an algebra.
+
+  Given an algebra `σ` over `R` and a function `f : Fin n → σ`, evaluates the polynomial.
+-/
+def aeval {n : ℕ} {R σ : Type} [CommSemiring R] [CommSemiring σ] [Algebra R σ]
+    (f : Fin n → σ) (p : CMvPolynomial n R) : σ :=
+  sorry
+
+/-- Substitution: substitutes polynomials for variables.
+
+  Given `f : Fin n → CMvPolynomial m R`, substitutes `f i` for variable `X i`.
+-/
+def bind₁ {n m : ℕ} {R : Type} [CommSemiring R] [BEq R] [LawfulBEq R]
+    (f : Fin n → CMvPolynomial m R) (p : CMvPolynomial n R) : CMvPolynomial m R :=
+  sorry
+
+/-- Rename variables using a function.
+
+  Given `f : Fin n → Fin m`, renames variable `X i` to `X (f i)`.
+-/
+def rename {n m : ℕ} {R : Type} [CommSemiring R] [BEq R] [LawfulBEq R]
+    (f : Fin n → Fin m) (p : CMvPolynomial n R) : CMvPolynomial m R :=
+  let renameMonomial (mono : CMvMonomial n) : CMvMonomial m :=
+    Vector.ofFn (fun j => (Finset.univ.filter (fun i => f i = j)).sum (fun i => mono.get i))
+  ExtTreeMap.foldl (fun acc mono c => acc + monomial (renameMonomial mono) c) 0 p.1
+
+-- `renameEquiv` is defined in `CompPoly.Multivariate.Rename`
+
+/-- Scalar multiplication with zero handling.
+
+  This is automatically provided by `Module`, but we list it for completeness.
+
+  TODO: Requires `Module` instance (see above).
+-/
+instance {n : ℕ} {R : Type} [Zero R] [BEq R] [LawfulBEq R] : SMulZeroClass R (CMvPolynomial n R) :=
+  sorry
+
+/-- Convert sum representation to iterative form.
+
+  TODO: Clarify intended behavior - may be related to converting between different
+  polynomial representations or evaluation strategies.
+-/
+def sumToIter {n : ℕ} {R : Type} [CommSemiring R] [BEq R] [LawfulBEq R]
+    (p : CMvPolynomial n R) : CMvPolynomial n R :=
+  sorry
+
+end CMvPolynomial
+
+-- TODO: Phase 1 items requiring Semiring/CommSemiring instances from MvPolyEquiv.lean:
+-- TODO: `Algebra R (CMvPolynomial n R)` instance
+-- TODO: `Module R (CMvPolynomial n R)` instance
+-- TODO: `eval₂Hom` - Ring homomorphism for evaluation
+-- TODO: `finSuccEquiv` - Equivalence between (n+1)-variable and n-variable polynomials
+-- TODO: `optionEquivLeft` - Equivalence for option-indexed variables
+-- TODO: `isEmptyAlgEquiv` - Algebra equivalence for empty variable set
+
+end CPoly

--- a/CompPoly/Multivariate/Rename.lean
+++ b/CompPoly/Multivariate/Rename.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dimitris Mitsios
 -/
-import CompPoly.Multivariate.MvPolyEquiv
+import CompPoly.Multivariate.Operations
 import Mathlib.Algebra.MvPolynomial.Rename
 
 /-!

--- a/CompPoly/Multivariate/Restrict.lean
+++ b/CompPoly/Multivariate/Restrict.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fawad Haider
 -/
-import CompPoly.Multivariate.CMvPolynomial
+import CompPoly.Multivariate.Operations
 
 /-!
 # Lemmas for `CMvPolynomial.restrictBy`, `restrictTotalDegree`, and `restrictDegree`


### PR DESCRIPTION
The current PR fixes #55. A new file `CMvPolynomialBasic.lean` is added that contains basic definitions for polynomials resolving the circular dependency. Additionally, 

-  `CommRing` instance is implemented and typechecks
- Ring axioms are proven