### PR TITLE
refactor(comp-poly): minimize bivariate transport assumptions

### DIFF
--- a/CompPoly/Bivariate/ToPoly.lean
+++ b/CompPoly/Bivariate/ToPoly.lean
@@ -39,7 +39,7 @@ section ToPolyCore
   Maps each Y-coefficient through `CPolynomial.toPoly`, then builds
   `Polynomial (Polynomial R)` as the sum of monomials.
   -/
-noncomputable def toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+noncomputable def toPoly {R : Type*} [BEq R] [LawfulBEq R] [Semiring R]
     (p : CBivariate R) : R[X][Y] :=
   (CPolynomial.support p).sum (fun j ↦
     monomial j (CPolynomial.toPoly (p.val.coeff j)))
@@ -49,14 +49,14 @@ noncomputable def toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring 
   Extracts each Y-coefficient via `p.coeff`, converts to `CPolynomial R` via
   `toImpl` and trimming, then builds the canonical bivariate sum.
   -/
-def ofPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+def ofPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     [DecidableEq R] (p : R[X][Y]) : CBivariate R :=
   (p.support).sum (fun j ↦
     let cj := p.coeff j
     CPolynomial.monomial j ⟨cj.toImpl, CPolynomial.Raw.isCanonical_toImpl cj⟩)
 
 /-- `toPoly` preserves addition. -/
