### PR TITLE
feat(clMul): Optimize clMul in Binary Common (issue #129)

### DIFF
--- a/CompPoly/Fields/Binary/BF128Ghash/Impl.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Impl.lean
@@ -211,11 +211,10 @@ lemma reduce_clMul_correct (prod : B256) :
     let h := prod.extractLsb 255 128
     let l := prod.extractLsb 127 0
     have h_toPoly_l_deg_lt := toPoly_degree_lt_w (by omega) l
-    let term1 := clMul (to256 h) (to256 R_val)
+    let term1 := clMul h R_val
     have h_term1_deg : (toPoly term1).degree < 135 := by
-      rw [toPoly_clMul_no_overflow (da := 128) (db := 8)]
+      rw [toPoly_clMul]
       · apply (Polynomial.degree_mul_le _ _).trans_lt
-        rw [toPoly_128_extend_256, toPoly_128_extend_256]
         have deg_h : (toPoly h).degree < 128 := toPoly_degree_lt_w (by omega) h
         have deg_R : (toPoly R_val).degree < 8 := by
           apply toPoly_degree_of_lt_two_pow;
@@ -246,10 +245,6 @@ lemma reduce_clMul_correct (prod : B256) :
             exact Nat.le_of_lt_succ h_deg_R_nat
         apply lt_of_le_of_lt (add_le_add h_deg_h_le h_deg_R_le)
         norm_cast
-        · rw [to256_toNat]; apply BitVec.toNat_lt_twoPow_of_le (by omega)
-      · rw [to256_toNat]; simp only [R_val, toNat_ofNat, Nat.reducePow, Nat.reduceMod,
-        Nat.reduceLT]
-      · norm_num
     have h_term1_lt : term1.toNat < 2^135 := by
       apply BitVec_lt_two_pow_of_toPoly_degree_lt term1 h_term1_deg
     have h_acc_deg : (toPoly (term1 ^^^ to256 l)).degree < 135 := by
@@ -281,46 +276,42 @@ lemma reduce_clMul_correct (prod : B256) :
     unfold fold_step
     let h2 := acc.extractLsb 255 128
     let l2 := acc.extractLsb 127 0
-    let term2 := clMul (to256 h2) (to256 R_val)
+    let term2 := clMul h2  R_val
 
-    rw [toPoly_xor, toPoly_clMul_no_overflow (da := 7) (db := 8)]
-    · apply (Polynomial.degree_add_le _ _).trans_lt
-      rw [max_lt_iff]
-      constructor
-      · apply (Polynomial.degree_mul_le _ _).trans_lt
-        rw [toPoly_128_extend_256, toPoly_128_extend_256]
-        have deg_h2 : (toPoly h2).degree < 7 := toPoly_degree_of_lt_two_pow _ h_h2_bound
-        have deg_R : (toPoly R_val).degree < 8 := by
-          apply toPoly_degree_of_lt_two_pow; dsimp only [R_val, reduceToNat, Nat.reducePow]; omega
-        have h_deg_h2_le : (toPoly h2).degree ≤ (6 : WithBot ℕ) := by
-          by_cases h_deg_bot : (toPoly h2).degree = ⊥
-          · rw [h_deg_bot]; exact bot_le
-          · obtain ⟨n, h_n_eq⟩ := WithBot.ne_bot_iff_exists.mp h_deg_bot
-            rw [←h_n_eq] at deg_h2
-            norm_cast at deg_h2
-            rw [h_n_eq.symm]
-            change (n : WithBot ℕ) ≤ (6 : ℕ)
-            change (n : WithBot ℕ) < (7 : ℕ) at deg_h2
-            norm_cast at deg_h2 ⊢
-            exact Nat.le_of_lt_succ deg_h2
-        have h_deg_R_le : (toPoly R_val).degree ≤ (7 : WithBot ℕ) := by
-          by_cases h_deg_bot : (toPoly R_val).degree = ⊥
-          · rw [h_deg_bot]; exact bot_le
-          · obtain ⟨n, h_n_eq⟩ := WithBot.ne_bot_iff_exists.mp h_deg_bot
-            rw [←h_n_eq] at deg_R
-            rw [h_n_eq.symm]
-            change (n : WithBot ℕ) ≤ (7 : ℕ)
-            change (n : WithBot ℕ) < (8 : ℕ) at deg_R
-            norm_cast at deg_R ⊢
-            exact Nat.le_of_lt_succ deg_R
-        apply lt_of_le_of_lt (add_le_add h_deg_h2_le h_deg_R_le)
-        norm_cast
-      · rw [toPoly_128_extend_256]
-        apply toPoly_degree_of_lt_two_pow
-        exact BitVec.isLt l2
-    · rw [to256_toNat]; exact h_h2_bound
-    · rw [to256_toNat]; dsimp only [R_val, reduceToNat, Nat.reducePow]; omega
-    · norm_num
+    rw [toPoly_xor, toPoly_clMul]
+    apply (Polynomial.degree_add_le _ _).trans_lt
+    rw [max_lt_iff]
+    constructor
+    · apply (Polynomial.degree_mul_le _ _).trans_lt
+      have deg_h2 : (toPoly h2).degree < 7 := toPoly_degree_of_lt_two_pow _ h_h2_bound
+      have deg_R : (toPoly R_val).degree < 8 := by
+        apply toPoly_degree_of_lt_two_pow; dsimp only [R_val, reduceToNat, Nat.reducePow]; omega
+      have h_deg_h2_le : (toPoly h2).degree ≤ (6 : WithBot ℕ) := by
+        by_cases h_deg_bot : (toPoly h2).degree = ⊥
+        · rw [h_deg_bot]; exact bot_le
+        · obtain ⟨n, h_n_eq⟩ := WithBot.ne_bot_iff_exists.mp h_deg_bot
+          rw [←h_n_eq] at deg_h2
+          norm_cast at deg_h2
+          rw [h_n_eq.symm]
+          change (n : WithBot ℕ) ≤ (6 : ℕ)
+          change (n : WithBot ℕ) < (7 : ℕ) at deg_h2
+          norm_cast at deg_h2 ⊢
+          exact Nat.le_of_lt_succ deg_h2
+      have h_deg_R_le : (toPoly R_val).degree ≤ (7 : WithBot ℕ) := by
+        by_cases h_deg_bot : (toPoly R_val).degree = ⊥
+        · rw [h_deg_bot]; exact bot_le
+        · obtain ⟨n, h_n_eq⟩ := WithBot.ne_bot_iff_exists.mp h_deg_bot
+          rw [←h_n_eq] at deg_R
+          rw [h_n_eq.symm]
+          change (n : WithBot ℕ) ≤ (7 : ℕ)
+          change (n : WithBot ℕ) < (8 : ℕ) at deg_R
+          norm_cast at deg_R ⊢
+          exact Nat.le_of_lt_succ deg_R
+      apply lt_of_le_of_lt (add_le_add h_deg_h2_le h_deg_R_le)
+      norm_cast
+    · rw [toPoly_128_extend_256]
+      apply toPoly_degree_of_lt_two_pow
+      exact BitVec.isLt l2
   have h_extract : toPoly (res.extractLsb 127 0) = toPoly res := by
     have h_res_eq : res = to256 (res.extractLsb 127 0) := by
       dsimp only [to256]
@@ -354,7 +345,7 @@ instance : Sub ConcreteBF128Ghash where sub a b := a ^^^ b
 
 instance : Mul ConcreteBF128Ghash where
   mul a b :=
-    let prod := clMul (to256 a) (to256 b)
+    let prod := clMul a b
     reduce_clMul prod
 
 -- -----------------------------------------------------------------------------
@@ -438,7 +429,7 @@ instance : AddCommGroup ConcreteBF128Ghash where
 
 instance : Mul ConcreteBF128Ghash where
   mul a b :=
-    let prod := clMul (to256 a) (to256 b)
+    let prod := clMul a b
     reduce_clMul prod
 
 end AddCommGroupInstance
@@ -515,16 +506,11 @@ lemma toQuot_ne_zero (a : ConcreteBF128Ghash) (h_a_ne_zero : a ≠ 0) : toQuot a
 mod P. -/
 lemma toQuot_mul (a b : ConcreteBF128Ghash) : toQuot (a * b) = toQuot a * toQuot b := by
   unfold toQuot
-  have h_clMul : toPoly (clMul (to256 a) (to256 b)) = toPoly (to256 a) * toPoly (to256 b) := by
-    apply toPoly_clMul_no_overflow (da := 128) (db := 128)
-    · rw [to256_toNat]; exact BitVec.toNat_lt_twoPow_of_le (n := 128) (by omega)
-    · rw [to256_toNat]; exact BitVec.toNat_lt_twoPow_of_le (n := 128) (by omega)
-    · norm_num
-  rw [toPoly_128_extend_256, toPoly_128_extend_256] at h_clMul
-  have h_reduce : toPoly (reduce_clMul (clMul (to256 a) (to256 b))) =
-                  toPoly (clMul (to256 a) (to256 b)) % ghashPoly := by
+  have h_clMul : toPoly (clMul a b) = toPoly a * toPoly b :=  toPoly_clMul a b
+  have h_reduce : toPoly (reduce_clMul (clMul a b)) =
+                  toPoly (clMul a b) % ghashPoly := by
     apply reduce_clMul_correct
-  change AdjoinRoot.mk ghashPoly (toPoly (reduce_clMul (clMul (to256 a) (to256 b)))) =
+  change AdjoinRoot.mk ghashPoly (toPoly (reduce_clMul (clMul a b))) =
          AdjoinRoot.mk ghashPoly (toPoly a) * AdjoinRoot.mk ghashPoly (toPoly b)
   rw [h_reduce, h_clMul, ← map_mul (AdjoinRoot.mk ghashPoly), AdjoinRoot.mk_eq_mk]
   apply dvd_sub_comm.mp

--- a/CompPoly/Fields/Binary/BF128Ghash/Impl.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Impl.lean
@@ -170,7 +170,7 @@ lemma poly_reduce_step (A : Polynomial (ZMod 2)) :
 def fold_step (prod : B256) : B256 :=
   let h := prod.extractLsb 255 128
   let l := prod.extractLsb 127 0
-  clMul (to256 h) (to256 R_val) ^^^ (to256 l)
+  clMul h R_val ^^^ (to256 l)
 
 /-- Modular Reduction using Folding (Algebraic).
   Fast O(1) reduction replacing long division.
@@ -187,18 +187,15 @@ lemma fold_step_mod_eq (x : B256) :
   let h := x.extractLsb 255 128
   let l := x.extractLsb 127 0
   rw [toPoly_xor]
-  rw [toPoly_clMul_no_overflow (da := 128) (db := 8)]
-  · rw [toPoly_128_extend_256, toPoly_128_extend_256, R_val_eq_ghashTail, toPoly_128_extend_256]
-    rw [toPoly_split_256 x]
-    rw [CanonicalEuclideanDomain.add_mod_eq (hn := ghashPoly_ne_zero)]
-    conv_rhs => rw [CanonicalEuclideanDomain.add_mod_eq (hn := ghashPoly_ne_zero)]
-    have h_first_eq : (toPoly (extractLsb 255 128 x) * ghashTail) % ghashPoly =
-                      (toPoly (extractLsb 255 128 x) * X^128) % ghashPoly := by
-      symm; apply poly_reduce_step
-    grind
-  · rw [to256_toNat]; omega
-  · rw [to256_toNat]; dsimp only [R_val, reduceToNat, Nat.reducePow]; omega
-  · norm_num
+  rw [toPoly_clMul]
+  rw [toPoly_128_extend_256, R_val_eq_ghashTail]
+  rw [toPoly_split_256 x]
+  rw [CanonicalEuclideanDomain.add_mod_eq (hn := ghashPoly_ne_zero)]
+  conv_rhs => rw [CanonicalEuclideanDomain.add_mod_eq (hn := ghashPoly_ne_zero)]
+  have h_first_eq : (toPoly (extractLsb 255 128 x) * ghashTail) % ghashPoly =
+                    (toPoly (extractLsb 255 128 x) * X^128) % ghashPoly := by
+    symm; apply poly_reduce_step
+  grind
 
 /-- Main Theorem: reduce_clMul correctly computes modulo P. -/
 lemma reduce_clMul_correct (prod : B256) :
@@ -249,7 +246,7 @@ lemma reduce_clMul_correct (prod : B256) :
             exact Nat.le_of_lt_succ h_deg_R_nat
         apply lt_of_le_of_lt (add_le_add h_deg_h_le h_deg_R_le)
         norm_cast
-      · rw [to256_toNat]; apply BitVec.toNat_lt_twoPow_of_le (by omega)
+        · rw [to256_toNat]; apply BitVec.toNat_lt_twoPow_of_le (by omega)
       · rw [to256_toNat]; simp only [R_val, toNat_ofNat, Nat.reducePow, Nat.reduceMod,
         Nat.reduceLT]
       · norm_num

--- a/CompPoly/Fields/Binary/BF128Ghash/Impl.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Impl.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chung Thai Nguyen, Quang Dao
+Authors: Chung Thai Nguyen, Quang Dao, Dimitris Mitsios
 -/
 
 import CompPoly.Fields.Binary.BF128Ghash.Basic

--- a/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
@@ -373,33 +373,14 @@ private theorem clMulNat_bv_eq_fold_range (a b : Nat) :
           ofNat_shiftLeft_256, BitVec.xor_comm]
       · simp [clMulNat, hbit, clMulNat_bv_eq_fold_range a b n]
 
