### PR TITLE
refactor(binary-tower): rewrite towerAlgebraMap using Fin.dfoldl

### DIFF
--- a/CompPoly/Fields/Binary/Tower/Basic.lean
+++ b/CompPoly/Fields/Binary/Tower/Basic.lean
@@ -647,8 +647,8 @@ private lemma towerAlgebraMapCore_succ_last (l d : ℕ) :
   exact congrArg (fun f => ((canonicalEmbedding (l + d)).comp f) x) hfold
 
 def towerAlgebraMap (l r : ℕ) (h_le : l ≤ r) : BTField l →+* BTField r := by
-  if h_lt : l = r then
-    subst h_lt
+  if h_eq : l = r then
+    subst h_eq
     exact RingHom.id (BTField l)
   else
     exact cast (BTField.RingHom_eq_of_dest_eq (k:=l) (m:=l + (r - l)) (n:=r)


### PR DESCRIPTION
I moved the main logic to `towerAlgebraMapCore`, `towerAlgebraMap` is now just a wrapper around it. Existing callers of `towerAlgebraMap` require no API changes. I kept the current if else branching logic in `towerAlgebraMap` because it helps with proofs. But if preferred I can also do something like:

`def towerAlgebraMap (l r : ℕ) (h_le : l ≤ r) : BTField l →+* BTField r :=
  cast (BTField.RingHom_eq_of_dest_eq (k:=l) (m:=l + (r - l)) (n:=r) (Nat.add_sub_of_le h_le))
    (towerAlgebraMapCore l (r - l))`

Also, I changed the name of the hypothesis in the `towerAlgebraMap` branch to h_eq because it made more sense.

Fixes #130

Co-authored-by: GPT-5.3-Codex