-lemma toPoly_add {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+lemma toPoly_add {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (p q : CBivariate R) : toPoly (p + q) = toPoly p + toPoly q := by
       have h_linear : ∀ (p q : CPolynomial R), (p + q).toPoly = p.toPoly + q.toPoly := by
         intros p q
@@ -99,7 +99,8 @@ lemma toPoly_add {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
         grind
 
 /-- `toPoly` sends a Y-monomial to the corresponding monomial in `R[X][Y]`. -/
-lemma toPoly_monomial {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R]
+lemma toPoly_monomial {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
+    [DecidableEq R]
     (n : ℕ) (c : CPolynomial R) :
     toPoly (CPolynomial.monomial n c) = monomial n (c.toPoly) := by
       unfold CPolynomial.monomial
@@ -113,7 +114,8 @@ lemma toPoly_monomial {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] 
         exact toFinsupp_eq_zero.mp rfl
 
 /-- `ofPoly` sends a Y-monomial in `R[X][Y]` to a bivariate monomial. -/
-lemma ofPoly_monomial {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R]
+lemma ofPoly_monomial {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
+    [DecidableEq R]
     (n : ℕ) (c : R[X]) :
     ofPoly (monomial n c) =
     CPolynomial.monomial n ⟨c.toImpl, CPolynomial.Raw.isCanonical_toImpl c⟩ := by
@@ -125,7 +127,7 @@ lemma ofPoly_monomial {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] 
 /--
 `Polynomial.toImpl` preserves addition, accounting for trimming in the raw representation.
 -/
-lemma toImpl_add {R : Type*} [BEq R] [LawfulBEq R] [Ring R] (p q : R[X]) :
+lemma toImpl_add {R : Type*} [BEq R] [LawfulBEq R] [Semiring R] (p q : R[X]) :
     p.toImpl + q.toImpl = (p + q).toImpl := by
       have h_add : (p.toImpl + q.toImpl).toPoly = (p + q).toImpl.toPoly := by
         have h_add : (p.toImpl + q.toImpl).toPoly = p.toImpl.toPoly + q.toImpl.toPoly := by
@@ -152,7 +154,8 @@ lemma toImpl_add {R : Type*} [BEq R] [LawfulBEq R] [Ring R] (p q : R[X]) :
       · exact Eq.symm (CPolynomial.Raw.trim_toImpl (p + q))
 
 /-- `ofPoly` preserves addition in `R[X][Y]`. -/
-lemma ofPoly_add {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R]
+lemma ofPoly_add {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
+    [DecidableEq R]
     (p q : R[X][Y]) : ofPoly (p + q) = ofPoly p + ofPoly q := by
       -- Sum of two polynomials is sum of their coefficients; convert back using `ofPoly`.
       have h_ofPoly_add_p : ∀ (p q : Polynomial (Polynomial R)),
@@ -179,7 +182,8 @@ lemma ofPoly_add {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [Deci
       exact h_ofPoly_add_p p q
 
 /-- The outer coefficient of `ofPoly p` converts back to the corresponding `R[X]` coefficient. -/
-theorem ofPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R]
+theorem ofPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
+    [DecidableEq R]
     (p : R[X][Y]) (n : ℕ) : (CPolynomial.coeff (ofPoly p) n).toPoly = p.coeff n := by
       -- By definition of `coeff`, we can express it as a sum over the support of `p`.
       have h_coeff_sum : CPolynomial.coeff (ofPoly p) n =
@@ -202,7 +206,7 @@ theorem ofPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [
       · aesop
 
 /-- The outer coefficient of `toPoly p` is `CPolynomial.coeff p n` converted to `R[X]`. -/
-theorem toPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem toPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Semiring R]
     (p : CBivariate R) (n : ℕ) : (toPoly p).coeff n = (CPolynomial.coeff p n).toPoly := by
       rw [ CBivariate.toPoly, Polynomial.finset_sum_coeff ]
       rw [ Finset.sum_eq_single n ] <;> simp +contextual [ Polynomial.coeff_monomial ]
@@ -212,7 +216,7 @@ theorem toPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
 /--
 `toPoly` is the map of the outer polynomial via `CPolynomial.ringEquiv`.
 -/
-theorem toPoly_eq_map {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem toPoly_eq_map {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (p : CBivariate R) :
     toPoly p = (CPolynomial.toPoly p).map (CPolynomial.ringEquiv (R := R)) := by
       convert Polynomial.ext _
@@ -228,7 +232,7 @@ theorem toPoly_eq_map {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
         by_cases h : n < Array.size p.val <;> aesop
 
 /-- `toPoly` preserves multiplication. -/
-theorem toPoly_mul {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem toPoly_mul {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (p q : CBivariate R) :
     toPoly (p * q) = toPoly p * toPoly q := by
       have h_mul : (p * q).toPoly =
@@ -242,7 +246,8 @@ end ToPolyCore
 section RingEquiv
 
 /-- Round-trip from Mathlib: converting a polynomial to `CBivariate` and back is the identity. -/
-theorem ofPoly_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R]
+theorem ofPoly_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
+    [DecidableEq R]
     (p : R[X][Y]) : toPoly (ofPoly p) = p := by
       induction p using Polynomial.induction_on'
       · rw [ ofPoly_add, toPoly_add,
@@ -252,7 +257,8 @@ theorem ofPoly_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] 
         exact congr_arg _ ( CPolynomial.Raw.toPoly_toImpl )
 
 /-- Round-trip from `CBivariate`: converting to Mathlib and back is the identity. -/
-theorem toPoly_ofPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R]
+theorem toPoly_ofPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
+    [DecidableEq R]
     (p : CBivariate R) : ofPoly (toPoly p) = p := by
       apply CPolynomial.eq_iff_coeff.mpr
       intro i
@@ -268,7 +274,7 @@ theorem toPoly_ofPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] 
 
 /-- Ring equivalence between `CBivariate R` and Mathlib's `R[X][Y]`. -/
 noncomputable def ringEquiv
-    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R] :
+    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] [DecidableEq R] :
     CBivariate R ≃+* R[X][Y] where
   toFun := toPoly
   invFun := ofPoly
@@ -279,20 +285,20 @@ noncomputable def ringEquiv
 
 /-- `toPoly` preserves `1`. -/
 theorem toPoly_one
-    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R] :
+    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] [DecidableEq R] :
     toPoly (1 : CBivariate R) = 1 := by
   simpa [ringEquiv] using (ringEquiv (R := R)).map_one
 
 /-- `ofPoly` preserves `1`. -/
 theorem ofPoly_one
-    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R] :
+    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] [DecidableEq R] :
     ofPoly (1 : R[X][Y]) = 1 := by
   apply (ringEquiv (R := R)).injective
   change toPoly (ofPoly (1 : R[X][Y])) = toPoly (1 : CBivariate R)
   rw [ofPoly_toPoly, toPoly_one]
 
 /-- `toPoly` maps the zero bivariate polynomial to `0`. -/
-lemma toPoly_zero {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] :
+lemma toPoly_zero {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] :
     toPoly (0 : CBivariate R) = 0 := by
       -- The sum over the empty set is zero.
       simp [CBivariate.toPoly]
@@ -300,26 +306,26 @@ lemma toPoly_zero {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] :
       aesop
 
 /-- `ofPoly` maps `0` in `R[X][Y]` to the zero bivariate polynomial. -/
-lemma ofPoly_zero {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R] :
+lemma ofPoly_zero {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] [DecidableEq R] :
     ofPoly (0 : R[X][Y]) = 0 := by
       unfold CBivariate.ofPoly
       simp +decide [ Polynomial.support ]
 
 /-- Ring hom from computable bivariates to Mathlib bivariates. -/
 noncomputable def toPolyRingHom
-    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R] :
+    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] [DecidableEq R] :
     CBivariate R →+* R[X][Y] :=
   (ringEquiv (R := R)).toRingHom
 
 /-- Ring hom from Mathlib bivariates to computable bivariates. -/
 noncomputable def ofPolyRingHom
-    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R] :
+    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] [DecidableEq R] :
     R[X][Y] →+* CBivariate R :=
   (ringEquiv (R := R)).symm.toRingHom
 
 /-- `ofPoly` preserves multiplication. -/
 theorem ofPoly_mul
