### PR TITLE
Implement Algebra instance for CMvPolynomial (#91)

### DIFF
--- a/CompPoly/Multivariate/MvPolyEquiv.lean
+++ b/CompPoly/Multivariate/MvPolyEquiv.lean
@@ -495,7 +495,8 @@ instance instSMulZeroClass : SMulZeroClass R (CMvPolynomial n R) where
 @[simp]
 lemma smul_def (r : R) (p : CMvPolynomial n R) : r • p = C r * p := rfl
 
-open Std in
+section Algebra
+
 /-- `fromCMvPolynomial` maps `CMvPolynomial.C` to `MvPolynomial.C`. -/
 lemma fromCMvPolynomial_C (r : R) :
     fromCMvPolynomial (C r : CMvPolynomial n R) = MvPolynomial.C r := by
@@ -546,6 +547,8 @@ noncomputable instance instAlgebra : Algebra R (CMvPolynomial n R) :=
   Algebra.mk (toSMul := instSMul) CRingHom
     (fun r x => mul_comm (C r) x)
     (fun _ _ => rfl)
+
+end Algebra
 
 end CMvPolynomial
 


### PR DESCRIPTION
Closes #91

This PR adds proofs autoformalised by @Aristotle-Harmonic.

Implements `Algebra R (CMvPolynomial n R)` in `CompPoly/Multivariate/MvPolyEquiv.lean` by adding `fromCMvPolynomial_C` and `CRingHom`, then constructing `instAlgebra` from existing scalar multiplication.
This resolves the phase-1 theory target in issue #91 

Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>