-/-- Rewrite `clMul` from a fold over `Fin 256` to a fold over `range 256`. -/
-private theorem clMul_eq_fold_range (a b : B256) :
+/-- Rewrite `clMul` from a fold over `Fin 128` to a fold over `range 128`. -/
+private theorem clMul_eq_fold_range (a b : B128) :
     clMul a b =
-      (Finset.range 256).fold BitVec.xor 0
-        (fun i => if a.toNat.testBit i then b <<< i else 0) := by
-  rw [clMul_eq_fold]
-  have hImage :=
-    Finset.fold_image
-      (op := BitVec.xor)
-      (b := (0 : B256))
-      (f := fun i => if a.toNat.testBit i then b <<< i else 0)
-      (g := fun i : Fin 256 => i.val)
-      (s := (Finset.univ : Finset (Fin 256)))
-      (H := by
-        intro x _ y _ hxy
-        exact Fin.ext hxy)
-  have hRange :
-      ((Finset.univ : Finset (Fin 256)).image fun i : Fin 256 => i.val) =
-        Finset.range 256 := by
-    ext i
-    constructor
-    · intro hi
-      rcases Finset.mem_image.mp hi with ⟨j, _, rfl⟩
-      exact Finset.mem_range.mpr j.isLt
-    · intro hi
-      exact Finset.mem_image.mpr ⟨⟨i, Finset.mem_range.mp hi⟩, by simp, rfl⟩
-  simpa [hRange, Function.comp, BitVec.getLsb] using hImage.symm
+      (Finset.range 128).fold BitVec.xor 0
+        (fun i => if a.toNat.testBit i then (to256 b) <<< i else 0) := by
+      rw [clMul_unfold, fold_range_xor_eq_foldl]
+      rfl
+
 
 /-- The 256-step Nat checker matches `clMul` on all `B256` inputs. -/
 private theorem clMulNat_bv_eq_clMul (a b : B256) :

