### PR TITLE
  Migrate towerAlgebraMap recursion to Fin.dfoldl

### DIFF
--- a/CompPoly/Fields/Binary/Tower/Abstract/Algebra.lean
+++ b/CompPoly/Fields/Binary/Tower/Abstract/Algebra.lean
@@ -285,14 +285,14 @@ def binaryTowerModule {l r : ℕ} (h_le : l ≤ r) : Module (BTField l) (BTField
   (binaryAlgebraTower (h_le := h_le)).toModule
 
 /-- The canonical `Algebra` instance between adjacent tower levels `l` and `l + 1`. -/
-instance (priority := 1000) algebra_adjacent_tower (l : ℕ) :
+instance (priority := 1000) algebraAdjacentTower (l : ℕ) :
   Algebra (BTField l) (BTField (l + 1)) := by
   exact binaryAlgebraTower (h_le := by omega)
 
 /-- The `algebraMap` between adjacent levels equals the `canonicalEmbedding`. -/
 lemma algebraMap_adjacent_tower_def (l : ℕ) :
     (algebraMap (BTField l) (BTField (l + 1))) = canonicalEmbedding l := by
-  unfold algebra_adjacent_tower
+  unfold algebraAdjacentTower
   rw [binaryTowerAlgebra_def]
   exact towerAlgebraMap_succ_1 l
 
@@ -303,16 +303,16 @@ lemma algebraMap_adjacent_tower_succ_eq_Adjoin_of (k : ℕ) :
   rfl
 
 /-- The adjacent tower algebra instance equals the canonical embedding's algebra. -/
-lemma algebra_adjacent_tower_def (l : ℕ) :
-    (algebra_adjacent_tower l) = (canonicalEmbedding l).toAlgebra := by
-  unfold algebra_adjacent_tower
+lemma algebraAdjacentTower_def (l : ℕ) :
+    (algebraAdjacentTower l) = (canonicalEmbedding l).toAlgebra := by
+  unfold algebraAdjacentTower
   rw [binaryTowerAlgebra_def]
   rw [towerAlgebraMap_succ_1]
 
 /-- The adjacent tower algebra instance equals the `AdjoinRoot` algebra instance. -/
-lemma algebra_adjacent_tower_eq_AdjoinRoot_algebra (k : ℕ) :
-    (algebra_adjacent_tower k) = (AdjoinRoot.instAlgebra (poly k)) := by
-  rw [algebra_adjacent_tower_def]
+lemma algebraAdjacentTower_eq_adjoinRoot_algebra (k : ℕ) :
+    (algebraAdjacentTower k) = (AdjoinRoot.instAlgebra (poly k)) := by
+  rw [algebraAdjacentTower_def]
   unfold canonicalEmbedding
   rw [←AdjoinRoot.algebraMap_eq]
   rw [algebraMap, Algebra.algebraMap]
@@ -321,7 +321,7 @@ lemma algebra_adjacent_tower_eq_AdjoinRoot_algebra (k : ℕ) :
       (AdjoinRoot.instAlgebra (poly k)) (congrFun rfl)
 
 /-- The algebra equivalence between `AdjoinRoot (poly k)` and `BTField (k + 1)`. -/
-def BTField_succ_alg_equiv_adjoinRoot (k : ℕ) :
+def btFieldSuccAlgEquivAdjoinRoot (k : ℕ) :
     AdjoinRoot (poly k) ≃ₐ[BTField k] BTField (k + 1) := by
   have h_eq : AdjoinRoot (poly k) = BTField (k + 1) := BTField_succ_eq_adjoinRoot k
   exact { -- We can construct RingEquiv in a similar way

--- a/CompPoly/Fields/Binary/Tower/Abstract/Basis.lean
+++ b/CompPoly/Fields/Binary/Tower/Abstract/Basis.lean
@@ -89,7 +89,7 @@ def multilinearBasis (l r : ℕ) (h_le : l ≤ r) :
     -- ⊢ Basis (Fin 2 × Fin (2 ^ n')) (BTField l) (BTField (r))
     have h_eq : l + (n' + 1) = (r1) + 1 := by rw [←add_assoc]
     letI instAlgebraSucc : Algebra (BTField (r1)) (BTField (r1 + 1)) := by
-      exact algebra_adjacent_tower (r1)
+      exact algebraAdjacentTower (r1)
     letI instModuleSucc : Module (BTField l) (BTField (r1 + 1)) := by
       exact instAlgebra.toModule
     letI : IsScalarTower (BTField l) (BTField (r1)) (BTField (r1 + 1)) := by
@@ -242,7 +242,7 @@ theorem multilinearBasis_apply (r : ℕ) : ∀ l : ℕ, (h_le : l ≤ r) → ∀
       rw! (castMode:=.all) [h1]
 
       letI instAlgebraSucc : Algebra (BTField (r1)) (BTField (r1 + 1)) := by
-        exact algebra_adjacent_tower (r1)
+        exact algebraAdjacentTower (r1)
       letI instModuleSucc : Module (BTField l) (BTField (r1 + 1)) := by
         exact instAlgebra.toModule
 
@@ -275,7 +275,7 @@ theorem multilinearBasis_apply (r : ℕ) : ∀ l : ℕ, (h_le : l ≤ r) → ∀
 
       have h_cast_basis_succ_of_eq_rec_apply :=
         PowerBasis.cast_basis_succ_of_eq_rec_apply (r1:=r1) (r:=r) (h_r:=h_r) (k:=indexLeft)
-      unfold algebra_adjacent_tower
+      unfold algebraAdjacentTower
       rw! (castMode:=.all) [←h_r]
       conv_lhs =>
         arg 2
@@ -300,7 +300,7 @@ theorem multilinearBasis_apply (r : ℕ) : ∀ l : ℕ, (h_le : l ≤ r) → ∀
       conv_lhs =>
         rw [←Fin.prod_congr' (b:=r1-l) (a:=prevDiff) (h:=by omega)]
         simp only [Fin.val_cast]
-      simp_rw [algebraMap, instAlgebraSucc, algebra_adjacent_tower]
+      simp_rw [algebraMap, instAlgebraSucc, algebraAdjacentTower]
       rw [RingHom.map_pow]
       simp_rw [←binaryTowerAlgebra_apply_assoc]
       ------------------ Equality of bit-based powers of generators -----------------

--- a/CompPoly/Fields/Binary/Tower/Abstract/Split.lean
+++ b/CompPoly/Fields/Binary/Tower/Abstract/Split.lean
@@ -81,11 +81,11 @@ def powerBasisSucc (k : ℕ) :
     PowerBasis (BTField k) (BTField (k+1)) := by
   let pb : PowerBasis (BTField k) (AdjoinRoot (poly k)) :=
     AdjoinRoot.powerBasis (hf:=by exact poly_ne_zero k)
-  -- ⊢ algebra_adjacent_tower k = AdjoinRoot.instAlgebra (poly k) => TODO : make a lemma for this
+  -- ⊢ algebraAdjacentTower k = AdjoinRoot.instAlgebra (poly k) => TODO : make a lemma for this
   -- NOTE : pb.gen is definitionally equal to AdjoinRoot.root (poly k)
   have h_eq : AdjoinRoot (poly k) = BTField (k+1) := BTField_succ_eq_adjoinRoot k
   -- ⊢ PowerBasis (BTField k) (BTField (k + 1))
-  apply pb.map (e:=BTField_succ_alg_equiv_adjoinRoot k)
+  apply pb.map (e:=btFieldSuccAlgEquivAdjoinRoot k)
 
 lemma powerBasisSucc_gen (k : ℕ) :
     (powerBasisSucc k).gen = (Z (k+1)) := by
@@ -313,7 +313,7 @@ lemma split_algebraMap_eq_zero_x {k : ℕ} (h_pos : k > 0) (x : BTField (k - 1))
   rw [Algebra.smul_def', map_zero, zero_mul, zero_add]
   have h := algebraMap_adjacent_tower_def (l:=k-1)
   rw! (castMode:=.all) [Nat.sub_one_add_one (by omega)] at h
-  simp only [algebra_adjacent_tower, eqRec_eq_cast] at h
+  simp only [algebraAdjacentTower, eqRec_eq_cast] at h
   rw [algebraMap, Algebra.algebraMap] at ⊢ h
   rw! (castMode:=.all) [Nat.sub_one_add_one (by omega)] at h
   simp only [cast_eq] at h


### PR DESCRIPTION
Closes #131. Refactor both concreteTowerAlgebraMap and towerAlgebraMap to use left-to-right composition via Fin.dfoldl (through new Core helpers), replacing the previous right-to-left well-founded recursion.  All existing lemma signatures and downstream call sites are preserved.