### PR TITLE
feat(univariate): Horner's method implementation

### DIFF
--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles, Natalie Klaus
+Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles, Natalie Klaus, Dimitris Mitsios
 -/
 import CompPoly.Univariate.Raw.Core
 

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -32,6 +32,21 @@ variable {S : Type*}
 def eval₂ [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) : S :=
   p.zipIdx.foldl (fun acc ⟨a, i⟩ => acc + f a * x ^ i) 0
 
+def eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) : S :=
+  p.foldr (fun a acc => acc * x + f a) 0
+
+theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) :
+  eval₂ f x p = eval₂Horner f x p := by
+    unfold eval₂ eval₂Horner
+    rw [← Array.foldl_toList, ← Array.foldr_toList, Array.toList_zipIdx]
+    induction p.toList with
+    | nil => simp
+    | cons head tail tail_ih =>
+
+
+
+private lemma
+
 /-- Evaluates a `CPolynomial.Raw` at a given value -/
 @[inline, specialize]
 def eval [Semiring R] (x : R) (p : CPolynomial.Raw R) : R :=

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -35,6 +35,15 @@ def eval₂ [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.R
 def eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) : S :=
   p.foldr (fun a acc => acc * x + f a) 0
 
+lemma foldl_zipIdx_eq_foldr_pow_k [Semiring R] [Semiring S] (f : R →+* S) (x : S) (init : S) (k : Nat) (l : List R) :
+  List.foldl (fun acc a => acc + (f a.1) * x ^ a.2) init (l.zipIdx k) = List.foldr (fun a acc => acc * x + f a) 0 l * x ^ k + init := by
+    induction l generalizing init k with
+    | nil => simp
+    | cons head tail tail_ih =>
+           simp only [List.foldr_cons, List.zipIdx_cons, List.foldl_cons]
+           rw [tail_ih]
+           rw [add_mul, mul_assoc, ← pow_succ', add_comm init, add_assoc]
+
 theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) :
   eval₂ f x p = eval₂Horner f x p := by
     unfold eval₂ eval₂Horner
@@ -42,10 +51,9 @@ theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : 
     induction p.toList with
     | nil => simp
     | cons head tail tail_ih =>
-
-
-
-private lemma
+           simp
+           rw [foldl_zipIdx_eq_foldr_pow_k]
+           simp
 
 /-- Evaluates a `CPolynomial.Raw` at a given value -/
 @[inline, specialize]

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -54,7 +54,7 @@ theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : 
 /-- Evaluates a `CPolynomial.Raw` at a given value -/
 @[inline, specialize]
 def eval [Semiring R] (x : R) (p : CPolynomial.Raw R) : R :=
-  p.eval₂ (RingHom.id R) x
+  p.eval₂Horner (RingHom.id R) x
 
 /-- Raw addition: pointwise sum of coefficient arrays (padded to equal length).
 

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -48,12 +48,8 @@ theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : 
   eval₂ f x p = eval₂Horner f x p := by
     unfold eval₂ eval₂Horner
     rw [← Array.foldl_toList, ← Array.foldr_toList, Array.toList_zipIdx]
-    induction p.toList with
-    | nil => simp
-    | cons head tail tail_ih =>
-           simp
-           rw [foldl_zipIdx_eq_foldr_pow_k]
-           simp
+    have := foldl_zipIdx_eq_foldr_pow_k f x 0 0 p.toList
+    simpa using this
 
 /-- Evaluates a `CPolynomial.Raw` at a given value -/
 @[inline, specialize]

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -1,7 +1,8 @@
 /-
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles, Natalie Klaus, Dimitris Mitsios
+Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles,
+  Natalie Klaus, Dimitris Mitsios
 -/
 import CompPoly.Univariate.Raw.Core
 

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -31,6 +31,9 @@ variable {S : Type*}
 def eval₂ [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) : S :=
   p.zipIdx.foldl (fun acc ⟨a, i⟩ => acc + f a * x ^ i) 0
 