--- a/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
@@ -425,7 +425,13 @@ theorem to256_truncate_128 (v : B256) (hv : v.toNat < 2^128) :
           rw [to256_toNat, BitVec.truncate_eq_setWidth, BitVec.toNat_setWidth]
           exact Nat.mod_eq_of_lt hv
 
+theorem toPoly_truncate_128 (v : B256) (hv : v.toNat < 2^128) :
+  toPoly (v.truncate 128) = toPoly v := by
+    rw [← toPoly_128_extend_256, to256_truncate_128 v hv]
 
+theorem toPoly_clMul_B256 (q b : B256) (hq : q.toNat < 2^128) (hb : b.toNat < 2^128) :
+    toPoly (clMul (q.truncate 128) (b.truncate 128)) = toPoly q * toPoly b := by
+      rw [toPoly_clMul, toPoly_truncate_128 q hq, toPoly_truncate_128 b hb]
 
 /-- Polynomial semantics of the 128-step Nat carry-less multiply. -/
 private theorem toPoly_clMulNat_eq_mul_128 (a b : B256)

--- a/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
@@ -390,7 +390,7 @@ private theorem clMulNat_bv_eq_clMul (a b : B128) :
 
 
 
-private lemma toNat_truncate_of_lt {n m : Nat} (v : BitVec n)
+private theorem toNat_truncate_of_lt {n m : Nat} (v : BitVec n)
     (hv : v.toNat < 2^m) :
     (v.truncate m).toNat = v.toNat := by
   rw [BitVec.truncate_eq_setWidth, BitVec.toNat_setWidth]

--- a/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
@@ -418,6 +418,15 @@ private theorem clMulNat_bv_eq_clMul_128 (a b : B256) (ha : a.toNat < 2 ^ 128) :
           (fun i => if a.toNat.testBit i then b <<< i else 0) := htrim.symm
     _ = clMul a b := clMul_eq_fold_range a b |>.symm
 
+
+theorem to256_truncate_128 (v : B256) (hv : v.toNat < 2^128) :
+        to256 (v.truncate 128) = v := by
+          apply BitVec.eq_of_toNat_eq
+          rw [to256_toNat, BitVec.truncate_eq_setWidth, BitVec.toNat_setWidth]
+          exact Nat.mod_eq_of_lt hv
+
+
+
 /-- Polynomial semantics of the 128-step Nat carry-less multiply. -/
 private theorem toPoly_clMulNat_eq_mul_128 (a b : B256)
     (ha : a.toNat < 2 ^ 128) (hb : b.toNat < 2 ^ 128) :

--- a/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
@@ -383,14 +383,12 @@ private theorem clMul_eq_fold_range (a b : B128) :
 
 
 /-- The 256-step Nat checker matches `clMul` on all `B256` inputs. -/
-private theorem clMulNat_bv_eq_clMul (a b : B256) :
-    (BitVec.ofNat 256 (clMulNat a.toNat b.toNat 256) : B256) = clMul a b := by
-  calc
-    (BitVec.ofNat 256 (clMulNat a.toNat b.toNat 256) : B256)
-        = (Finset.range 256).fold BitVec.xor 0
-            (fun i => if a.toNat.testBit i then b <<< i else 0) := by
-              simpa [ofNat_toB256 b] using (clMulNat_bv_eq_fold_range a.toNat b.toNat 256)
-    _ = clMul a b := clMul_eq_fold_range a b |>.symm
+private theorem clMulNat_bv_eq_clMul (a b : B128) :
+    (BitVec.ofNat 256 (clMulNat a.toNat b.toNat 128) : B256) = clMul a b := by
+    rw [ clMulNat_bv_eq_fold_range, clMul_eq_fold_range]
+    rw [← to256_toNat b, ofNat_toB256]
+
+
 
 /-- The 128-step Nat checker matches `clMul` when the first multiplicand is 128-bit. -/
 private theorem clMulNat_bv_eq_clMul_128 (a b : B256) (ha : a.toNat < 2 ^ 128) :

--- a/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
@@ -33,11 +33,11 @@ set_option maxRecDepth 550 -- for ghashPoly_eq_P_val
 open Polynomial AdjoinRoot BinaryField
 
 -- Re-export common definitions for convenience
-export BinaryField (B128 B256 to256 to256_toNat clMul clSq toPoly clMul_eq_fold
+export BinaryField (B128 B256 to256 to256_toNat clMul clSq toPoly clMul_unfold
   toPoly_one_eq_one toPoly_zero_eq_zero toPoly_ne_zero_iff_ne_zero
   toPoly_degree_lt_w toPoly_degree_of_lt_two_pow BitVec_lt_two_pow_of_toPoly_degree_lt
   toPoly_xor toPoly_fold_xor toPoly_128_extend_256 toPoly_shiftLeft_no_overflow
-  toPoly_clMul_no_overflow gcd_eq_gcd_next_step gcd_one_zero)
+  toPoly_clMul gcd_eq_gcd_next_step gcd_one_zero)
 
 section GHASHPolynomial
 
@@ -390,40 +390,16 @@ private theorem clMulNat_bv_eq_clMul (a b : B128) :
 
 
 
-/-- The 128-step Nat checker matches `clMul` when the first multiplicand is 128-bit. -/
-private theorem clMulNat_bv_eq_clMul_128 (a b : B256) (ha : a.toNat < 2 ^ 128) :
-    (BitVec.ofNat 256 (clMulNat a.toNat b.toNat 128) : B256) = clMul a b := by
-  have htrim :
-      (Finset.range 256).fold BitVec.xor 0
-          (fun i => if a.toNat.testBit i then b <<< i else 0) =
-        (Finset.range 128).fold BitVec.xor 0
-          (fun i => if a.toNat.testBit i then b <<< i else 0) := by
-    calc
-      (Finset.range 256).fold BitVec.xor 0
-          (fun i => if a.toNat.testBit i then b <<< i else 0)
-          = (BitVec.ofNat 256 (clMulNat a.toNat b.toNat 256) : B256) := by
-              simpa [ofNat_toB256 b] using (clMulNat_bv_eq_fold_range a.toNat b.toNat 256).symm
-      _ = (BitVec.ofNat 256 (clMulNat a.toNat b.toNat 128) : B256) := by
-            exact congrArg (fun n => (BitVec.ofNat 256 n : B256))
-              (clMulNat_high_bits_zero a.toNat b.toNat 128 256 (by omega) ha)
-      _ = (Finset.range 128).fold BitVec.xor 0
-            (fun i => if a.toNat.testBit i then b <<< i else 0) := by
-            simpa [ofNat_toB256 b] using (clMulNat_bv_eq_fold_range a.toNat b.toNat 128)
-  calc
-    (BitVec.ofNat 256 (clMulNat a.toNat b.toNat 128) : B256)
-        = (Finset.range 128).fold BitVec.xor 0
-            (fun i => if a.toNat.testBit i then b <<< i else 0) := by
-              simpa [ofNat_toB256 b] using (clMulNat_bv_eq_fold_range a.toNat b.toNat 128)
-    _ = (Finset.range 256).fold BitVec.xor 0
-          (fun i => if a.toNat.testBit i then b <<< i else 0) := htrim.symm
-    _ = clMul a b := clMul_eq_fold_range a b |>.symm
-
+private lemma toNat_truncate_of_lt {n m : Nat} (v : BitVec n)
+    (hv : v.toNat < 2^m) :
+    (v.truncate m).toNat = v.toNat := by
+  rw [BitVec.truncate_eq_setWidth, BitVec.toNat_setWidth]
+  exact Nat.mod_eq_of_lt hv
 
 theorem to256_truncate_128 (v : B256) (hv : v.toNat < 2^128) :
         to256 (v.truncate 128) = v := by
           apply BitVec.eq_of_toNat_eq
