### PR TITLE
lagrangeToMono_eq_lagrangeToMonoSpec

### DIFF
--- a/CompPoly/Multilinear/Basic.lean
+++ b/CompPoly/Multilinear/Basic.lean
@@ -21,7 +21,9 @@ import CompPoly.Data.Nat.Bitwise
   `MvPolynomial.restrictDegree (Fin n) R 1`).
 
   ## TODOs
-  - The abstract formula for `monoToLagrange` (zeta formula) and `lagrangeToMono` (mobius formula)
+  - The abstract zeta formula for `monoToLagrange`
+  - A naive `O(4^n)` zeta spec `monoToLagrangeSpec` mirroring `lagrangeToMonoSpec`,
+    plus equivalence `monoToLagrange = monoToLagrangeSpec`
 -/
 
 namespace CompPoly
@@ -380,9 +382,10 @@ def lagrangeToMono (n : ℕ) :
     Vector R (2 ^ n) → Vector R (2 ^ n) :=
   (List.finRange n).foldr (fun h acc => lagrangeToMonoLevel h acc)
 
-/-- The O(n^3) computable version of the Mobius Transform, serving as the spec.
+/-- The $ O(4^n) $ computable version of the Mobius Transform, serving as the spec.
 
-TODO: prove equivalence between `lagrangeToMono` and `lagrangeToMonoSpec` -/
+For each output index $ i $, this sums over all indices $ j $ that are bitwise subsets
+of $ i $, with sign determined by the parity of the Hamming-weight difference. -/
 def lagrangeToMonoSpec (p : CMlPolynomialEval R n) : CMlPolynomialEval R n :=
   -- We define the output vector by specifying the value for each entry `i`.
   Vector.ofFn (fun i =>
@@ -403,6 +406,475 @@ def lagrangeToMonoSpec (p : CMlPolynomialEval R n) : CMlPolynomialEval R n :=
 
 -- #eval lagrangeToMono 2 #v[(78 : ℤ), 3, 4, 100]
 -- #eval lagrangeToMonoSpec (n:=2) #v[(78 : ℤ), 3, 4, 100]
+
+section MobiusEquivalence
+
+/-! ### Fast ↔ Spec equivalence for the Möbius transform
+
+We prove `lagrangeToMono = lagrangeToMonoSpec` by introducing an indexed family of
+"partial Möbius sums" `mobiusPartial k` that interpolates between the identity (at `k = n`)
+and the full spec (at `k = 0`). Each step of the fast transform `lagrangeToMonoLevel (k-1)`
+decrements the parameter by exactly one. Combined with the base case we obtain the result
+by descending induction on `k`. -/
+
+/-- Partial Möbius sum at index `i` after processing levels `[k, k+1, …, n-1]`.
+
+Sums over `j : Fin (2^n)` that are bitwise subsets of `i` and that agree with `i` modulo `2^k`
+(i.e. on all bits strictly below `k`), weighted by `(-1)^(popCount i - popCount j)`.
+
+* At `k = n` only `j = i` satisfies the constraints, so the result is `p[i]`.
+* At `k = 0` the low-bits constraint is vacuous and the formula is exactly
+  `lagrangeToMonoSpec`.
+-/
+private def mobiusPartial (k : ℕ) (p : Vector R (2^n)) (i : Fin (2^n)) : R :=
+  ∑ j : Fin (2^n),
+    if (i.val &&& j.val = j.val) ∧ (i.val % 2^k = j.val % 2^k) then
+      if (i.val.popCount - j.val.popCount) % 2 = 0 then p.get j else -p.get j
+    else 0
+
+/-- Base case: at `k = n` the modular constraint forces `j = i`. -/
+private lemma mobiusPartial_n (p : Vector R (2^n)) (i : Fin (2^n)) :
+    mobiusPartial n p i = p.get i := by
+  unfold mobiusPartial
+  rw [Finset.sum_eq_single i]
+  · have h1 : i.val &&& i.val = i.val := by simp [Nat.and_self]
+    have h2 : i.val % 2^n = i.val % 2^n := rfl
+    simp only [h1, and_self, if_true, Nat.sub_self, Nat.zero_mod, if_true]
+  · intro j _ hji
+    have hji' : j.val ≠ i.val := fun h => hji (Fin.ext h)
+    have hi_lt : i.val < 2^n := i.isLt
+    have hj_lt : j.val < 2^n := j.isLt
+    have : i.val % 2^n ≠ j.val % 2^n := by
+      rw [Nat.mod_eq_of_lt hi_lt, Nat.mod_eq_of_lt hj_lt]
+      exact fun h => hji' h.symm
+    simp [this]
+  · intro h; exact absurd (Finset.mem_univ i) h
+
+/-- The `k = 0` case is (definitionally) equivalent to `lagrangeToMonoSpec`. -/
+private lemma mobiusPartial_zero_eq_spec (p : Vector R (2^n)) (i : Fin (2^n)) :
+    mobiusPartial 0 p i = (lagrangeToMonoSpec p).get i := by
+  unfold mobiusPartial lagrangeToMonoSpec
+  simp only [pow_zero, Nat.mod_one, and_true, Vector.get_ofFn]
+
+
+private lemma popCount_zero' :
+    Nat.popCount 0 = 0 := by
+  unfold Nat.popCount; simp [Nat.digits]
+
+private lemma popCount_pos' {m : ℕ} (hm : 0 < m) :
+    Nat.popCount m =
+      m % 2 + Nat.popCount (m / 2) := by
+  unfold Nat.popCount
+  rw [Nat.digits_def' (by norm_num : 1 < 2) hm]
+  simp [List.sum_cons]
+
+private lemma testBit_succ_eq_div2 (m k : ℕ) :
+    m.testBit (k + 1) = (m / 2).testBit k := by
+  have h := @Nat.testBit_div_two_pow 1 m k
+  rw [pow_one] at h; exact h.symm
+
+private lemma popCount_sub_two_pow {m k : ℕ}
+    (hbit : m.testBit k = true) :
+    Nat.popCount m =
+      Nat.popCount (m - 2 ^ k) + 1 := by
+  induction k generalizing m with
+  | zero =>
+    have hm_pos : 0 < m := by
+      by_contra h; push_neg at h
+      simp only [Nat.le_zero] at h
+      subst h; simp at hbit
+    have hm_odd : m % 2 = 1 := by
+      rw [Nat.testBit] at hbit
+      simp only [Nat.shiftRight_zero,
+        Nat.one_and_eq_mod_two, Nat.mod_two_bne_zero,
+        beq_iff_eq] at hbit; omega
+    rw [popCount_pos' hm_pos, hm_odd, pow_zero]
+    by_cases h1 : m = 1
+    · subst h1; simp [popCount_zero']
+    · rw [popCount_pos' (by omega : 0 < m - 1)]
+      have : (m - 1) % 2 = 0 := by omega
+      have : (m - 1) / 2 = m / 2 := by omega
+      simp_all; ring
+  | succ k ih =>
+    have h2k_le := Nat.ge_two_pow_of_testBit hbit
+    have hm_pos : 0 < m := by
+      linarith [Nat.two_pow_pos (k + 1)]
+    rw [popCount_pos' hm_pos]
+    have hbd : (m / 2).testBit k = true := by
+      rwa [← testBit_succ_eq_div2]
+    by_cases h_eq : m = 2 ^ (k + 1)
+    · subst h_eq
+      rw [Nat.sub_self, popCount_zero']
+      have hmod : 2 ^ (k + 1) % 2 = 0 :=
+        Nat.dvd_iff_mod_eq_zero.mp
+          (dvd_pow_self 2 (by omega))
+      have hdiv : 2 ^ (k + 1) / 2 = 2 ^ k := by
+        have := pow_succ 2 k; omega
+      rw [hmod, hdiv, Nat.zero_add]
+      have h := @ih (2 ^ k) Nat.testBit_two_pow_self
+      rw [Nat.sub_self, popCount_zero'] at h; omega
+    · rw [ih hbd, popCount_pos'
+        (by omega : 0 < m - 2 ^ (k + 1))]
+      have : (m - 2 ^ (k + 1)) % 2 = m % 2 := by
+        have : 2 ∣ 2 ^ (k + 1) :=
+          dvd_pow_self 2 (by omega); omega
+      have : (m - 2 ^ (k + 1)) / 2 =
+          m / 2 - 2 ^ k := by
+        have := pow_succ 2 k; omega
+      simp_all; ring
+
+private lemma submask_testBit_false {i j k : ℕ}
+    (hsub : i &&& j = j)
+    (hbit : i.testBit k = false) :
+    j.testBit k = false := by
+  by_contra hj; simp only [Bool.not_eq_false] at hj
+  have h := Nat.testBit_and i j k
+  rw [hsub] at h
+  simp only [hbit, Bool.false_and] at h
+  exact absurd h.symm (by simp [hj])
+
+private lemma testBit_eq_of_getBit_eq {a b k : ℕ}
+    (h : Nat.getBit k a = Nat.getBit k b) :
+    a.testBit k = b.testBit k := by
+  rw [Nat.getBit_eq_testBit,
+    Nat.getBit_eq_testBit] at h
+  cases ha : a.testBit k <;>
+    cases hb : b.testBit k <;> simp_all
+
+private lemma testBit_sub_self {m k : ℕ}
+    (hbit : m.testBit k = true) :
+    (m - 2 ^ k).testBit k = false := by
+  rw [Nat.testBit_false_eq_getBit_eq_0]
+  have hgb : Nat.getBit k m = 1 := by
+    rw [Nat.testBit_true_eq_getBit_eq_1] at hbit
+    exact hbit
+  have h :=
+    Nat.getBit_of_sub_two_pow_of_bit_1 hgb (j := k)
+  simp at h; exact h
+
+private lemma testBit_sub_ne {a k m : ℕ}
+    (hbit : a.testBit k = true) (hm : m ≠ k) :
+    (a - 2 ^ k).testBit m = a.testBit m := by
+  apply testBit_eq_of_getBit_eq
+  have hgb : Nat.getBit k a = 1 := by
+    rw [Nat.testBit_true_eq_getBit_eq_1] at hbit
+    exact hbit
+  have h :=
+    Nat.getBit_of_sub_two_pow_of_bit_1 hgb (j := m)
+  simp only [hm, ite_false] at h; exact h
+
+private lemma div_mod2_of_testBit_true {a k : ℕ}
+    (h : a.testBit k = true) :
+    (a / 2 ^ k) % 2 = 1 := by
+  rw [Nat.testBit] at h
+  simp only [Nat.shiftRight_eq_div_pow] at h
+  simp only [Nat.one_and_eq_mod_two,
+    Nat.mod_two_bne_zero, beq_iff_eq] at h; omega
+
+private lemma div_mod2_of_testBit_false {a k : ℕ}
+    (h : a.testBit k = false) :
+    (a / 2 ^ k) % 2 = 0 := by
+  rw [Nat.testBit] at h
+  simp only [Nat.shiftRight_eq_div_pow] at h
+  simp only [Nat.one_and_eq_mod_two,
+    Nat.mod_two_bne_zero,
+    beq_eq_false_iff_ne, ne_eq] at h; omega
+
+private lemma rewrite_odd (x P : ℕ)
+    (hodd : (x / P) % 2 = 1) :
+    x = P * 2 * (x / P / 2) + (P + x % P) := by
+  have hd := Nat.div_add_mod x P
+  have : P * (x / P) =
+      P * 2 * (x / P / 2) + P := by
+    have hq : x / P = 2 * (x / P / 2) + 1 := by
+      omega
+    conv_lhs => rw [hq]; rw [Nat.mul_add, Nat.mul_one]
+    show P * (2 * (x / P / 2)) + P =
+      P * 2 * (x / P / 2) + P
+    congr 1; ring
+  linarith
+
+private lemma rewrite_even (x P : ℕ)
+    (heven : (x / P) % 2 = 0) :
+    x = P * 2 * (x / P / 2) + x % P := by
+  have hd := Nat.div_add_mod x P
+  have : P * (x / P) = P * 2 * (x / P / 2) := by
+    have hq : x / P = 2 * (x / P / 2) := by omega
+    conv_lhs => rw [hq]
+    show P * (2 * (x / P / 2)) =
+      P * 2 * (x / P / 2)
+    ring
+  linarith
+
+private lemma mod_double_of_odd_div (x P : ℕ)
+    (hP : 0 < P) (hodd : (x / P) % 2 = 1) :
+    x % (P * 2) = P + x % P := by
+  have := Nat.mod_lt x hP
+  conv_lhs => rw [rewrite_odd x P hodd]
+  rw [Nat.mul_add_mod, Nat.mod_eq_of_lt (by omega)]
+
+private lemma mod_double_of_even_div (x P : ℕ)
+    (hP : 0 < P) (heven : (x / P) % 2 = 0) :
+    x % (P * 2) = x % P := by
+  have := Nat.mod_lt x hP
+  conv_lhs => rw [rewrite_even x P heven]
+  rw [Nat.mul_add_mod, Nat.mod_eq_of_lt (by omega)]
+
+private lemma mod_pow_succ_of_testBit_false
+    {m k : ℕ} (hbit : m.testBit k = false) :
+    m % 2 ^ (k + 1) = m % 2 ^ k := by
+  rw [pow_succ]; exact mod_double_of_even_div m _
+    (Nat.two_pow_pos k)
+    (div_mod2_of_testBit_false hbit)
+
+private lemma mod_pow_succ_sub_of_testBit_true
+    {m k : ℕ} (hbit : m.testBit k = true) :
+    (m - 2 ^ k) % 2 ^ (k + 1) = m % 2 ^ k := by
+  rw [pow_succ, mod_double_of_even_div _ _
+    (Nat.two_pow_pos k)
+    (div_mod2_of_testBit_false (testBit_sub_self hbit))]
+  have : 2 ^ k * 1 ≤ m := by
+    have := Nat.ge_two_pow_of_testBit hbit; omega
+  have := @Nat.sub_mul_mod m 1 (2^k) this
+  simp at this; exact this
+
+private lemma mod_succ_of_both_true {a b k : ℕ}
+    (ha : a.testBit k = true)
+    (hb : b.testBit k = true)
+    (hmod : a % 2 ^ k = b % 2 ^ k) :
+    a % 2 ^ (k + 1) = b % 2 ^ (k + 1) := by
+  rw [pow_succ,
+    mod_double_of_odd_div a _ (Nat.two_pow_pos k)
+      (div_mod2_of_testBit_true ha),
+    mod_double_of_odd_div b _ (Nat.two_pow_pos k)
+      (div_mod2_of_testBit_true hb), hmod]
+
+private lemma mod_succ_ne_of_diff {a b k : ℕ}
+    (ha : a.testBit k = true)
+    (hb : b.testBit k = false) :
+    a % 2 ^ (k + 1) ≠ b % 2 ^ (k + 1) := by
+  rw [pow_succ,
+    mod_double_of_odd_div a _ (Nat.two_pow_pos k)
+      (div_mod2_of_testBit_true ha),
+    mod_double_of_even_div b _ (Nat.two_pow_pos k)
+      (div_mod2_of_testBit_false hb)]
+  have := Nat.mod_lt a (Nat.two_pow_pos k); omega
+
+private lemma mod_ne_lift {a b k : ℕ}
+    (h : a % 2 ^ k ≠ b % 2 ^ k) :
+    a % 2 ^ (k + 1) ≠ b % 2 ^ (k + 1) := by
+  intro heq; apply h
+  have hdvd := Nat.pow_dvd_pow 2 (Nat.le_succ k)
+  rw [← Nat.mod_mod_of_dvd a hdvd, heq,
+    Nat.mod_mod_of_dvd b hdvd]
+
+private lemma submask_sub_two_pow {i j k : ℕ}
+    (hsub : i &&& j = j)
+    (hbit_i : i.testBit k = true)
+    (hbit_j : j.testBit k = false) :
+    (i - 2 ^ k) &&& j = j := by
+  apply Nat.eq_of_testBit_eq; intro m
+  rw [Nat.testBit_and]
+  have hsub_tb : (i.testBit m && j.testBit m) =
+      j.testBit m := by
+    have h := Nat.testBit_and i j m
+    rw [hsub] at h; exact h.symm
+  if hm : m = k then
+    subst hm; simp [hbit_j]
+  else rw [testBit_sub_ne hbit_i hm, hsub_tb]
+
+private lemma popCount_le_of_and_eq :
+    ∀ {i j : ℕ}, i &&& j = j →
+      j.popCount ≤ i.popCount := by
+  intro i
+  induction i using Nat.strongRecOn with
+  | ind i ih =>
+    intro j h
+    by_cases hj : j = 0
+    · subst hj; simp [popCount_zero']
+    · have hi : i > 0 := by
+        by_contra h0; push_neg at h0
+        simp only [Nat.le_zero] at h0; subst h0
+        simp at h; exact hj h.symm
+      rw [popCount_pos' (by omega : 0 < j),
+        popCount_pos' hi]
+      have h_div :
+          (i / 2) &&& (j / 2) = j / 2 := by
+        have := @Nat.and_div_two_pow i j 1
+        simp [pow_one] at this; rw [h] at this
+        exact this.symm
+      have hmod_le : j % 2 ≤ i % 2 := by
+        have hmod := @Nat.and_mod_two_pow i j 1
+        simp [pow_one] at hmod; rw [h] at hmod
+        rw [hmod]; exact Nat.and_le_left
+      have := ih (i / 2)
+        (Nat.div_lt_self (by omega) (by norm_num))
+        h_div
+      omega
+
+private lemma mobiusPartial_step
+    {k : ℕ} (hk : k < n) (p : Vector R (2^n))
+    (i : Fin (2^n)) :
+    Vector.get
+      (lagrangeToMonoLevel ⟨k, hk⟩
+        (Vector.ofFn (mobiusPartial (k + 1) p)))
+      i =
+    mobiusPartial k p i := by
+  unfold lagrangeToMonoLevel mobiusPartial
+  simp only [Vector.get_eq_getElem,
+    Vector.getElem_ofFn, BitVec.getLsb_eq_getElem,
+    Fin.getElem_fin, BitVec.getElem_ofFin]
+  if hbit : i.val.testBit k = true then
+    simp only [hbit, ↓reduceIte]
+    have h2k_le := Nat.ge_two_pow_of_testBit hbit
+    have hi_sub_lt : i.val - 2 ^ k < 2 ^ n :=
+      Nat.sub_lt_of_lt i.isLt
+    have hbit' : (i.val - 2^k).testBit k = false :=
+      testBit_sub_self hbit
+    rw [← Finset.sum_sub_distrib]
+    apply Finset.sum_congr rfl; intro j _
+    by_cases hjbit : j.val.testBit k = true
+    · have hnsub' :
+          ¬((i.val - 2^k) &&& j.val = j.val) := by
+        intro h
+        have := submask_testBit_false h hbit'
+        simp [this] at hjbit
+      simp only [hnsub', false_and, ite_false,
+        sub_zero]
+      by_cases hsub : i.val &&& j.val = j.val
+      · by_cases hmod :
+            i.val % 2^k = j.val % 2^k
+        · simp [hsub, mod_succ_of_both_true
+            hbit hjbit hmod, hmod]
+        · simp [hsub, mod_ne_lift hmod, hmod]
+      · simp [hsub]
+    · simp only [Bool.not_eq_true] at hjbit
+      by_cases hsub : i.val &&& j.val = j.val
+      · have hsub' :=
+          submask_sub_two_pow hsub hbit hjbit
+        have hmod_ne :=
+          mod_succ_ne_of_diff hbit hjbit
+        simp only [hsub, true_and, hmod_ne,
+          ite_false, zero_sub, hsub', true_and]
+        have hmod_iff :
+            (i.val % 2^k = j.val % 2^k) ↔
+            ((i.val - 2^k) % 2^(k+1) =
+              j.val % 2^(k+1)) := by
+          rw [mod_pow_succ_sub_of_testBit_true hbit,
+            mod_pow_succ_of_testBit_false hjbit]
+        by_cases hmod :
+            i.val % 2^k = j.val % 2^k
+        · simp only [hmod, ite_true,
+            hmod_iff.mp hmod]
+          have hpc := popCount_sub_two_pow hbit
+          have hpc_le := popCount_le_of_and_eq hsub'
+          by_cases hpar :
+            (i.val.popCount -
+              j.val.popCount) % 2 = 0
+          · have : ((i.val - 2^k).popCount -
+                j.val.popCount) % 2 = 1 := by omega
+            simp only [hpar, ite_true, this]; norm_num
+          · have hp1 : (i.val.popCount -
+                j.val.popCount) % 2 = 1 := by omega
+            have : ((i.val - 2^k).popCount -
+                j.val.popCount) % 2 = 0 := by omega
+            simp only [hp1, this]; norm_num
+        · simp only [hmod, ite_false]
+          have : ¬((i.val - 2^k) % 2^(k+1) =
+              j.val % 2^(k+1)) :=
+            fun h => hmod (hmod_iff.mpr h)
+          simp [this]
+      · have hnsub' :
+            ¬((i.val-2^k) &&& j.val = j.val) := by
+          intro h'; apply hsub
+          apply Nat.eq_of_testBit_eq; intro m
+          rw [Nat.testBit_and]
+          have hh := Nat.testBit_and
+            (i.val - 2^k) j.val m
+          rw [h'] at hh
+          if hm : m = k then
+            subst hm; simp [hjbit]
+          else
+            rw [testBit_sub_ne hbit hm] at hh
+            exact hh.symm
+        simp [hsub, hnsub']
+  else
+    simp only [Bool.not_eq_true] at hbit
+    simp only [hbit]
+    apply Finset.sum_congr rfl; intro j _
+    by_cases hsub : i.val &&& j.val = j.val
+    · have hjf := submask_testBit_false hsub hbit
+      have hmod_eq :
+          (i.val % 2^(k+1) = j.val % 2^(k+1)) ↔
+          (i.val % 2^k = j.val % 2^k) := by
+        rw [mod_pow_succ_of_testBit_false hbit,
+          mod_pow_succ_of_testBit_false hjf]
+      simp only [hsub, true_and]
+      by_cases hmod :
+          i.val % 2^k = j.val % 2^k
+      · simp [hmod_eq.mpr hmod, hmod]
+      · have : ¬(i.val % 2^(k+1) =
+            j.val % 2^(k+1)) :=
+          fun h => hmod (hmod_eq.mp h)
+        simp [this, hmod]
+    · simp [hsub]
+
+private lemma lagrangeToMono_eq_mobiusPartial_zero
+    (p : Vector R (2^n)) :
+    lagrangeToMono n p =
+      Vector.ofFn (mobiusPartial 0 p) := by
+  unfold lagrangeToMono
+  suffices h : ∀ m ≤ n,
+      ((List.finRange n).drop (n - m)).foldr
+        (fun h acc => lagrangeToMonoLevel h acc)
+        p =
+      Vector.ofFn (mobiusPartial (n - m) p) by
+    have := h n (le_refl n)
+    simp only [Nat.sub_self, List.drop_zero] at this
+    exact this
+  intro m hm
+  induction m with
+  | zero =>
+    simp only [Nat.sub_zero]
+    have hdrop : (List.finRange n).drop n = [] :=
+      List.drop_of_length_le (by simp)
+    simp only [hdrop, List.foldr_nil]
+    ext i hi; simp only [Vector.getElem_ofFn]
+    exact (mobiusPartial_n p ⟨i, hi⟩).symm
+  | succ m' ih =>
+    have hm' : m' ≤ n := by omega
+    have hk : n - (m' + 1) < n := by omega
+    have hlen : n - m' - 1 <
+        (List.finRange n).length := by
+      simp [List.length_finRange]; omega
+    have hdrop := List.drop_eq_getElem_cons hlen
+      (l := List.finRange n)
+    simp only [List.getElem_finRange,
+      show n - m' - 1 + 1 = n - m' from by omega]
+      at hdrop
+    rw [show n - (m' + 1) = n - m' - 1 from by
+      omega, hdrop, List.foldr_cons, ih hm']
+    ext idx hidx
+    simp only [Vector.getElem_ofFn]
+    have hstep := mobiusPartial_step hk p
+      ⟨idx, hidx⟩
+    simp only [Vector.get_eq_getElem] at hstep
+    have h1 : n - m' - 1 = n - (m' + 1) := by omega
+    have h2 : n - m' = n - (m' + 1) + 1 := by omega
+    simp only [h2] at *
+    convert hstep using 2
+
+theorem lagrangeToMono_eq_lagrangeToMonoSpec
+    {R : Type*} [CommRing R] {n : ℕ}
+    (p : Vector R (2^n)) :
+    CMlPolynomial.lagrangeToMono n p =
+      CMlPolynomial.lagrangeToMonoSpec p := by
+  rw [lagrangeToMono_eq_mobiusPartial_zero]
+  ext i hi
+  simp only [Vector.getElem_ofFn]
+  exact mobiusPartial_zero_eq_spec p ⟨i, hi⟩
+
+end MobiusEquivalence
 
 /--
 Generates a list of indices representing a range of bit positions [l, r] in increasing order.

--- a/CompPoly/Multilinear/Basic.lean
+++ b/CompPoly/Multilinear/Basic.lean
@@ -898,7 +898,7 @@ private lemma lagrangeToMono_eq_mobiusPartial_zero
 /-- The fast Möbius transform `lagrangeToMono` is pointwise equal to the inclusion-exclusion
 specification `lagrangeToMonoSpec`. Combines the fold lemma with the `k = 0` base case. -/
 theorem lagrangeToMono_eq_lagrangeToMonoSpec
-    {R : Type*} [CommRing R] {n : ℕ}
+    {R : Type*} [AddCommGroup R] {n : ℕ}
     (p : Vector R (2 ^ n)) :
     CMlPolynomial.lagrangeToMono n p =
       CMlPolynomial.lagrangeToMonoSpec p := by

--- a/CompPoly/Multilinear/Basic.lean
+++ b/CompPoly/Multilinear/Basic.lean
@@ -413,54 +413,56 @@ section MobiusEquivalence
 
 We prove `lagrangeToMono = lagrangeToMonoSpec` by introducing an indexed family of
 "partial Möbius sums" `mobiusPartial k` that interpolates between the identity (at `k = n`)
-and the full spec (at `k = 0`). Each step of the fast transform `lagrangeToMonoLevel (k-1)`
-decrements the parameter by exactly one. Combined with the base case we obtain the result
-by descending induction on `k`. -/
+and the full spec (at `k = 0`). Each step of the fast transform
+`lagrangeToMonoLevel (k - 1)` decrements the parameter by exactly one. Combined with the
+base case we obtain the result by descending induction on `k`. -/
 
-/-- Partial Möbius sum at index `i` after processing levels `[k, k+1, …, n-1]`.
+/-- Partial Möbius sum at index `i` after processing levels `[k, k + 1, …, n - 1]`.
 
-Sums over `j : Fin (2^n)` that are bitwise subsets of `i` and that agree with `i` modulo `2^k`
-(i.e. on all bits strictly below `k`), weighted by `(-1)^(popCount i - popCount j)`.
+Sums over `j : Fin (2 ^ n)` that are bitwise subsets of `i` and that agree with `i` modulo
+`2 ^ k` (i.e. on all bits strictly below `k`), weighted by
+`(-1) ^ (popCount i - popCount j)`.
 
 * At `k = n` only `j = i` satisfies the constraints, so the result is `p[i]`.
 * At `k = 0` the low-bits constraint is vacuous and the formula is exactly
   `lagrangeToMonoSpec`.
 -/
-private def mobiusPartial (k : ℕ) (p : Vector R (2^n)) (i : Fin (2^n)) : R :=
-  ∑ j : Fin (2^n),
-    if (i.val &&& j.val = j.val) ∧ (i.val % 2^k = j.val % 2^k) then
+private def mobiusPartial (k : ℕ) (p : Vector R (2 ^ n)) (i : Fin (2 ^ n)) : R :=
+  ∑ j : Fin (2 ^ n),
+    if (i.val &&& j.val = j.val) ∧ (i.val % 2 ^ k = j.val % 2 ^ k) then
       if (i.val.popCount - j.val.popCount) % 2 = 0 then p.get j else -p.get j
     else 0
 
-/-- Base case: at `k = n` the modular constraint forces `j = i`. -/
-private lemma mobiusPartial_n (p : Vector R (2^n)) (i : Fin (2^n)) :
+/-- Base case: at `k = n` the modular constraint forces `j = i`, so the partial sum
+collapses to `p.get i`. -/
+private lemma mobiusPartial_n (p : Vector R (2 ^ n)) (i : Fin (2 ^ n)) :
     mobiusPartial n p i = p.get i := by
   unfold mobiusPartial
   rw [Finset.sum_eq_single i]
   · have h1 : i.val &&& i.val = i.val := by simp [Nat.and_self]
-    have h2 : i.val % 2^n = i.val % 2^n := rfl
     simp only [h1, and_self, if_true, Nat.sub_self, Nat.zero_mod, if_true]
   · intro j _ hji
     have hji' : j.val ≠ i.val := fun h => hji (Fin.ext h)
-    have hi_lt : i.val < 2^n := i.isLt
-    have hj_lt : j.val < 2^n := j.isLt
-    have : i.val % 2^n ≠ j.val % 2^n := by
+    have hi_lt : i.val < 2 ^ n := i.isLt
+    have hj_lt : j.val < 2 ^ n := j.isLt
+    have : i.val % 2 ^ n ≠ j.val % 2 ^ n := by
       rw [Nat.mod_eq_of_lt hi_lt, Nat.mod_eq_of_lt hj_lt]
       exact fun h => hji' h.symm
     simp [this]
   · intro h; exact absurd (Finset.mem_univ i) h
 
 /-- The `k = 0` case is (definitionally) equivalent to `lagrangeToMonoSpec`. -/
-private lemma mobiusPartial_zero_eq_spec (p : Vector R (2^n)) (i : Fin (2^n)) :
+private lemma mobiusPartial_zero_eq_spec (p : Vector R (2 ^ n)) (i : Fin (2 ^ n)) :
     mobiusPartial 0 p i = (lagrangeToMonoSpec p).get i := by
   unfold mobiusPartial lagrangeToMonoSpec
   simp only [pow_zero, Nat.mod_one, and_true, Vector.get_ofFn]
 
-
+/-- `Nat.popCount 0 = 0`: the zero-bit count of `0` is `0`. -/
 private lemma popCount_zero' :
     Nat.popCount 0 = 0 := by
   unfold Nat.popCount; simp [Nat.digits]
 
+/-- Recursion for `Nat.popCount` on positive arguments: split off the least-significant bit. -/
 private lemma popCount_pos' {m : ℕ} (hm : 0 < m) :
     Nat.popCount m =
       m % 2 + Nat.popCount (m / 2) := by
@@ -468,11 +470,13 @@ private lemma popCount_pos' {m : ℕ} (hm : 0 < m) :
   rw [Nat.digits_def' (by norm_num : 1 < 2) hm]
   simp [List.sum_cons]
 
+/-- `testBit` at index `k + 1` equals `testBit` at index `k` of the half. -/
 private lemma testBit_succ_eq_div2 (m k : ℕ) :
     m.testBit (k + 1) = (m / 2).testBit k := by
   have h := @Nat.testBit_div_two_pow 1 m k
   rw [pow_one] at h; exact h.symm
 
+/-- Clearing a set bit at position `k` decreases `popCount` by exactly one. -/
 private lemma popCount_sub_two_pow {m k : ℕ}
     (hbit : m.testBit k = true) :
     Nat.popCount m =
@@ -523,24 +527,28 @@ private lemma popCount_sub_two_pow {m k : ℕ}
         have := pow_succ 2 k; omega
       simp_all; ring
 
-private lemma submask_testBit_false {i j k : ℕ}
-    (hsub : i &&& j = j)
-    (hbit : i.testBit k = false) :
-    j.testBit k = false := by
+/-- If `n &&& m = m` (i.e. `m` is a bitwise submask of `n`) and `n` has bit `k` clear,
+then so does `m`. -/
+private lemma submask_testBit_false {m n k : ℕ}
+    (hsub : n &&& m = m)
+    (hbit : n.testBit k = false) :
+    m.testBit k = false := by
   by_contra hj; simp only [Bool.not_eq_false] at hj
-  have h := Nat.testBit_and i j k
+  have h := Nat.testBit_and n m k
   rw [hsub] at h
   simp only [hbit, Bool.false_and] at h
   exact absurd h.symm (by simp [hj])
 
-private lemma testBit_eq_of_getBit_eq {a b k : ℕ}
-    (h : Nat.getBit k a = Nat.getBit k b) :
-    a.testBit k = b.testBit k := by
+/-- Transfer `getBit` equality to `testBit` equality. -/
+private lemma testBit_eq_of_getBit_eq {m n k : ℕ}
+    (h : Nat.getBit k m = Nat.getBit k n) :
+    m.testBit k = n.testBit k := by
   rw [Nat.getBit_eq_testBit,
     Nat.getBit_eq_testBit] at h
-  cases ha : a.testBit k <;>
-    cases hb : b.testBit k <;> simp_all
+  cases hm : m.testBit k <;>
+    cases hn : n.testBit k <;> simp_all
 
+/-- Clearing bit `k` in a number that has bit `k` set gives a number with bit `k` clear. -/
 private lemma testBit_sub_self {m k : ℕ}
     (hbit : m.testBit k = true) :
     (m - 2 ^ k).testBit k = false := by
@@ -552,74 +560,84 @@ private lemma testBit_sub_self {m k : ℕ}
     Nat.getBit_of_sub_two_pow_of_bit_1 hgb (j := k)
   simp at h; exact h
 
-private lemma testBit_sub_ne {a k m : ℕ}
-    (hbit : a.testBit k = true) (hm : m ≠ k) :
-    (a - 2 ^ k).testBit m = a.testBit m := by
+/-- Bits other than `k` are unchanged when subtracting `2 ^ k` from a number with bit `k` set. -/
+private lemma testBit_sub_ne {m k l : ℕ}
+    (hbit : m.testBit k = true) (hl : l ≠ k) :
+    (m - 2 ^ k).testBit l = m.testBit l := by
   apply testBit_eq_of_getBit_eq
-  have hgb : Nat.getBit k a = 1 := by
+  have hgb : Nat.getBit k m = 1 := by
     rw [Nat.testBit_true_eq_getBit_eq_1] at hbit
     exact hbit
   have h :=
-    Nat.getBit_of_sub_two_pow_of_bit_1 hgb (j := m)
-  simp only [hm, ite_false] at h; exact h
+    Nat.getBit_of_sub_two_pow_of_bit_1 hgb (j := l)
+  simp only [hl, ite_false] at h; exact h
 
-private lemma div_mod2_of_testBit_true {a k : ℕ}
-    (h : a.testBit k = true) :
-    (a / 2 ^ k) % 2 = 1 := by
+/-- `(m / 2 ^ k) % 2 = 1` when bit `k` of `m` is set. -/
+private lemma div_mod2_of_testBit_true {m k : ℕ}
+    (h : m.testBit k = true) :
+    (m / 2 ^ k) % 2 = 1 := by
   rw [Nat.testBit] at h
   simp only [Nat.shiftRight_eq_div_pow] at h
   simp only [Nat.one_and_eq_mod_two,
     Nat.mod_two_bne_zero, beq_iff_eq] at h; omega
 
-private lemma div_mod2_of_testBit_false {a k : ℕ}
-    (h : a.testBit k = false) :
-    (a / 2 ^ k) % 2 = 0 := by
+/-- `(m / 2 ^ k) % 2 = 0` when bit `k` of `m` is clear. -/
+private lemma div_mod2_of_testBit_false {m k : ℕ}
+    (h : m.testBit k = false) :
+    (m / 2 ^ k) % 2 = 0 := by
   rw [Nat.testBit] at h
   simp only [Nat.shiftRight_eq_div_pow] at h
   simp only [Nat.one_and_eq_mod_two,
     Nat.mod_two_bne_zero,
     beq_eq_false_iff_ne, ne_eq] at h; omega
 
-private lemma rewrite_odd (x P : ℕ)
-    (hodd : (x / P) % 2 = 1) :
-    x = P * 2 * (x / P / 2) + (P + x % P) := by
-  have hd := Nat.div_add_mod x P
-  have : P * (x / P) =
-      P * 2 * (x / P / 2) + P := by
-    have hq : x / P = 2 * (x / P / 2) + 1 := by
+/-- Decomposition for the case `(m / d) % 2 = 1`: express `m` via
+`(d * 2) * q + r` with `r = d + m % d`. Useful to read `m % (d * 2)`. -/
+private lemma rewrite_odd (m d : ℕ)
+    (hodd : (m / d) % 2 = 1) :
+    m = d * 2 * (m / d / 2) + (d + m % d) := by
+  have hd := Nat.div_add_mod m d
+  have : d * (m / d) =
+      d * 2 * (m / d / 2) + d := by
+    have hq : m / d = 2 * (m / d / 2) + 1 := by
       omega
     conv_lhs => rw [hq]; rw [Nat.mul_add, Nat.mul_one]
-    show P * (2 * (x / P / 2)) + P =
-      P * 2 * (x / P / 2) + P
+    show d * (2 * (m / d / 2)) + d =
+      d * 2 * (m / d / 2) + d
     congr 1; ring
   linarith
 
-private lemma rewrite_even (x P : ℕ)
-    (heven : (x / P) % 2 = 0) :
-    x = P * 2 * (x / P / 2) + x % P := by
-  have hd := Nat.div_add_mod x P
-  have : P * (x / P) = P * 2 * (x / P / 2) := by
-    have hq : x / P = 2 * (x / P / 2) := by omega
+/-- Decomposition for the case `(m / d) % 2 = 0`: express `m` via
+`(d * 2) * q + r` with `r = m % d`. Useful to read `m % (d * 2)`. -/
+private lemma rewrite_even (m d : ℕ)
+    (heven : (m / d) % 2 = 0) :
+    m = d * 2 * (m / d / 2) + m % d := by
+  have hd := Nat.div_add_mod m d
+  have : d * (m / d) = d * 2 * (m / d / 2) := by
+    have hq : m / d = 2 * (m / d / 2) := by omega
     conv_lhs => rw [hq]
-    show P * (2 * (x / P / 2)) =
-      P * 2 * (x / P / 2)
+    show d * (2 * (m / d / 2)) =
+      d * 2 * (m / d / 2)
     ring
   linarith
 
-private lemma mod_double_of_odd_div (x P : ℕ)
-    (hP : 0 < P) (hodd : (x / P) % 2 = 1) :
-    x % (P * 2) = P + x % P := by
-  have := Nat.mod_lt x hP
-  conv_lhs => rw [rewrite_odd x P hodd]
+/-- When `(m / d) % 2 = 1`, the value of `m % (d * 2)` is `d + m % d`. -/
+private lemma mod_double_of_odd_div (m d : ℕ)
+    (hd : 0 < d) (hodd : (m / d) % 2 = 1) :
+    m % (d * 2) = d + m % d := by
+  have := Nat.mod_lt m hd
+  conv_lhs => rw [rewrite_odd m d hodd]
   rw [Nat.mul_add_mod, Nat.mod_eq_of_lt (by omega)]
 
-private lemma mod_double_of_even_div (x P : ℕ)
-    (hP : 0 < P) (heven : (x / P) % 2 = 0) :
-    x % (P * 2) = x % P := by
-  have := Nat.mod_lt x hP
-  conv_lhs => rw [rewrite_even x P heven]
+/-- When `(m / d) % 2 = 0`, the value of `m % (d * 2)` is `m % d`. -/
+private lemma mod_double_of_even_div (m d : ℕ)
+    (hd : 0 < d) (heven : (m / d) % 2 = 0) :
+    m % (d * 2) = m % d := by
+  have := Nat.mod_lt m hd
+  conv_lhs => rw [rewrite_even m d heven]
   rw [Nat.mul_add_mod, Nat.mod_eq_of_lt (by omega)]
 
+/-- If bit `k` of `m` is clear then `m % 2 ^ (k + 1) = m % 2 ^ k`. -/
 private lemma mod_pow_succ_of_testBit_false
     {m k : ℕ} (hbit : m.testBit k = false) :
     m % 2 ^ (k + 1) = m % 2 ^ k := by
@@ -627,6 +645,7 @@ private lemma mod_pow_succ_of_testBit_false
     (Nat.two_pow_pos k)
     (div_mod2_of_testBit_false hbit)
 
+/-- If bit `k` of `m` is set then `(m - 2 ^ k) % 2 ^ (k + 1) = m % 2 ^ k`. -/
 private lemma mod_pow_succ_sub_of_testBit_true
     {m k : ℕ} (hbit : m.testBit k = true) :
     (m - 2 ^ k) % 2 ^ (k + 1) = m % 2 ^ k := by
@@ -635,86 +654,97 @@ private lemma mod_pow_succ_sub_of_testBit_true
     (div_mod2_of_testBit_false (testBit_sub_self hbit))]
   have : 2 ^ k * 1 ≤ m := by
     have := Nat.ge_two_pow_of_testBit hbit; omega
-  have := @Nat.sub_mul_mod m 1 (2^k) this
+  have := @Nat.sub_mul_mod m 1 (2 ^ k) this
   simp at this; exact this
 
-private lemma mod_succ_of_both_true {a b k : ℕ}
-    (ha : a.testBit k = true)
-    (hb : b.testBit k = true)
-    (hmod : a % 2 ^ k = b % 2 ^ k) :
-    a % 2 ^ (k + 1) = b % 2 ^ (k + 1) := by
+/-- Lift equality modulo `2 ^ k` to equality modulo `2 ^ (k + 1)` when bit `k` agrees on
+both sides (both set). -/
+private lemma mod_succ_of_both_true {m n k : ℕ}
+    (hm : m.testBit k = true)
+    (hn : n.testBit k = true)
+    (hmod : m % 2 ^ k = n % 2 ^ k) :
+    m % 2 ^ (k + 1) = n % 2 ^ (k + 1) := by
   rw [pow_succ,
-    mod_double_of_odd_div a _ (Nat.two_pow_pos k)
-      (div_mod2_of_testBit_true ha),
-    mod_double_of_odd_div b _ (Nat.two_pow_pos k)
-      (div_mod2_of_testBit_true hb), hmod]
+    mod_double_of_odd_div m _ (Nat.two_pow_pos k)
+      (div_mod2_of_testBit_true hm),
+    mod_double_of_odd_div n _ (Nat.two_pow_pos k)
+      (div_mod2_of_testBit_true hn), hmod]
 
-private lemma mod_succ_ne_of_diff {a b k : ℕ}
-    (ha : a.testBit k = true)
-    (hb : b.testBit k = false) :
-    a % 2 ^ (k + 1) ≠ b % 2 ^ (k + 1) := by
+/-- When bit `k` disagrees between `m` and `n` (set vs clear), their residues modulo
+`2 ^ (k + 1)` differ. -/
+private lemma mod_succ_ne_of_diff {m n k : ℕ}
+    (hm : m.testBit k = true)
+    (hn : n.testBit k = false) :
+    m % 2 ^ (k + 1) ≠ n % 2 ^ (k + 1) := by
   rw [pow_succ,
-    mod_double_of_odd_div a _ (Nat.two_pow_pos k)
-      (div_mod2_of_testBit_true ha),
-    mod_double_of_even_div b _ (Nat.two_pow_pos k)
-      (div_mod2_of_testBit_false hb)]
-  have := Nat.mod_lt a (Nat.two_pow_pos k); omega
+    mod_double_of_odd_div m _ (Nat.two_pow_pos k)
+      (div_mod2_of_testBit_true hm),
+    mod_double_of_even_div n _ (Nat.two_pow_pos k)
+      (div_mod2_of_testBit_false hn)]
+  have := Nat.mod_lt m (Nat.two_pow_pos k); omega
 
-private lemma mod_ne_lift {a b k : ℕ}
-    (h : a % 2 ^ k ≠ b % 2 ^ k) :
-    a % 2 ^ (k + 1) ≠ b % 2 ^ (k + 1) := by
+/-- If residues modulo `2 ^ k` disagree, then so do residues modulo `2 ^ (k + 1)`. -/
+private lemma mod_ne_lift {m n k : ℕ}
+    (h : m % 2 ^ k ≠ n % 2 ^ k) :
+    m % 2 ^ (k + 1) ≠ n % 2 ^ (k + 1) := by
   intro heq; apply h
   have hdvd := Nat.pow_dvd_pow 2 (Nat.le_succ k)
-  rw [← Nat.mod_mod_of_dvd a hdvd, heq,
-    Nat.mod_mod_of_dvd b hdvd]
+  rw [← Nat.mod_mod_of_dvd m hdvd, heq,
+    Nat.mod_mod_of_dvd n hdvd]
 
-private lemma submask_sub_two_pow {i j k : ℕ}
-    (hsub : i &&& j = j)
-    (hbit_i : i.testBit k = true)
-    (hbit_j : j.testBit k = false) :
-    (i - 2 ^ k) &&& j = j := by
-  apply Nat.eq_of_testBit_eq; intro m
+/-- If `m` has bit `k` set and `n` is a submask of `m` with bit `k` clear, then `n`
+remains a submask after clearing bit `k` in `m`. -/
+private lemma submask_sub_two_pow {m n k : ℕ}
+    (hsub : m &&& n = n)
+    (hbit_m : m.testBit k = true)
+    (hbit_n : n.testBit k = false) :
+    (m - 2 ^ k) &&& n = n := by
+  apply Nat.eq_of_testBit_eq; intro l
   rw [Nat.testBit_and]
-  have hsub_tb : (i.testBit m && j.testBit m) =
-      j.testBit m := by
-    have h := Nat.testBit_and i j m
+  have hsub_tb : (m.testBit l && n.testBit l) =
+      n.testBit l := by
+    have h := Nat.testBit_and m n l
     rw [hsub] at h; exact h.symm
-  if hm : m = k then
-    subst hm; simp [hbit_j]
-  else rw [testBit_sub_ne hbit_i hm, hsub_tb]
+  if hl : l = k then
+    subst hl; simp [hbit_n]
+  else rw [testBit_sub_ne hbit_m hl, hsub_tb]
 
+/-- A bitwise submask has no more set bits than its supermask. -/
 private lemma popCount_le_of_and_eq :
-    ∀ {i j : ℕ}, i &&& j = j →
-      j.popCount ≤ i.popCount := by
-  intro i
-  induction i using Nat.strongRecOn with
-  | ind i ih =>
-    intro j h
-    by_cases hj : j = 0
-    · subst hj; simp [popCount_zero']
-    · have hi : i > 0 := by
+    ∀ {m n : ℕ}, m &&& n = n →
+      n.popCount ≤ m.popCount := by
+  intro m
+  induction m using Nat.strongRecOn with
+  | ind m ih =>
+    intro n h
+    by_cases hn : n = 0
+    · subst hn; simp [popCount_zero']
+    · have hm : m > 0 := by
         by_contra h0; push_neg at h0
         simp only [Nat.le_zero] at h0; subst h0
-        simp at h; exact hj h.symm
-      rw [popCount_pos' (by omega : 0 < j),
-        popCount_pos' hi]
+        simp at h; exact hn h.symm
+      rw [popCount_pos' (by omega : 0 < n),
+        popCount_pos' hm]
       have h_div :
-          (i / 2) &&& (j / 2) = j / 2 := by
-        have := @Nat.and_div_two_pow i j 1
+          (m / 2) &&& (n / 2) = n / 2 := by
+        have := @Nat.and_div_two_pow m n 1
         simp [pow_one] at this; rw [h] at this
         exact this.symm
-      have hmod_le : j % 2 ≤ i % 2 := by
-        have hmod := @Nat.and_mod_two_pow i j 1
+      have hmod_le : n % 2 ≤ m % 2 := by
+        have hmod := @Nat.and_mod_two_pow m n 1
         simp [pow_one] at hmod; rw [h] at hmod
         rw [hmod]; exact Nat.and_le_left
-      have := ih (i / 2)
+      have := ih (m / 2)
         (Nat.div_lt_self (by omega) (by norm_num))
         h_div
       omega
 
+/-- Step lemma: applying `lagrangeToMonoLevel k` to the partial sum at level `k + 1`
+yields the partial sum at level `k`. This is the induction step that chains the fast
+transform to the inclusion-exclusion spec one bit at a time. -/
 private lemma mobiusPartial_step
-    {k : ℕ} (hk : k < n) (p : Vector R (2^n))
-    (i : Fin (2^n)) :
+    {k : ℕ} (hk : k < n) (p : Vector R (2 ^ n))
+    (i : Fin (2 ^ n)) :
     Vector.get
       (lagrangeToMonoLevel ⟨k, hk⟩
         (Vector.ofFn (mobiusPartial (k + 1) p)))
@@ -729,21 +759,20 @@ private lemma mobiusPartial_step
     have h2k_le := Nat.ge_two_pow_of_testBit hbit
     have hi_sub_lt : i.val - 2 ^ k < 2 ^ n :=
       Nat.sub_lt_of_lt i.isLt
-    have hbit' : (i.val - 2^k).testBit k = false :=
+    have hbit' : (i.val - 2 ^ k).testBit k = false :=
       testBit_sub_self hbit
     rw [← Finset.sum_sub_distrib]
     apply Finset.sum_congr rfl; intro j _
     by_cases hjbit : j.val.testBit k = true
     · have hnsub' :
-          ¬((i.val - 2^k) &&& j.val = j.val) := by
+          ¬((i.val - 2 ^ k) &&& j.val = j.val) := by
         intro h
         have := submask_testBit_false h hbit'
         simp [this] at hjbit
-      simp only [hnsub', false_and, ite_false,
-        sub_zero]
+      simp only [hnsub', false_and, ite_false, sub_zero]
       by_cases hsub : i.val &&& j.val = j.val
       · by_cases hmod :
-            i.val % 2^k = j.val % 2^k
+            i.val % 2 ^ k = j.val % 2 ^ k
         · simp [hsub, mod_succ_of_both_true
             hbit hjbit hmod, hmod]
         · simp [hsub, mod_ne_lift hmod, hmod]
@@ -757,45 +786,44 @@ private lemma mobiusPartial_step
         simp only [hsub, true_and, hmod_ne,
           ite_false, zero_sub, hsub', true_and]
         have hmod_iff :
-            (i.val % 2^k = j.val % 2^k) ↔
-            ((i.val - 2^k) % 2^(k+1) =
-              j.val % 2^(k+1)) := by
+            (i.val % 2 ^ k = j.val % 2 ^ k) ↔
+            ((i.val - 2 ^ k) % 2 ^ (k + 1) =
+              j.val % 2 ^ (k + 1)) := by
           rw [mod_pow_succ_sub_of_testBit_true hbit,
             mod_pow_succ_of_testBit_false hjbit]
         by_cases hmod :
-            i.val % 2^k = j.val % 2^k
-        · simp only [hmod, ite_true,
-            hmod_iff.mp hmod]
+            i.val % 2 ^ k = j.val % 2 ^ k
+        · simp only [hmod, ite_true, hmod_iff.mp hmod]
           have hpc := popCount_sub_two_pow hbit
           have hpc_le := popCount_le_of_and_eq hsub'
           by_cases hpar :
             (i.val.popCount -
               j.val.popCount) % 2 = 0
-          · have : ((i.val - 2^k).popCount -
+          · have : ((i.val - 2 ^ k).popCount -
                 j.val.popCount) % 2 = 1 := by omega
             simp only [hpar, ite_true, this]; norm_num
           · have hp1 : (i.val.popCount -
                 j.val.popCount) % 2 = 1 := by omega
-            have : ((i.val - 2^k).popCount -
+            have : ((i.val - 2 ^ k).popCount -
                 j.val.popCount) % 2 = 0 := by omega
             simp only [hp1, this]; norm_num
         · simp only [hmod, ite_false]
-          have : ¬((i.val - 2^k) % 2^(k+1) =
-              j.val % 2^(k+1)) :=
+          have : ¬((i.val - 2 ^ k) % 2 ^ (k + 1) =
+              j.val % 2 ^ (k + 1)) :=
             fun h => hmod (hmod_iff.mpr h)
           simp [this]
       · have hnsub' :
-            ¬((i.val-2^k) &&& j.val = j.val) := by
+            ¬((i.val - 2 ^ k) &&& j.val = j.val) := by
           intro h'; apply hsub
-          apply Nat.eq_of_testBit_eq; intro m
+          apply Nat.eq_of_testBit_eq; intro l
           rw [Nat.testBit_and]
           have hh := Nat.testBit_and
-            (i.val - 2^k) j.val m
+            (i.val - 2 ^ k) j.val l
           rw [h'] at hh
-          if hm : m = k then
-            subst hm; simp [hjbit]
+          if hl : l = k then
+            subst hl; simp [hjbit]
           else
-            rw [testBit_sub_ne hbit hm] at hh
+            rw [testBit_sub_ne hbit hl] at hh
             exact hh.symm
         simp [hsub, hnsub']
   else
@@ -805,22 +833,25 @@ private lemma mobiusPartial_step
     by_cases hsub : i.val &&& j.val = j.val
     · have hjf := submask_testBit_false hsub hbit
       have hmod_eq :
-          (i.val % 2^(k+1) = j.val % 2^(k+1)) ↔
-          (i.val % 2^k = j.val % 2^k) := by
+          (i.val % 2 ^ (k + 1) = j.val % 2 ^ (k + 1)) ↔
+          (i.val % 2 ^ k = j.val % 2 ^ k) := by
         rw [mod_pow_succ_of_testBit_false hbit,
           mod_pow_succ_of_testBit_false hjf]
       simp only [hsub, true_and]
       by_cases hmod :
-          i.val % 2^k = j.val % 2^k
+          i.val % 2 ^ k = j.val % 2 ^ k
       · simp [hmod_eq.mpr hmod, hmod]
-      · have : ¬(i.val % 2^(k+1) =
-            j.val % 2^(k+1)) :=
+      · have : ¬(i.val % 2 ^ (k + 1) =
+            j.val % 2 ^ (k + 1)) :=
           fun h => hmod (hmod_eq.mp h)
         simp [this, hmod]
     · simp [hsub]
 
+/-- Fold lemma: applying all `n` levels of the fast Möbius transform reduces `p` to the
+value `Vector.ofFn (mobiusPartial 0 p)`. Proved by descending induction on the number of
+remaining levels. -/
 private lemma lagrangeToMono_eq_mobiusPartial_zero
-    (p : Vector R (2^n)) :
+    (p : Vector R (2 ^ n)) :
     lagrangeToMono n p =
       Vector.ofFn (mobiusPartial 0 p) := by
   unfold lagrangeToMono
@@ -864,9 +895,11 @@ private lemma lagrangeToMono_eq_mobiusPartial_zero
     simp only [h2] at *
     convert hstep using 2
 
+/-- The fast Möbius transform `lagrangeToMono` is pointwise equal to the inclusion-exclusion
+specification `lagrangeToMonoSpec`. Combines the fold lemma with the `k = 0` base case. -/
 theorem lagrangeToMono_eq_lagrangeToMonoSpec
     {R : Type*} [CommRing R] {n : ℕ}
-    (p : Vector R (2^n)) :
+    (p : Vector R (2 ^ n)) :
     CMlPolynomial.lagrangeToMono n p =
       CMlPolynomial.lagrangeToMonoSpec p := by
   rw [lagrangeToMono_eq_mobiusPartial_zero]


### PR DESCRIPTION
This is the first part of Möbius Equivalence Proof (Phase 2 -> item 5) from the [Roadmap](https://github.com/Verified-zkEVM/CompPoly/blob/master/ROADMAP.md)

Added a new MobiusEquivalence section in Multilinear/Basic.lean, lines: 404-875 that proves the headline theorem:

`theorem lagrangeToMono_eq_lagrangeToMonoSpec (p : Vector R (2^n)) :
    CMlPolynomial.lagrangeToMono n p = CMlPolynomial.lagrangeToMonoSpec p
`

**Proof structure**

The proof uses the partial-Möbius-sum technique: introduce an indexed family `mobiusPartial k` that interpolates between the identity (at k = n) and the full spec (at k = 0), with each fast-transform level `lagrangeToMonoLevel (k-1)` decrementing the parameter by exactly one.

1. Base cases: `mobiusPartial n = identity` and `mobiusPartial 0 = lagrangeToMonoSpec`.
2. Step lemma `mobiusPartial_step`: one `lagrangeToMonoLevel k` step connects `mobiusPartial (k+1)` to `mobiusPartial k`.
3. Fold lemma `lagrangeToMono_eq_mobiusPartial_zero` (proved by induction)

**Aux infrastructure proved**

14 private helper lemmas covering popCount arithmetic (`popCount_sub_two_pow`), bitwise-modular interplay, submask preservation under bit-clearing, and Möbius-sign manipulation.

Updated the TODO to reflect the remaining work

In the next PR we are planning to finish task 5 from the ROADMAP:

- Define monoToLagrangeSpec (zeta spec mirror of lagrangeToMonoSpec).
- Prove monoToLagrange = monoToLagrangeSpec
- Add docstrings with explicit transform formulas and complexity guarantees.