-    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R]
+    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] [DecidableEq R]
     (p q : R[X][Y]) :
     ofPoly (p * q) = ofPoly p * ofPoly q := by
   apply (ringEquiv (R := R)).injective
@@ -333,7 +339,7 @@ end RingEquiv
 /-- Converting a `foldl` over `Array.zipIdx` of `CPolynomial` coefficients to a
     `Finset.sum` of their `toPoly` images commutes with the `toPoly` map. -/
 private theorem toPoly_foldl_zipIdx_eq_sum {R : Type*} [BEq R] [LawfulBEq R]
-    [Nontrivial R] [Ring R] (arr : Array (CPolynomial R)) (y : R) :
+    [Nontrivial R] [Semiring R] (arr : Array (CPolynomial R)) (y : R) :
     (Array.foldl (fun (acc : CPolynomial R) (x : CPolynomial R × ℕ) ↦
       acc + x.1 * CPolynomial.C y ^ x.2) 0 (Array.zipIdx arr) 0 arr.size).toPoly =
     ∑ i ∈ Finset.range arr.size, (arr[i]?.getD 0).toPoly * (Polynomial.C y) ^ i := by
@@ -361,7 +367,7 @@ private theorem toPoly_foldl_zipIdx_eq_sum {R : Type*} [BEq R] [LawfulBEq R]
 section ImplementationCorrectness
 
 /-- `toPoly` preserves full evaluation: `evalEval x y f = (toPoly f).evalEval x y`. -/
-theorem evalEval_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem evalEval_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (x y : R) (f : CBivariate R) :
     @CBivariate.evalEval R _ _ _ _ x y f = (toPoly f).evalEval x y := by
       unfold CBivariate.evalEval Polynomial.evalEval
@@ -384,7 +390,7 @@ theorem evalEval_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R
       exact CPolynomial.eval_toPoly x (CPolynomial.Raw.eval (CPolynomial.C y) ↑f)
 
 /-- `toPoly` preserves coefficients: coefficient of `X^i Y^j` matches. -/
-theorem coeff_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem coeff_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (f : CBivariate R) (i j : ℕ) :
     ((toPoly f).coeff j).coeff i = CBivariate.coeff (R := R) f i j := by
   rw [toPoly_coeff]
@@ -392,7 +398,7 @@ theorem coeff_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
     (CPolynomial.coeff_toPoly (p := CPolynomial.coeff f j) (i := i)).symm
 
 /-- The outer support of `toPoly f` equals the Y-support of `f`. -/