-          rw [to256_toNat, BitVec.truncate_eq_setWidth, BitVec.toNat_setWidth]
-          exact Nat.mod_eq_of_lt hv
+          rw [to256_toNat, toNat_truncate_of_lt v hv]
 
 theorem toPoly_truncate_128 (v : B256) (hv : v.toNat < 2^128) :
   toPoly (v.truncate 128) = toPoly v := by
@@ -433,13 +409,6 @@ theorem toPoly_clMul_B256 (q b : B256) (hq : q.toNat < 2^128) (hb : b.toNat < 2^
     toPoly (clMul (q.truncate 128) (b.truncate 128)) = toPoly q * toPoly b := by
       rw [toPoly_clMul, toPoly_truncate_128 q hq, toPoly_truncate_128 b hb]
 
-/-- Polynomial semantics of the 128-step Nat carry-less multiply. -/
-private theorem toPoly_clMulNat_eq_mul_128 (a b : B256)
-    (ha : a.toNat < 2 ^ 128) (hb : b.toNat < 2 ^ 128) :
-    toPoly (BitVec.ofNat 256 (clMulNat a.toNat b.toNat 128)) = (toPoly a) * (toPoly b) := by
-  rw [clMulNat_bv_eq_clMul_128 a b ha]
-  exact toPoly_clMul_no_overflow (da := 128) (db := 128) a b ha hb (by omega)
-
 /-- Bitvector semantics of `clSqNat` for a 128-bit input. -/
 private theorem clSqNat_bv_eq_clSq (x : B128) :
     (BitVec.ofNat 256 (clSqNat x.toNat 128) : B256) = clSq x := by
@@ -447,16 +416,13 @@ private theorem clSqNat_bv_eq_clSq (x : B128) :
     rw [to256_toNat]
     exact x.isLt
   simpa [clSqNat, clSq, to256_toNat] using
-    (clMulNat_bv_eq_clMul_128 (to256 x) (to256 x) hx)
+    (clMulNat_bv_eq_clMul x x)
 
 /-- Polynomial semantics of `clSqNat` for a 128-bit input. -/
 private theorem toPoly_clSqNat_eq_sq (x : B128) :
     toPoly (BitVec.ofNat 256 (clSqNat x.toNat 128)) = (toPoly x) ^ 2 := by
-  have hx : (to256 x).toNat < 2 ^ 128 := by
-    rw [to256_toNat]
-    exact x.isLt
-  simpa [clSqNat, pow_two, to256_toNat, toPoly_128_extend_256] using
-    (toPoly_clMulNat_eq_mul_128 (to256 x) (to256 x) hx hx)
+      rw [clSqNat_bv_eq_clSq x, clSq, toPoly_clMul, pow_two]
+
 
 /-- Shift a 128-bit input inside 256 bits without changing its polynomial meaning. -/
 private theorem toPoly_ofNat_shiftLeft_to256 (x : B128) (shift : Nat) (hshift : 128 + shift ≤ 256) :
@@ -500,8 +466,7 @@ theorem verify_square_step_correct (rPrev q rNext : B128) :
   have hr : (to256 rPrev).toNat < 2 ^ 128 := by
     rw [to256_toNat]
     exact rPrev.isLt
-  rw [toPoly_clMul_no_overflow (da := 128) (db := 128) (a := to256 rPrev) (b := to256 rPrev) hr hr
-    (by omega), toPoly_128_extend_256, toPoly_128_extend_256] at hBv
+  rw [toPoly_clMul rPrev rPrev, toPoly_128_extend_256] at hBv
   simpa [pow_two, toPoly_128_extend_256] using hBv
 
 /-- Soundness of the kernel-efficient division-step checker. -/
@@ -514,9 +479,10 @@ theorem verify_div_step_bounded (a q b r : B256) (hq : q.toNat < 2 ^ 128)
       (BitVec.ofNat 256 (clMulNat q.toNat b.toNat 128 ^^^ r.toNat) : B256) := by
     simpa using congrArg (fun n => (BitVec.ofNat 256 n : B256)) h
   rw [ofNat_toB256 a, ofNat_xor_256, ofNat_toB256 r] at hBv
-  rw [clMulNat_bv_eq_clMul_128 q b hq] at hBv
+  rw [← toNat_truncate_of_lt q hq, ← toNat_truncate_of_lt b hb,
+      clMulNat_bv_eq_clMul (q.truncate 128) (b.truncate 128)] at hBv
   apply_fun toPoly at hBv
-  rw [toPoly_xor, toPoly_clMul_no_overflow (da := 128) (db := 128) q b hq hb (by omega)] at hBv
+  rw [toPoly_xor, toPoly_clMul_B256 q b hq hb] at hBv
   exact hBv
 
 /-- Soundness of the kernel-efficient division-step checker. -/
@@ -531,9 +497,11 @@ theorem verify_div_step (a q b r : B256) (hq : q.toNat < 2 ^ 128)
       (BitVec.ofNat 256 (clMulNat q.toNat b.toNat 256 ^^^ r.toNat) : B256) := by
     simpa using congrArg (fun n => (BitVec.ofNat 256 n : B256)) h
   rw [ofNat_toB256 a, ofNat_xor_256, ofNat_toB256 r] at hBv
-  rw [clMulNat_bv_eq_clMul q b] at hBv
+  rw [clMulNat_high_bits_zero q.toNat b.toNat 128 256 (by omega) hq] at hBv
+  rw [← toNat_truncate_of_lt q hq, ← toNat_truncate_of_lt b hb,
+      clMulNat_bv_eq_clMul (q.truncate 128) (b.truncate 128)] at hBv
   apply_fun toPoly at hBv
-  rw [toPoly_xor, toPoly_clMul_no_overflow (da := 128) (db := 128) q b hq hb (by omega)] at hBv
+  rw [toPoly_xor, toPoly_clMul_B256 q b hq hb] at hBv
   exact hBv
 
 end KernelEfficientCheckers

--- a/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chung Thai Nguyen, Quang Dao
+Authors: Chung Thai Nguyen, Quang Dao, Dimitris Mitsios
 -/
 
 import CompPoly.Fields.Binary.Common
@@ -397,13 +397,13 @@ private theorem toNat_truncate_of_lt {n m : Nat} (v : BitVec n)
   exact Nat.mod_eq_of_lt hv
 
 theorem to256_truncate_128 (v : B256) (hv : v.toNat < 2^128) :
-        to256 (v.truncate 128) = v := by
-          apply BitVec.eq_of_toNat_eq
-          rw [to256_toNat, toNat_truncate_of_lt v hv]
+    to256 (v.truncate 128) = v := by
+  apply BitVec.eq_of_toNat_eq
+  rw [to256_toNat, toNat_truncate_of_lt v hv]
 
 theorem toPoly_truncate_128 (v : B256) (hv : v.toNat < 2^128) :
-  toPoly (v.truncate 128) = toPoly v := by
-    rw [← toPoly_128_extend_256, to256_truncate_128 v hv]
+    toPoly (v.truncate 128) = toPoly v := by
+  rw [← toPoly_128_extend_256, to256_truncate_128 v hv]
 
 theorem toPoly_clMul_B256 (q b : B256) (hq : q.toNat < 2^128) (hb : b.toNat < 2^128) :
     toPoly (clMul (q.truncate 128) (b.truncate 128)) = toPoly q * toPoly b := by

--- a/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
+++ b/CompPoly/Fields/Binary/BF128Ghash/Prelude.lean
@@ -381,14 +381,11 @@ private theorem clMul_eq_fold_range (a b : B128) :
       rw [clMul_unfold, fold_range_xor_eq_foldl]
       rfl
 
-
 /-- The 256-step Nat checker matches `clMul` on all `B256` inputs. -/
 private theorem clMulNat_bv_eq_clMul (a b : B128) :
     (BitVec.ofNat 256 (clMulNat a.toNat b.toNat 128) : B256) = clMul a b := by
     rw [ clMulNat_bv_eq_fold_range, clMul_eq_fold_range]
     rw [← to256_toNat b, ofNat_toB256]
-
-
 
 private theorem toNat_truncate_of_lt {n m : Nat} (v : BitVec n)
     (hv : v.toNat < 2^m) :
@@ -422,7 +419,6 @@ private theorem clSqNat_bv_eq_clSq (x : B128) :
 private theorem toPoly_clSqNat_eq_sq (x : B128) :
     toPoly (BitVec.ofNat 256 (clSqNat x.toNat 128)) = (toPoly x) ^ 2 := by
       rw [clSqNat_bv_eq_clSq x, clSq, toPoly_clMul, pow_two]
-
 
 /-- Shift a 128-bit input inside 256 bits without changing its polynomial meaning. -/
 private theorem toPoly_ofNat_shiftLeft_to256 (x : B128) (shift : Nat) (hshift : 128 + shift ≤ 256) :

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -266,8 +266,7 @@ instance {w : Nat} : Std.Associative (α := BitVec w) BitVec.xor where
 -- TODO: optimize clMul, potentially using Karatsuba decomposition
 /-- Carry-less (polynomial) multiplication of two 256-bit vectors. -/
 def clMul (a b : B128) : B256 :=
-  let b256 := to256 b
-  Fin.foldl 128 (fun acc i => if a.getLsbD i then acc ^^^ (b256 <<< (i : Nat)) else acc) (0 : B256)
+  Fin.foldl 128 (fun acc i => if a.getLsbD i then acc ^^^ (to256 b <<< (i : Nat)) else acc) (0 : B256)
 
 /-- Carry-less squaring of a 128-bit vector. -/
 def clSq (a : B128) : B256 :=
@@ -291,6 +290,9 @@ noncomputable def toPoly {w : Nat} (v : BitVec w) : (ZMod 2)[X] :=
 -- lemma clMul_eq_fold (a b : B256) :
 --     clMul a b = (Finset.univ : Finset (Fin 256)).fold BitVec.xor 0
 --       (fun i => if a.getLsb i then b <<< i.val else 0) := by rfl
+
+lemma clMul_unfold (a b : B128) :
+  clMul a b = Fin.foldl 128 (fun acc i => if a.getLsbD i then acc ^^^ (to256 b <<< (i : Nat)) else acc) (0 : B256) := by rfl
 
 lemma toPoly_one_eq_one {w : Nat} (h_w_pos : w > 0) : toPoly (BitVec.ofNat w 1) = 1 := by
   unfold toPoly
@@ -682,6 +684,8 @@ theorem toPoly_shiftLeft_no_overflow {w d : ℕ} (a : BitVec w) (ha : a.toNat < 
 
 lemma toPoly_clMul_no_overflow (a b : B128) :
     toPoly (clMul a b) = toPoly a * toPoly b := by
+    rw[clMul_unfold]
+
 
 
 /--

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -705,7 +705,9 @@ theorem toPoly_shiftLeft_no_overflow {w d : ℕ} (a : BitVec w) (ha : a.toNat < 
 
 lemma toPoly_clMul_no_overflow (a b : B128) :
     toPoly (clMul a b) = toPoly a * toPoly b := by
-    rw[clMul_unfold]
+    rw [clMul_unfold]
+    rw [toPoly_fold_xor]
+
 
 
 

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -600,7 +600,6 @@ theorem BitVec_getLsb_eq_false_of_toNat_lt_two_pow {w d : ℕ} (a : BitVec w) (h
   have hbit : a.toNat.testBit (i : ℕ) = false := Nat.testBit_eq_false_of_lt hlt
   simpa [BitVec.getLsb] using hbit
 
-
 theorem BitVec_getElem_eq_false_of_toNat_lt_two_pow {w d : ℕ} (a : BitVec w) (ha : a.toNat < 2 ^ d)
     (n : ℕ) (hn : n < w) (hd : d ≤ n) : a[n] = false := by
   classical

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -31,7 +31,7 @@ direct GF(2^128) implementation (`BF128Ghash/`).
 - `toPoly`: Convert a BitVec to a polynomial over GF(2)
 - `clMul`: Carry-less multiplication of bit vectors
 - `toPoly_xor`: `toPoly (a ^^^ b) = toPoly a + toPoly b`
-- `toPoly_clMul_no_overflow`: `toPoly (clMul a b) = toPoly a * toPoly b`
+- `toPoly_clMul`: `toPoly (clMul a b) = toPoly a * toPoly b`
 -/
 
 /-! ## Section 1: ZMod 2 Polynomial Lemmas -/
@@ -263,8 +263,7 @@ instance {w : Nat} : Std.Associative (α := BitVec w) BitVec.xor where
     ext i
     simp only [BitVec.xor_eq, BitVec.getElem_xor, Bool.bne_assoc]
 
--- TODO: optimize clMul, potentially using Karatsuba decomposition
-/-- Carry-less (polynomial) multiplication of two 256-bit vectors. -/
+/-- Carry-less (polynomial) multiplication of two 128-bit vectors. -/
 def clMul (a b : B128) : B256 :=
   Fin.foldl 128 (fun acc i => if a.getLsbD i then acc ^^^ (to256 b <<< (i : Nat)) else acc) (0 : B256)
 
@@ -293,15 +292,7 @@ section PolynomialIsomorphism
 noncomputable def toPoly {w : Nat} (v : BitVec w) : (ZMod 2)[X] :=
   ∑ i : Fin w, if v.getLsb i then X^i.val else 0
 
--- 2. The clMul Definition in Fold Form
--- We define this lemma to exactly match the structure above:
--- s = Finset.univ (Fin 256)
--- f = fun i => if a[i] then b <<< i else 0
--- lemma clMul_eq_fold (a b : B256) :
---     clMul a b = (Finset.univ : Finset (Fin 256)).fold BitVec.xor 0
---       (fun i => if a.getLsb i then b <<< i.val else 0) := by rfl
-
-/-- Unfold clMul modifying the return value to always perform a xor operation. This form of clMul simplifies the proof of toPoly_clMul128 because toPoly_fold_xor applies directly. -/
+/-- Unfold clMul modifying the return value to always perform a xor operation. This form of clMul simplifies the proof of toPoly_clMul because toPoly_fold_xor applies directly. -/
 lemma clMul_unfold (a b : B128) :
   clMul a b = Fin.foldl 128 (fun acc i => acc ^^^ (if a.getLsbD i then to256 b <<< (i : Nat) else 0)) (0 : B256) := by
     unfold clMul
@@ -736,45 +727,7 @@ lemma toPoly_clMul (a b : B128) :
       ring
     · simp [toPoly_zero_eq_zero]
 
-/--
-Generalized No-Overflow Multiplication.
-Safe to use whenever the bit-widths sum to ≤ 257.
-This covers both squaring (128+128=256) and reduction check (128+129=257).
-
-lemma toPoly_clMul_no_overflow {da db : ℕ} (a b : B256)
-    (ha : a.toNat < 2 ^ da)
-    (hb : b.toNat < 2 ^ db)
-    (h_sum : da + db ≤ 257) :
-    toPoly (clMul a b) = toPoly a * toPoly b := by
-
-  rw [clMul_eq_fold]
-  rw [toPoly_fold_xor]
-
-  conv_rhs => rw [toPoly]
-  rw [Finset.sum_mul]
-
-  apply Finset.sum_congr rfl
-  intro i _
-
-  split_ifs with h_bit
-  · rw [mul_comm]
-    rw [toPoly_shiftLeft_no_overflow (d := db) (ha := hb)]
-    · have h_i_lt_da : i.val < da := by
-        simp only [BitVec.getLsb] at h_bit
-        by_contra h_i_ge_da
-        simp only [not_lt] at h_i_ge_da
-        have h_testBit_lt_2_pow := Nat.testBit_lt_two_pow (i := i) (x := BitVec.toNat a)
-          (lt := by
-            apply lt_of_lt_of_le (b := 2^da) (by omega) (by
-              apply Nat.pow_le_pow_right (hx := by omega) (by omega)))
-        rw [h_testBit_lt_2_pow] at h_bit
-        exact (Bool.eq_not_self false).mp h_bit
-      omega
-
-  · simp [toPoly_zero_eq_zero]
-
-
-Helper lemma to chain the modular squaring steps -/
+/-- Helper lemma to chain the modular squaring steps. -/
 lemma chain_step {P : Polynomial (ZMod 2)} (hP : P ≠ 0) {k : ℕ}
     {prev next : Polynomial (ZMod 2)} {q_val : B128}
     (h_prev : X ^ (2 ^ k) % P = prev % P)

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -265,14 +265,13 @@ instance {w : Nat} : Std.Associative (α := BitVec w) BitVec.xor where
 
 -- TODO: optimize clMul, potentially using Karatsuba decomposition
 /-- Carry-less (polynomial) multiplication of two 256-bit vectors. -/
-def clMul (a b : B256) : B256 :=
-  (Finset.univ : Finset (Fin 256)).fold BitVec.xor 0
-      (fun i => if a.getLsb i then b <<< i.val else 0)
+def clMul (a b : B128) : B256 :=
+  let b256 := to256 b
+  Fin.foldl 128 (fun acc i => if a.getLsbD i then acc ^^^ (b256 <<< (i : Nat)) else acc) (0 : B256)
 
 /-- Carry-less squaring of a 128-bit vector. -/
 def clSq (a : B128) : B256 :=
-  let a256 := to256 a
-  clMul a256 a256
+  clMul a a
 
 end BitVecOperations
 
@@ -289,9 +288,9 @@ noncomputable def toPoly {w : Nat} (v : BitVec w) : (ZMod 2)[X] :=
 -- We define this lemma to exactly match the structure above:
 -- s = Finset.univ (Fin 256)
 -- f = fun i => if a[i] then b <<< i else 0
-lemma clMul_eq_fold (a b : B256) :
-    clMul a b = (Finset.univ : Finset (Fin 256)).fold BitVec.xor 0
-      (fun i => if a.getLsb i then b <<< i.val else 0) := by rfl
+-- lemma clMul_eq_fold (a b : B256) :
+--     clMul a b = (Finset.univ : Finset (Fin 256)).fold BitVec.xor 0
+--       (fun i => if a.getLsb i then b <<< i.val else 0) := by rfl
 
 lemma toPoly_one_eq_one {w : Nat} (h_w_pos : w > 0) : toPoly (BitVec.ofNat w 1) = 1 := by
   unfold toPoly
@@ -681,11 +680,15 @@ theorem toPoly_shiftLeft_no_overflow {w d : ℕ} (a : BitVec w) (ha : a.toNat < 
       · simp [toPoly_coeff, hn, hs, hns]
     · simp [toPoly_coeff, hn, hs]
 
+lemma toPoly_clMul_no_overflow (a b : B128) :
+    toPoly (clMul a b) = toPoly a * toPoly b := by
+
+
 /--
 Generalized No-Overflow Multiplication.
 Safe to use whenever the bit-widths sum to ≤ 257.
 This covers both squaring (128+128=256) and reduction check (128+129=257).
--/
+
 lemma toPoly_clMul_no_overflow {da db : ℕ} (a b : B256)
     (ha : a.toNat < 2 ^ da)
     (hb : b.toNat < 2 ^ db)
@@ -718,7 +721,8 @@ lemma toPoly_clMul_no_overflow {da db : ℕ} (a b : B256)
 
   · simp [toPoly_zero_eq_zero]
 
-/-- Helper lemma to chain the modular squaring steps -/
+
+Helper lemma to chain the modular squaring steps -/
 lemma chain_step {P : Polynomial (ZMod 2)} (hP : P ≠ 0) {k : ℕ}
     {prev next : Polynomial (ZMod 2)} {q_val : B128}
     (h_prev : X ^ (2 ^ k) % P = prev % P)

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -706,10 +706,28 @@ theorem toPoly_shiftLeft_no_overflow {w d : ℕ} (a : BitVec w) (ha : a.toNat < 
 lemma toPoly_clMul_no_overflow (a b : B128) :
     toPoly (clMul a b) = toPoly a * toPoly b := by
     rw [clMul_unfold]
-    rw [toPoly_fold_xor]
-
-
-
+    rw [toPoly_fold_xor (f := fun k => if a.getLsbD k = true then to256 b <<<
+  k else 0)]
+    conv_rhs => enter [1]; unfold toPoly
+    unfold BitVec.getLsb
+    rw [Fin.sum_univ_eq_sum_range  (f := fun i => if (BitVec.toNat a).testBit i = true then X ^ i else 0)]
+    rw [Finset.sum_mul]
+    apply Finset.sum_congr rfl
+    intro i hi
+    simp only [Finset.mem_range] at hi
+    unfold BitVec.getLsbD
+    split_ifs
+    · have ha_proof : (to256 b).toNat < 2 ^ 128 := by
+           rw [to256_toNat]
+           exact b.isLt
+      have h_no_overflow_proof : 128 + i ≤ 256 := by
+           omega
+      rw  [toPoly_shiftLeft_no_overflow (d := 128) (to256 b)
+                                        (ha := ha_proof)
+                                        (h_no_overflow := h_no_overflow_proof)]
+      rw [toPoly_128_extend_256]
+      ring
+    · simp [toPoly_zero_eq_zero]
 
 /--
 Generalized No-Overflow Multiplication.

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -277,10 +277,9 @@ lemma fold_range_xor_eq_foldl {w : Nat} (n : Nat) (f : Nat → BitVec w) :
   induction n with
   | zero => simp
   | succ k ih =>
-    rw [Finset.range_add_one, Finset.fold_insert Finset.notMem_range_self,
-        Fin.foldl_succ_last]
-    simp only [Fin.val_last, Fin.val_castSucc]
-    rw [← ih, BitVec.xor_comm]
+    rw [Fin.foldl_succ_last, Finset.range_add_one, Finset.fold_insert Finset.notMem_range_self]
+    simp only [Fin.val_castSucc, Fin.val_last]
+    rw [←ih, BitVec.xor_comm]
     rfl
 
 end BitVecOperations

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -272,6 +272,17 @@ def clMul (a b : B128) : B256 :=
 def clSq (a : B128) : B256 :=
   clMul a a
 
+lemma fold_range_xor_eq_foldl {w : Nat} (n : Nat) (f : Nat → BitVec w) :
+  (Finset.range n).fold BitVec.xor 0 f = Fin.foldl n (fun acc i => acc ^^^ (f i)) 0 := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [Finset.range_add_one, Finset.fold_insert Finset.notMem_range_self,
+        Fin.foldl_succ_last]
+    simp only [Fin.val_last, Fin.val_castSucc]
+    rw [← ih, BitVec.xor_comm]
+    rfl
+
 end BitVecOperations
 
 /-! ## Section 4: BitVec ↔ Polynomial Isomorphism -/
@@ -531,8 +542,6 @@ lemma toPoly_xor {w} (a b : BitVec w) : toPoly (a ^^^ b) = toPoly a + toPoly b :
     rw [h_a_getLsb_i, h_b_getLsb_i]
     simp only [bne_self_eq_false, Bool.false_eq_true, ↓reduceIte, add_zero]
 
-
-#check Finset Nat
 /--
 The "Homomorphism" Lemma.
 Since toPoly(a ^^^ b) = toPoly a + toPoly b,
@@ -703,11 +712,10 @@ theorem toPoly_shiftLeft_no_overflow {w d : ℕ} (a : BitVec w) (ha : a.toNat < 
       · simp [toPoly_coeff, hn, hs, hns]
     · simp [toPoly_coeff, hn, hs]
 
-lemma toPoly_clMul_no_overflow (a b : B128) :
+lemma toPoly_clMul (a b : B128) :
     toPoly (clMul a b) = toPoly a * toPoly b := by
     rw [clMul_unfold]
-    rw [toPoly_fold_xor (f := fun k => if a.getLsbD k = true then to256 b <<<
-  k else 0)]
+    rw [toPoly_fold_xor (f := fun k => if a.getLsbD k = true then to256 b <<< k else 0)]
     conv_rhs => enter [1]; unfold toPoly
     unfold BitVec.getLsb
     rw [Fin.sum_univ_eq_sum_range  (f := fun i => if (BitVec.toNat a).testBit i = true then X ^ i else 0)]

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024-2025 ArkLib Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chung Thai Nguyen, Quang Dao, Derek Sorensen
+Authors: Chung Thai Nguyen, Quang Dao, Derek Sorensen, Dimitris Mitsios
 -/
 
 import Mathlib.FieldTheory.Finite.Basic
@@ -265,14 +265,17 @@ instance {w : Nat} : Std.Associative (α := BitVec w) BitVec.xor where
 
 /-- Carry-less (polynomial) multiplication of two 128-bit vectors. -/
 def clMul (a b : B128) : B256 :=
-  Fin.foldl 128 (fun acc i => if a.getLsbD i then acc ^^^ (to256 b <<< (i : Nat)) else acc) (0 : B256)
+  Fin.foldl 128 (fun acc i =>
+    if a.getLsbD i then acc ^^^ (to256 b <<< (i : Nat))
+    else acc) (0 : B256)
 
 /-- Carry-less squaring of a 128-bit vector. -/
 def clSq (a : B128) : B256 :=
   clMul a a
 
 lemma fold_range_xor_eq_foldl {w : Nat} (n : Nat) (f : Nat → BitVec w) :
-  (Finset.range n).fold BitVec.xor 0 f = Fin.foldl n (fun acc i => acc ^^^ (f i)) 0 := by
+    (Finset.range n).fold BitVec.xor 0 f =
+    Fin.foldl n (fun acc i => acc ^^^ (f i)) 0 := by
   induction n with
   | zero => simp
   | succ k ih =>
@@ -292,9 +295,12 @@ section PolynomialIsomorphism
 noncomputable def toPoly {w : Nat} (v : BitVec w) : (ZMod 2)[X] :=
   ∑ i : Fin w, if v.getLsb i then X^i.val else 0
 
-/-- Unfold clMul modifying the return value to always perform a xor operation. This form of clMul simplifies the proof of toPoly_clMul because toPoly_fold_xor applies directly. -/
+/-- Unfold `clMul` into an always-XOR form so that `toPoly_fold_xor`
+applies directly in the proof of `toPoly_clMul`. -/
 lemma clMul_unfold (a b : B128) :
-  clMul a b = Fin.foldl 128 (fun acc i => acc ^^^ (if a.getLsbD i then to256 b <<< (i : Nat) else 0)) (0 : B256) := by
+    clMul a b = Fin.foldl 128
+      (fun acc i => acc ^^^ (if a.getLsbD i
+        then to256 b <<< (i : Nat) else 0)) (0 : B256) := by
     unfold clMul
     congr
     funext acc i
@@ -551,7 +557,8 @@ lemma toPoly_fold_xor {α} {w} (s : Finset α) (f : α → (BitVec w)) :
 -/
 
 lemma toPoly_fold_xor {w : Nat} (n : Nat) (f : Nat → (BitVec w)) :
-  toPoly (Fin.foldl n (fun acc i => acc ^^^ (f i)) 0) = ∑ i ∈ (Finset.range n), toPoly (f i) := by
+    toPoly (Fin.foldl n (fun acc i => acc ^^^ (f i)) 0) =
+    ∑ i ∈ (Finset.range n), toPoly (f i) := by
     induction n with
     | zero =>
            simp [toPoly_zero_eq_zero]
@@ -708,7 +715,9 @@ lemma toPoly_clMul (a b : B128) :
     rw [toPoly_fold_xor (f := fun k => if a.getLsbD k = true then to256 b <<< k else 0)]
     conv_rhs => enter [1]; unfold toPoly
     unfold BitVec.getLsb
-    rw [Fin.sum_univ_eq_sum_range  (f := fun i => if (BitVec.toNat a).testBit i = true then X ^ i else 0)]
+    rw [Fin.sum_univ_eq_sum_range
+      (f := fun i => if (BitVec.toNat a).testBit i = true
+        then X ^ i else 0)]
     rw [Finset.sum_mul]
     apply Finset.sum_congr rfl
     intro i hi

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -556,8 +556,11 @@ lemma toPoly_fold_xor {w : Nat} (n : Nat) (f : Nat → (BitVec w)) :
     induction n with
     | zero =>
            simp [toPoly_zero_eq_zero]
-    | succ =>
-
+    | succ k ih =>
+           rw [Fin.foldl_succ_last]
+           rw [toPoly_xor]
+           simp only [Fin.val_castSucc, ih]
+           simp [Finset.sum_range_succ]
 
 lemma toPoly_128_extend_256 (a : B128) :
     toPoly (to256 a) = toPoly a := by

--- a/CompPoly/Fields/Binary/Common.lean
+++ b/CompPoly/Fields/Binary/Common.lean
@@ -291,8 +291,15 @@ noncomputable def toPoly {w : Nat} (v : BitVec w) : (ZMod 2)[X] :=
 --     clMul a b = (Finset.univ : Finset (Fin 256)).fold BitVec.xor 0
 --       (fun i => if a.getLsb i then b <<< i.val else 0) := by rfl
 
+/-- Unfold clMul modifying the return value to always perform a xor operation. This form of clMul simplifies the proof of toPoly_clMul128 because toPoly_fold_xor applies directly. -/
 lemma clMul_unfold (a b : B128) :
-  clMul a b = Fin.foldl 128 (fun acc i => if a.getLsbD i then acc ^^^ (to256 b <<< (i : Nat)) else acc) (0 : B256) := by rfl
+  clMul a b = Fin.foldl 128 (fun acc i => acc ^^^ (if a.getLsbD i then to256 b <<< (i : Nat) else 0)) (0 : B256) := by
+    unfold clMul
+    congr
+    funext acc i
+    cases h : BitVec.getLsbD a i
+    · simp
+    · simp
 
 lemma toPoly_one_eq_one {w : Nat} (h_w_pos : w > 0) : toPoly (BitVec.ofNat w 1) = 1 := by
   unfold toPoly
@@ -524,11 +531,13 @@ lemma toPoly_xor {w} (a b : BitVec w) : toPoly (a ^^^ b) = toPoly a + toPoly b :
     rw [h_a_getLsb_i, h_b_getLsb_i]
     simp only [bne_self_eq_false, Bool.false_eq_true, ↓reduceIte, add_zero]
 
+
+#check Finset Nat
 /--
 The "Homomorphism" Lemma.
 Since toPoly(a ^^^ b) = toPoly a + toPoly b,
 toPoly preserves the structure from Fold-XOR to Sum-Add.
--/
+
 lemma toPoly_fold_xor {α} {w} (s : Finset α) (f : α → (BitVec w)) :
     toPoly (s.fold BitVec.xor 0 f) = ∑ i ∈ s, toPoly (f i) := by
   induction s using Finset.cons_induction with
@@ -540,6 +549,15 @@ lemma toPoly_fold_xor {α} {w} (s : Finset α) (f : α → (BitVec w)) :
     change toPoly (f x ^^^ s.fold BitVec.xor 0 f) = toPoly (f x) + ∑ i ∈ s, toPoly (f i)
     rw [toPoly_xor]
     rw [ih]
+-/
+
+lemma toPoly_fold_xor {w : Nat} (n : Nat) (f : Nat → (BitVec w)) :
+  toPoly (Fin.foldl n (fun acc i => acc ^^^ (f i)) 0) = ∑ i ∈ (Finset.range n), toPoly (f i) := by
+    induction n with
+    | zero =>
+           simp [toPoly_zero_eq_zero]
+    | succ =>
+
 
 lemma toPoly_128_extend_256 (a : B128) :
     toPoly (to256 a) = toPoly a := by

--- a/tests/CompPolyTests/Fields/Binary/CommonBench.lean
+++ b/tests/CompPolyTests/Fields/Binary/CommonBench.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+import CompPoly.Fields.Binary.Common
+
+/-!
+  # Benchmarks on new `clMul` vs. the old implementation
+
+  The new `clMul : B128 → B128 → B256` uses `Fin.foldl` and widens with
+  `to256 b`. The old implementation was removed from Common.lean; it is
+  included below as `clMul_baseline : B256 → B256 → B256`.
+
+  This file is not imported by `CompPolyTests.lean` so `lake test` stays
+  fast.
+
+  ## Running
+
+  ```bash
+  lake build CompPolyTests.Fields.Binary.CommonBench
+  ```
+-/
+
+open BinaryField
+
+/-- Old baseline: `Finset.fold` over `Fin 256`, takes `B256` inputs. -/
+private def clMul_baseline (a b : B256) : B256 :=
+  (Finset.univ : Finset (Fin 256)).fold BitVec.xor 0
+    (fun i => if a.getLsb i then b <<< i.val else 0)
+
+/-! ## Correctness — baseline and new version must agree -/
+
+private def tv_a : B128 := (0xDEADBEEFCAFEBABE0123456789ABCDEF : B128)
+private def tv_b : B128 := (0xFEEDFACEFEEDFACE1122334455667788 : B128)
+
+-- Reference: widen then baseline
+private def ref_result : B256 := clMul_baseline (to256 tv_a) (to256 tv_b)
+
+#guard clMul tv_a tv_b == ref_result
+
+-- Sparse operand (like `R_val` in `fold_step`)
+private def tv_sparse : B128 := (0x87 : B128)
+private def ref_sparse : B256 := clMul_baseline (to256 tv_a) (to256 tv_sparse)
+
+#guard clMul tv_a tv_sparse == ref_sparse
+
+-- Identity and zero
+#guard clMul tv_a 1 == to256 tv_a
+#guard clMul tv_a 0 == 0
+
+/-! ## Benchmarks — fixed dense inputs -/
+
+private def benchFixedBaseline (n : Nat) (a b : B256) : IO B256 := do
+  let mut r : B256 := 0
+  for _ in List.range n do
+    r := clMul_baseline a b
+  return r
+
+private def benchFixedNew (n : Nat) (a b : B128) : IO B256 := do
+  let mut r : B256 := 0
+  for _ in List.range n do
+    r := clMul a b
+  return r
+
+#eval timeit "=== Fixed dense 128x128 (10000 iters) ===" (pure ())
+#eval timeit "  clMul_baseline(to256)" (benchFixedBaseline 10000 (to256 tv_a) (to256 tv_b))
+#eval timeit "  clMul (new)          " (benchFixedNew 10000 tv_a tv_b)
+
+/-! ## Benchmarks — varied inputs -/
+
+private def benchVariedBaseline (n : Nat) (a b : B256) : IO B256 := do
+  let mut r : B256 := 0
+  for i in List.range n do
+    let a' := a ^^^ (BitVec.ofNat 256 (i * 0x9E3779B97F4A7C15))
+    let b' := b ^^^ (BitVec.ofNat 256 (i * 0x6C62272E07BB0142))
+    r := clMul_baseline a' b'
+  return r
+
+private def benchVariedNew (n : Nat) (a b : B128) : IO B256 := do
+  let mut r : B256 := 0
+  for i in List.range n do
+    let a' := a ^^^ (BitVec.ofNat 128 (i * 0x9E3779B97F4A7C15))
+    let b' := b ^^^ (BitVec.ofNat 128 (i * 0x6C62272E07BB0142))
+    r := clMul a' b'
+  return r
+
+#eval timeit "=== Varied inputs 128x128 (10000 iters) ===" (pure ())
+#eval timeit "  clMul_baseline(to256)" (benchVariedBaseline 10000 (to256 tv_a) (to256 tv_b))
+#eval timeit "  clMul (new)          " (benchVariedNew 10000 tv_a tv_b)
+
+/-! ## Benchmarks — sparse inputs (128×8 bit, like fold_step) -/
+
+#eval timeit "=== Sparse 128x8 bit (10000 iters) ===" (pure ())
+#eval timeit "  clMul_baseline(to256)" (benchFixedBaseline 10000 (to256 tv_a) (to256 tv_sparse))
+#eval timeit "  clMul (new)          " (benchFixedNew 10000 tv_a tv_sparse)


### PR DESCRIPTION
This PR resolves issue #129. It includes a new definition and a new signature for `clMul: B128 → B128 → B256` that
- simplifies many downstream proofs by removing unnecessary hypothesis
- is faster by ~ 50% on the benchmarks at `CommonBench.lean`

  | Case | Baseline (B256) | New (B128) | Speedup |                             
  |------|-----------------|------------|---------|
  | Fixed dense 128×128 | 2.67s | 1.29s | 2.07× |                               
  | Varied inputs | 2.69s | 1.35s | 1.99× |                                     
  | Sparse 128×8 | 2.59s | 1.27s | 2.04× |
  
Benchmarks ran on: AMD Ryzen 5 3400G, 30GB RAM, Arch Linux 6.19.10.                                                                                 
 
  ## Changed files                                                              
                                                                                
  - **Common.lean**: new `clMul` definition, `clMul_unfold`,                    
    `fold_range_xor_eq_foldl`, `toPoly_fold_xor`, `toPoly_clMul`
  - **Prelude.lean**: new `clMul_eq_fold_range` (B128),                         
    `clMulNat_bv_eq_clMul` (B128), truncation bridges                           
    (`toNat_truncate_of_lt`, `to256_truncate_128`, `toPoly_truncate_128`,       
    `toPoly_clMul_B256`); deleted old B256 variants                             
  - **Impl.lean**: updated `fold_step`, `fold_step_mod_eq`,                     
    `reduce_clMul_correct`, `toQuot_mul`, and `Mul` instance to use             
    the new B128 API                                                            
  - **CommonBench.lean** (new): benchmark comparing old vs new `clMul`
    with correctness guards 
    
Developed with assistance from [Claude Code](https://claude.com/claude-code).
    