+/-- Evaluates a `CPolynomial.Raw` at `x : S` using Horner's method.
+
+  Computes `f(aₙ) + x * (f(aₙ₋₁) + x * (... + x * f(a₀)))` via a right fold. -/
 @[inline, specialize]
 def eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) : S :=
   p.foldr (fun a acc => acc * x + f a) 0
@@ -46,6 +49,7 @@ private lemma foldl_zipIdx_eq_foldr_pow_k [Semiring R] [Semiring S]
            rw [tail_ih]
            rw [add_mul, mul_assoc, ← pow_succ', add_comm init, add_assoc]
 
+/-- Horner evaluation agrees with the sum-of-powers evaluation. -/
 theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S]
     (f : R →+* S) (x : S) (p : CPolynomial.Raw R) :
     eval₂ f x p = eval₂Horner f x p := by

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -26,17 +26,18 @@ variable {S : Type*}
 
 /-- Evaluates a `CPolynomial.Raw` at `x : S` using a ring homomorphism `f : R →+* S`.
 
-  Computes `f(a₀) + f(a₁) * x + f(a₂) * x² + ...` where `aᵢ` are the coefficients.
-
-  TODO: define an efficient version of this with caching -/
+  Computes `f(a₀) + f(a₁) * x + f(a₂) * x² + ...` where `aᵢ` are the coefficients.  -/
 def eval₂ [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) : S :=
   p.zipIdx.foldl (fun acc ⟨a, i⟩ => acc + f a * x ^ i) 0
 
+@[inline, specialize]
 def eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) : S :=
   p.foldr (fun a acc => acc * x + f a) 0
 
-lemma foldl_zipIdx_eq_foldr_pow_k [Semiring R] [Semiring S] (f : R →+* S) (x : S) (init : S) (k : Nat) (l : List R) :
-  List.foldl (fun acc a => acc + (f a.1) * x ^ a.2) init (l.zipIdx k) = List.foldr (fun a acc => acc * x + f a) 0 l * x ^ k + init := by
+private lemma foldl_zipIdx_eq_foldr_pow_k [Semiring R] [Semiring S]
+    (f : R →+* S) (x : S) (init : S) (k : Nat) (l : List R) :
+    List.foldl (fun acc a => acc + (f a.1) * x ^ a.2) init (l.zipIdx k) =
+      List.foldr (fun a acc => acc * x + f a) 0 l * x ^ k + init := by
     induction l generalizing init k with
     | nil => simp
     | cons head tail tail_ih =>
@@ -44,8 +45,9 @@ lemma foldl_zipIdx_eq_foldr_pow_k [Semiring R] [Semiring S] (f : R →+* S) (x :
            rw [tail_ih]
            rw [add_mul, mul_assoc, ← pow_succ', add_comm init, add_assoc]
 
-theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) :
-  eval₂ f x p = eval₂Horner f x p := by
+theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S]
+    (f : R →+* S) (x : S) (p : CPolynomial.Raw R) :
+    eval₂ f x p = eval₂Horner f x p := by
     unfold eval₂ eval₂Horner
     rw [← Array.foldl_toList, ← Array.foldr_toList, Array.toList_zipIdx]
     have := foldl_zipIdx_eq_foldr_pow_k f x 0 0 p.toList
@@ -54,7 +56,7 @@ theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : 
 /-- Evaluates a `CPolynomial.Raw` at a given value -/
 @[inline, specialize]
 def eval [Semiring R] (x : R) (p : CPolynomial.Raw R) : R :=