-theorem support_toPoly_outer {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem support_toPoly_outer {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (f : CBivariate R) : (toPoly f).support = f.supportY := by
       ext x
       simp +decide [ CPolynomial.mem_support_iff, CBivariate.supportY ]
@@ -402,9 +408,8 @@ theorem support_toPoly_outer {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [R
       aesop
 
 /-- `toPoly` preserves Y-degree. -/
-theorem natDegreeY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem natDegreeY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (f : CBivariate R) : (toPoly f).natDegree = f.natDegreeY := by
-      unfold CBivariate.natDegreeY
       -- The degree of the polynomial is the supremum of the exponents in its support.
       have h_deg : ∀ p : Polynomial (Polynomial R), p.natDegree = p.support.sup id := by
         intro p
@@ -416,14 +421,11 @@ theorem natDegreeY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring
       rw [ h_deg, support_toPoly_outer ]
       -- Apply the fact that the degree of a polynomial is equal to the supremum of its support.
       apply Eq.symm
-      change
-        ((f : CPolynomial (CPolynomial R)).natDegree =
-          (CPolynomial.support (f : CPolynomial (CPolynomial R))).sup id)
-      simpa using
-        (CPolynomial.natDegree_eq_support_sup (p := (f : CPolynomial (CPolynomial R))))
+      simpa [CBivariate.natDegreeY, CBivariate.supportY, id] using
+        (CPolynomial.natDegree_eq_support_sup (p := f))
 
 /-- The outer `Y`-coefficient formula used for X-degree transport. -/
-theorem coeff_toPoly_Y {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem coeff_toPoly_Y {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (f : CBivariate R) (j : ℕ) :
     (toPoly f).coeff j = CPolynomial.toPoly (f.val.coeff j) := by
       erw [ Polynomial.finset_sum_coeff ]
@@ -435,7 +437,7 @@ theorem coeff_toPoly_Y {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
       · exact (CPolynomial.toPoly_eq_zero_iff 0).mpr rfl
 
 /-- `toPoly` preserves X-degree (max over Y-coefficients of their degree in X). -/
-theorem natDegreeX_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem natDegreeX_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (f : CBivariate R) :
     (toPoly f).support.sup (fun j ↦ ((toPoly f).coeff j).natDegree) = f.natDegreeX := by
       convert (Finset.sup_congr ?_ ?_)
@@ -461,7 +463,7 @@ theorem natDegreeX_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring
 /--
 `CC` corresponds to the nested constant polynomial in `R[X][Y]`.
 -/
-theorem CC_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] (r : R) :
+theorem CC_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] (r : R) :
     toPoly (CC (R := R) r) = Polynomial.C (Polynomial.C r) := by
   rw [ toPoly_eq_map ]
   unfold CBivariate.CC
@@ -472,7 +474,7 @@ theorem CC_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] (r :
 /--
 `X` (inner variable) corresponds to `Polynomial.C Polynomial.X` in `R[X][Y]`.
 -/
-theorem X_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] :
+theorem X_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] :
     toPoly (X (R := R)) = Polynomial.C Polynomial.X := by
   rw [ toPoly_eq_map ]
   simp [ CBivariate.X, CPolynomial.C_toPoly ]
@@ -482,7 +484,7 @@ theorem X_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] :
 /--
 `Y` (outer variable) corresponds to `Polynomial.X` in `R[X][Y]`.
 -/
-theorem Y_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R] :
+theorem Y_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] [DecidableEq R] :
     toPoly (CBivariate.Y (R := R)) = (Polynomial.X : Polynomial (Polynomial R)) := by
   simpa [CBivariate.Y, CPolynomial.C_toPoly] using
     (toPoly_monomial (R := R) 1 (CPolynomial.C 1))
