### PR TITLE
docs: clarify variable conventions for algebraic code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,15 +98,27 @@ Our [linting script](`./scripts/lint-style.sh`) helps enforce some aspects of th
 
 ### Variable Conventions
 
-* `u`, `v`, `w`, ... : Universes
-* `α`, `β`, `γ`, ... : Generic types
-* `a`, `b`, `c`, ... : Propositions
-* `x`, `y`, `z`, ... : Elements of a generic type
-* `h`, `h₁`, ...     : Assumptions/Hypotheses
-* `p`, `q`, `r`, ... : Predicates and relations
-* `m`, `n`, `k`, ... : Natural numbers
-* `i`, `j`, `k`, ... : Integers
-* `s`, `t`, ...      : Sets or Lists
+We follow Mathlib style, adapted for algebraic code. The conventions below
+reflect actual usage across the repository (`Univariate/`, `Multivariate/`,
+`Multilinear/`, `Bivariate/`, `Fields/`); please consult adjacent files when
+in doubt.
+
+* `u`, `v`, `w`, ...           : Universes
+* `α`, `β`, `γ`, ...            : Generic types (in non-algebraic contexts)
+* `R`, `M`, `G`, `F`, ...       : Algebraic carrier types (rings, modules,
+  groups, fields) — preferred over `α`, `β` in algebraic declarations such
+  as `variable {R : Type*} [Semiring R]`
+* `a`, `b`, `c`, ...            : Propositions
+* `x`, `y`, `z`, ...            : Elements of a generic type
+* `h`, `h₁`, ...                : Assumptions / hypotheses
+* `p`, `q`                     : Polynomials or predicates (disambiguate by
+  type and surrounding context — in this repo `p`, `q` are most often
+  `CPolynomial`, `CMvPolynomial`, or `CMlPolynomial` values)
+* `m`, `n`, `k`, ...            : Natural numbers
+* `i`, `j`, `k`, ...            : Indices into vectors, lists, or `Fin n`
+  (these may be `ℕ`- or `ℤ`-valued; the convention is about the indexing
+  role, not the underlying type)
+* `s`, `t`, ...                : Sets or lists
 
 ### Symbol Naming Dictionary
 


### PR DESCRIPTION
This PR improves the **Variable Conventions** section in `CONTRIBUTING.md` and closes issue #202 

Single file: `CONTRIBUTING.md` (+21 / −9). Key clarifications:

- **`R, M, G, F`** for algebraic carrier types (rings, modules, groups,
  fields) — preferred over `α, β` in algebraic declarations, matching actual
  usage like `variable {R : Type*} [Semiring R]` throughout the repo.
- **`p, q`** for polynomial values (`CPolynomial`, `CMvPolynomial`,
  `CMlPolynomial`) — disambiguated from "predicates and relations".
- **`i, j, k`** for indices into vectors, lists, or `Fin n` — clarifies that
  the convention is about the indexing role, not the underlying type
  (`ℕ` vs `ℤ`).