-  p.eval₂Horner (RingHom.id R) x
+  p.eval₂ (RingHom.id R) x
 
 /-- Raw addition: pointwise sum of coefficient arrays (padded to equal length).
 

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -38,26 +38,6 @@ def eval₂ [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.R
 def eval₂Horner [Semiring R] [Semiring S] (f : R →+* S) (x : S) (p : CPolynomial.Raw R) : S :=
   p.foldr (fun a acc => acc * x + f a) 0
 
-private lemma foldl_zipIdx_eq_foldr_pow_k [Semiring R] [Semiring S]
-    (f : R →+* S) (x : S) (init : S) (k : Nat) (l : List R) :
-    List.foldl (fun acc a => acc + (f a.1) * x ^ a.2) init (l.zipIdx k) =
-      List.foldr (fun a acc => acc * x + f a) 0 l * x ^ k + init := by
-    induction l generalizing init k with
-    | nil => simp
-    | cons head tail tail_ih =>
-           simp only [List.foldr_cons, List.zipIdx_cons, List.foldl_cons]
-           rw [tail_ih]
-           rw [add_mul, mul_assoc, ← pow_succ', add_comm init, add_assoc]
-
-/-- Horner evaluation agrees with the sum-of-powers evaluation. -/
-theorem eval₂_eq_eval₂Horner [Semiring R] [Semiring S]
-    (f : R →+* S) (x : S) (p : CPolynomial.Raw R) :
-    eval₂ f x p = eval₂Horner f x p := by
-    unfold eval₂ eval₂Horner
-    rw [← Array.foldl_toList, ← Array.foldr_toList, Array.toList_zipIdx]
-    have := foldl_zipIdx_eq_foldr_pow_k f x 0 0 p.toList
-    simpa using this
-
 /-- Evaluates a `CPolynomial.Raw` at a given value -/
 @[inline, specialize]
 def eval [Semiring R] (x : R) (p : CPolynomial.Raw R) : R :=

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -1,7 +1,8 @@
 /-
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles, Natalie Klaus
+Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles,
+  Natalie Klaus, Dimitris Mitsios
 -/
 import CompPoly.Univariate.Raw.Ops
 
@@ -904,6 +905,34 @@ protected theorem mul_assoc [LawfulBEq R] (p q r : CPolynomial.Raw R) :
   · exact mul_assoc_equiv p q r
 
 end MulTheorems
+
+section EvalTheorems
+
+variable [Semiring S]
+
+omit [BEq R] in
+private lemma foldl_zipIdx_eq_foldr_pow_k
+    (f : R →+* S) (x : S) (init : S) (k : Nat) (l : List R) :
+    List.foldl (fun acc a => acc + (f a.1) * x ^ a.2) init (l.zipIdx k) =
+      List.foldr (fun a acc => acc * x + f a) 0 l * x ^ k + init := by
+    induction l generalizing init k with
+    | nil => simp
+    | cons head tail tail_ih =>
+           simp only [List.foldr_cons, List.zipIdx_cons, List.foldl_cons]
+           rw [tail_ih]
+           rw [add_mul, mul_assoc, ← pow_succ', _root_.add_comm init, _root_.add_assoc]
+
+omit [BEq R] in
+/-- Horner evaluation agrees with the sum-of-powers evaluation. -/
+theorem eval₂_eq_eval₂Horner
+    (f : R →+* S) (x : S) (p : CPolynomial.Raw R) :
+    eval₂ f x p = eval₂Horner f x p := by
+    unfold eval₂ eval₂Horner
+    rw [← Array.foldl_toList, ← Array.foldr_toList, Array.toList_zipIdx]
+    have := foldl_zipIdx_eq_foldr_pow_k f x 0 0 p.toList
+    simpa using this
+
+end EvalTheorems
 
 end Semiring
 


### PR DESCRIPTION
This PR implements Horner's method (`eval₂Horner`) for univariate polynomial evaluation and provides a correctness proof (`eval₂_eq_eval₂Horner`). It does not replace the current implementation of `eval₂` and thus there is no proof breakage in the codebase. This is a deliberate choice that avoids refactoring all the proofs that depend on `eval` each time a new optimisation is introduced during Phase 2 of the Roadmap e.g. multi-point evaluation.

See also a much larger PR #190 that goes the other way modifying directly `eval, eval₂`, fixing broken proofs and adding even more optimisations!

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>