@@ -490,7 +492,7 @@ theorem Y_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [Deci
 /--
 `monomialXY n m c` corresponds to `Y^m` with inner coefficient `X^n * c`.
 -/
-theorem monomialXY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem monomialXY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     [DecidableEq R] (n m : ℕ) (c : R) :
     toPoly (monomialXY (R := R) n m c) = Polynomial.monomial m (Polynomial.monomial n c) := by
   unfold CBivariate.monomialXY
@@ -501,7 +503,7 @@ theorem monomialXY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring
 /--
 `supportX` corresponds to the union of inner supports of outer coefficients.
 -/
-theorem supportX_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem supportX_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (f : CBivariate R) :
     CBivariate.supportX (R := R) f =
       (toPoly f).support.biUnion (fun j ↦ ((toPoly f).coeff j).support) := by
@@ -514,7 +516,7 @@ theorem supportX_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R
 /--
 `totalDegree` corresponds to the supremum over `j` of `natDegree ((toPoly f).coeff j) + j`.
 -/
-theorem totalDegree_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem totalDegree_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (f : CBivariate R) :
     CBivariate.totalDegree (R := R) f =
       (toPoly f).support.sup (fun j ↦ ((toPoly f).coeff j).natDegree + j) := by
@@ -523,13 +525,12 @@ theorem totalDegree_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Rin
   refine Finset.sup_congr rfl ?_
   intro j hj
   rw [ toPoly_coeff ]
-  simpa using congrArg (fun n ↦ n + j)
-    (CPolynomial.natDegree_toPoly (f.val.coeff j))
+  simpa using congrArg (fun n ↦ n + j) (CPolynomial.natDegree_toPoly (f.val.coeff j))
 
 /--
 `evalX a` evaluates each inner coefficient at `a`.
 -/
-theorem evalX_toPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem evalX_toPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     [DecidableEq R] (a : R) (f : CBivariate R) (j : ℕ) :
     ((evalX (R := R) a f).toPoly).coeff j = ((toPoly f).coeff j).eval a := by
   have h₁ :
@@ -554,7 +555,7 @@ theorem evalX_toPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Rin
 /--
 `evalX` is compatible with full bivariate evaluation when `a` and `y` commute.
 -/
-theorem evalX_toPoly_eval_commute {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem evalX_toPoly_eval_commute {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     [DecidableEq R] (a y : R) (hc : Commute a y) (f : CBivariate R) :
     (evalX (R := R) a f).eval y = (toPoly f).evalEval a y := by
   have h_lhs :
@@ -594,7 +595,7 @@ theorem evalX_toPoly_eval_commute {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial 
 /--
 `evalX_toPoly_eval_commute` specialized to commutative rings.
 -/
-theorem evalX_toPoly_eval {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [CommRing R]
+theorem evalX_toPoly_eval {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [CommSemiring R]
     [DecidableEq R] (a y : R) (f : CBivariate R) :
     (evalX (R := R) a f).eval y = (toPoly f).evalEval a y := by
   simpa using
@@ -605,7 +606,7 @@ The `Commute` hypothesis in `evalX_toPoly_eval_commute` is necessary:
 if the identity holds for every bivariate polynomial then `a` and `y` commute.
 -/
 theorem evalX_toPoly_eval_commute_converse
-    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R] [DecidableEq R]
+    {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] [DecidableEq R]
     (a y : R)
     (h : ∀ f : CBivariate R,
       (evalX (R := R) a f).eval y = (toPoly f).evalEval a y) :
@@ -631,7 +632,7 @@ theorem evalX_toPoly_eval_commute_converse
 /--
 `evalY a` corresponds to outer evaluation at `Polynomial.C a`.
 -/
-theorem evalY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem evalY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (a : R) (f : CBivariate R) :
     (evalY (R := R) a f).toPoly = (toPoly f).eval (Polynomial.C a) := by
   unfold CBivariate.evalY
@@ -653,29 +654,22 @@ theorem evalY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
 /--
 `leadingCoeffY` corresponds to the leading coefficient in the outer variable.
 -/
-theorem leadingCoeffY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem leadingCoeffY_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     (f : CBivariate R) :
     (leadingCoeffY (R := R) f).toPoly = (toPoly f).leadingCoeff := by
   classical
-  have h_leadingCoeffY :
-      (leadingCoeffY (R := R) f).toPoly = (toPoly f).coeff (natDegreeY (R := R) f) := by
-    unfold CBivariate.leadingCoeffY CBivariate.natDegreeY
+  have h_leadingCoeffY : f.leadingCoeff.toPoly = (toPoly f).coeff f.natDegree := by
     rw [CBivariate.toPoly_coeff]
-    have hcoeffNat :
-        (f : CPolynomial (CPolynomial R)).leadingCoeff =
-          CPolynomial.coeff (f : CPolynomial (CPolynomial R))
-            ((f : CPolynomial (CPolynomial R)).natDegree) := by
-      simpa using
-        (CompPoly.CPolynomial.leadingCoeff_eq_coeff_natDegree
-          (p := (f : CPolynomial (CPolynomial R))))
-    exact congrArg CPolynomial.toPoly hcoeffNat
+    exact
+      congrArg CPolynomial.toPoly
+        (CompPoly.CPolynomial.leadingCoeff_eq_coeff_natDegree (p := f))
   rw [← Polynomial.coeff_natDegree, CompPoly.CBivariate.natDegreeY_toPoly]
-  exact h_leadingCoeffY
+  simpa [CBivariate.leadingCoeffY, CBivariate.natDegreeY] using h_leadingCoeffY
 
 /--
 `swap` exchanges X- and Y-exponents.
 -/
-theorem swap_toPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem swap_toPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     [DecidableEq R] (f : CBivariate R) (i j : ℕ) :
     ((toPoly (swap (R := R) f)).coeff j).coeff i = ((toPoly f).coeff i).coeff j := by
   rw [coeff_toPoly, coeff_toPoly]
@@ -782,7 +776,7 @@ theorem swap_toPoly_coeff {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring
 /--
 `leadingCoeffX` is the Y-leading coefficient of the swapped polynomial.
 -/
-theorem leadingCoeffX_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Ring R]
+theorem leadingCoeffX_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]
     [DecidableEq R] (f : CBivariate R) :
     (leadingCoeffX (R := R) f).toPoly = (toPoly (swap (R := R) f)).leadingCoeff := by
   simpa [ CBivariate.leadingCoeffX ] using


### PR DESCRIPTION
## Summary
- finish the remaining `CBivariate.toPoly` transport cleanup on top of the bounded-degree branch
- lower the bivariate bridge to the weaker assumptions its proofs actually use without changing behavior
- keep the PR focused on the bivariate transport layer after the prerequisite degree-transport work from PR #161

## Test plan
- [x] `lake build`
- [x] `./scripts/lint-style.sh`

Made with [Cursor](https://cursor.com)