### PR TITLE
perf(additive-ntt): verified faster implementation

### DIFF
--- a/CompPoly/Fields/Binary/AdditiveNTT/Correctness.lean
+++ b/CompPoly/Fields/Binary/AdditiveNTT/Correctness.lean
@@ -5,6 +5,7 @@ Authors: Chung Thai Nguyen, Quang Dao
 -/
 
 import CompPoly.Fields.Binary.AdditiveNTT.Algorithm
+import CompPoly.Fields.Binary.AdditiveNTT.Impl
 
 /-!
 # Additive NTT Correctness
@@ -15,6 +16,218 @@ Additive NTT.
 
 open Polynomial AdditiveNTT Module
 namespace AdditiveNTT
+
+section ImplementationEquivalence
+
+variable {r : ℕ} [NeZero r]
+variable {L : Type} [Field L] [Fintype L] [DecidableEq L]
+variable {𝔽q : Type} [Field 𝔽q] [Fintype 𝔽q] [DecidableEq 𝔽q]
+variable [hFq_card : Fact (Fintype.card 𝔽q = 2)]
+variable [h_Fq_char_prime : Fact (Nat.Prime (ringChar 𝔽q))]
+variable [Algebra 𝔽q L]
+variable (β : Fin r → L) [hβ_lin_indep : Fact (LinearIndependent 𝔽q β)]
+variable [h_β₀_eq_1 : Fact (β 0 = 1)]
+variable {ℓ R_rate : ℕ} (h_ℓ_add_R_rate : ℓ + R_rate < r)
+
+omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
+/-- The `bitsToU` mapping is a bijection: showing that iterating bits corresponds
+exactly to the linear span. -/
+theorem bitsToU_bijective (i : Fin r) :
+    Function.Bijective (bitsToU (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (R_rate := R_rate) i) := by
+  -- A map between finite sets of the same size is bijective iff it is injective.
+  apply (Fintype.bijective_iff_injective_and_card
+    (f := bitsToU (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (R_rate := R_rate) i)).mpr ?_
+  constructor
+  -- Part A: Injectivity (Linear Independence)
+  · intro k1 k2 h_eq
+    unfold bitsToU at h_eq
+    simp only [Subtype.mk.injEq] at h_eq
+    -- We define the coefficients c_j based on the bits of k
+    let c (k : ℕ) (j : Fin i) : 𝔽q :=
+      if (Nat.getBit (n := k) (k := j.val) == 1) then 1 else 0
+    -- The sum can be rewritten as a linear combination with coefficients in Fq
+    have h_sum (k : Fin (2^i.val)) :
+      (Finset.univ.sum fun (j : Fin i) =>
+        if (Nat.getBit (n := k.val) (k := j.val) == 1) then
+          β ⟨j, by omega⟩
+        else (0 : L)) =
+      Finset.univ.sum fun j => (c k.val j) • β ⟨j, by omega⟩ := by
+      apply Finset.sum_congr rfl
+      intro j _
+      dsimp [c]
+      split_ifs <;> simp
+    rw [h_sum k1, h_sum k2] at h_eq
+    -- 1. Move everything to LHS: sum (c1 - c2) * beta = 0
+    rw [←sub_eq_zero] at h_eq
+    rw [←Finset.sum_sub_distrib] at h_eq
+    simp_rw [←sub_smul] at h_eq
+    rw [←sub_eq_zero] at h_eq
+    -- 2. Establish that the first `i` basis elements are Linearly Independent
+    have h_lin_indep := hβ_lin_indep.out
+    -- We restrict the global independence (Fin r) to the subset (Fin i)
+    have h_indep_restricted := LinearIndependent.comp h_lin_indep
+      (Fin.castLE (Nat.le_of_lt_succ (by omega)) : Fin i → Fin r)
+      (Fin.castLE_injective _)
+    -- 3. Apply Linear Independence to show every coefficient is 0
+    -- This gives us: ∀ j, c k1 j - c k2 j = 0
+    simp only [sub_zero] at h_eq
+    have h_coeffs_zero : ∀ j : Fin i, j ∈ Finset.univ → c k1.val j - c k2.val j = 0 :=
+      linearIndependent_iff'.mp h_indep_restricted
+        (Finset.univ)
+        (fun j => c k1.val j - c k2.val j)
+        h_eq
+    -- 4. Prove k1 = k2 by showing all bits are equal
+    ext
+    apply Nat.eq_iff_eq_all_getBits.mpr
+    intro n
+    have h_bit_k1_lt_2 := Nat.getBit_lt_2 (n := k1) (k := n)
+    have h_bit_k2_lt_2 := Nat.getBit_lt_2 (n := k2) (k := n)
+    if hn : n < i.val then
+      let j : Fin i := ⟨n, hn⟩
+      have h_c_diff_zero := h_coeffs_zero j (Finset.mem_univ j)
+      simp only [sub_eq_zero] at h_c_diff_zero
+      dsimp only [beq_iff_eq, c] at h_c_diff_zero
+      interval_cases hk1: Nat.getBit (n := k1) (k := j)
+      · interval_cases hk2: Nat.getBit (n := k2) (k := j)
+        · rfl;
+        · simp only [Nat.reduceBEq, Bool.false_eq_true, ↓reduceIte, BEq.rfl,
+          zero_ne_one] at h_c_diff_zero;
+      · interval_cases hk2: Nat.getBit (n := k2) (k := j)
+        · simp only [BEq.rfl, ↓reduceIte, Nat.reduceBEq, Bool.false_eq_true,
+          one_ne_zero] at h_c_diff_zero;
+        · rfl
+    else
+      have h_k1 := Nat.getBit_of_lt_two_pow (n := i) (a := k1) (k := n)
+      have h_k2 := Nat.getBit_of_lt_two_pow (n := i) (a := k2) (k := n)
+      simp only [hn, ↓reduceIte] at h_k1 h_k2
+      rw [h_k1, h_k2]
+  -- Part B: Cardinality (Surjectivity check)
+  · -- ⊢ Fintype.card (Fin (2 ^ ↑i)) = Fintype.card ↥(U i)
+    rw [Fintype.card_fin]
+    rw [AdditiveNTT.U_card (𝔽q := 𝔽q)
+      (β := β) (i := i)]
+    rw [hFq_card.out]
+
+omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
+/-- Prove that `evalWAt` equals the standard definition of `W_i(x)`. -/
+theorem evalWAt_eq_W (i : Fin r) (x : L) :
+    evalWAt (β := β) (ℓ := ℓ) (R_rate := R_rate) (i := i) x =
+    (W (𝔽q := 𝔽q) (β := β) (i := i)).eval x := by
+  -- 1. Convert implementation to mathematical product over Fin(2^i)
+  unfold evalWAt getUElements
+  rw [List.map_map]
+  rw [List.prod_finRange_eq_finset_prod]
+  -- 2. Prepare RHS
+  rw [AdditiveNTT.W, Polynomial.eval_prod]
+  simp only [Polynomial.eval_sub, Polynomial.eval_X, Polynomial.eval_C]
+  -- 3. Use Finset.prod_bij to show equality via the bijection
+  apply Finset.prod_bij (s := ((Finset.univ (α := (Fin (2^(i.val)))))))
+    (t := (Finset.univ : Finset (U 𝔽q β i)))
+    (i := fun k _ =>
+      bitsToU (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (r := r) (R_rate := R_rate) (L := L) (i := i) k)
+    (hi := by
+      intro a _
+      exact Finset.mem_univ _)
+    (i_inj := by
+      intro a₁ _ a₂ _ h_eq
+      exact (bitsToU_bijective (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
+        (r := r) (R_rate := R_rate) (L := L) (i := i)).1 h_eq)
+    (i_surj := by
+      intro b _
+      obtain ⟨a, ha_eq⟩ := (bitsToU_bijective (𝔽q := 𝔽q)
+        (β := β) (ℓ := ℓ) (r := r) (R_rate := R_rate) (L := L) (i := i)).2 b
+      use a
+      constructor
+      · exact ha_eq
+      · exact Finset.mem_univ a
+    )
+    (h := by
+      intro a ha_univ
+      rfl
+    )
+
+omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
+/-- Prove that `evalNormalizedWAt` equals the standard definition of `Ŵ_i(x)`. -/
+theorem evalNormalizedWAt_eq_normalizedW (i : Fin r) (x : L) :
+    evalNormalizedWAt (β := β) (ℓ := ℓ) (R_rate := R_rate) (i := i) x
+    = (normalizedW (𝔽q := 𝔽q) (β := β) (i := i)).eval x := by
+  unfold evalNormalizedWAt
+  rw [evalWAt_eq_W (r := r) (L := L) (𝔽q := 𝔽q) (β := β) i x]
+  simp only
+  rw [evalWAt_eq_W (r := r) (L := L) (𝔽q := 𝔽q) (β := β) i (β i)]
+  rw [AdditiveNTT.normalizedW]
+  simp only [Polynomial.eval_mul, Polynomial.eval_C]
+  simp only [one_div]
+  apply mul_comm
+
+omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
+/-- Prove that `computableTwiddleFactor` equals the standard definition of `twiddleFactor`. -/
+theorem computableTwiddleFactor_eq_twiddleFactor (i : Fin ℓ) :
+    computableTwiddleFactor (r := r) (ℓ := ℓ) (β := β) (L := L)
+    (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨i, by omega⟩) =
+  twiddleFactor (𝔽q := 𝔽q) (L := L) (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+    (i := ⟨i, by omega⟩) := by
+  unfold computableTwiddleFactor twiddleFactor
+  simp_rw [evalNormalizedWAt_eq_normalizedW (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
+    (R_rate := R_rate) (i := ⟨i, by omega⟩)]
+
+omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
+/-- Prove that `computableNTTStage` equals the standard definition of `NTTStage`. -/
+theorem computableNTTStage_eq_NTTStage (i : Fin ℓ) :
+    computableNTTStage (𝔽q := 𝔽q) (r := r) (L := L) (ℓ := ℓ) (β := β) (R_rate := R_rate)
+    (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨i, by omega⟩) =
+  NTTStage (𝔽q := 𝔽q) (L := L) (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+    (i := ⟨i, by omega⟩) := by
+  unfold computableNTTStage NTTStage
+  simp only [Fin.eta]
+  simp_rw [computableTwiddleFactor_eq_twiddleFactor (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
+    (R_rate := R_rate) (i := ⟨i, by omega⟩)]
+
+omit [DecidableEq 𝔽q] [Fact (Nat.Prime (ringChar 𝔽q))] [Fact (β 0 = 1)] in
+/-- The proof-oriented computable additive NTT agrees with the abstract
+additive NTT specification. -/
+theorem computableAdditiveNTT_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
+    computableAdditiveNTT (𝔽q := 𝔽q) (L := L) (r := r) (β := β)
+      (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) =
+    additiveNTT (𝔽q := 𝔽q) (L := L) (β := β)
+      (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) := by
+  unfold computableAdditiveNTT additiveNTT
+  simp only
+  congr
+  funext current_b i
+  rw [computableNTTStage_eq_NTTStage (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
+    (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - i, by omega⟩)]
+
+/-- The ST-backed fast additive NTT is extensionally equal to the proof-oriented
+computable implementation after running the ST action.
+
+This is the preferred proof boundary for the fast path: once this theorem is
+proved, correctness against the abstract additive NTT specification follows from
+`computableAdditiveNTT_eq_additiveNTT`. -/
+theorem computableAdditiveNTTFastST_eq_computableAdditiveNTT (a : Fin (2 ^ ℓ) → L) :
+    runST (fun σ =>
+      computableAdditiveNTTFastST (L := L) (r := r) (β := β)
+        (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+        (σ := σ) (a := a)) =
+    computableAdditiveNTT (𝔽q := 𝔽q) (L := L) (r := r) (β := β)
+      (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) := by
+  sorry
+
+/-- The ST-backed fast additive NTT is correct against the abstract additive NTT
+specification after running the ST action. -/
+theorem computableAdditiveNTTFastST_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
+    runST (fun σ =>
+      computableAdditiveNTTFastST (L := L) (r := r) (β := β)
+        (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+        (σ := σ) (a := a)) =
+    additiveNTT (𝔽q := 𝔽q) (L := L) (β := β)
+      (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) := by
+  rw [computableAdditiveNTTFastST_eq_computableAdditiveNTT (𝔽q := 𝔽q) (β := β)
+    (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)]
+  exact computableAdditiveNTT_eq_additiveNTT (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
+    (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)
+
+end ImplementationEquivalence
 
 universe u
 
@@ -511,4 +724,5 @@ theorem additiveNTT_correctness (h_ℓ : ℓ ≤ r)
   simp_rw [Nat.sub_right_comm]
 
 end AlgorithmCorrectness
+
 end AdditiveNTT

--- a/CompPoly/Fields/Binary/AdditiveNTT/Correctness.lean
+++ b/CompPoly/Fields/Binary/AdditiveNTT/Correctness.lean
@@ -6,6 +6,8 @@ Authors: Chung Thai Nguyen, Quang Dao
 
 import CompPoly.Fields.Binary.AdditiveNTT.Algorithm
 import CompPoly.Fields.Binary.AdditiveNTT.Impl
+import Mathlib.Algebra.CharP.CharAndCard
+import Mathlib.Algebra.CharP.Two
 
 /-!
 # Additive NTT Correctness
@@ -18,6 +20,27 @@ open Polynomial AdditiveNTT Module
 namespace AdditiveNTT
 
 section ImplementationEquivalence
+
+/-- Running a state fold made only of state updates gives the same final state as
+the corresponding pure fold. -/
+lemma run_foldlM_modify_eq_foldl {σ : Type} (n : Nat) (f : σ → Fin n → σ) (init : σ) :
+    ((Fin.foldlM (m := StateM σ) (n := n)
+      (f := fun (_ : Unit) i => do
+        modifyThe σ fun current => f current i
+        pure ()) (init := ())).run init).2 =
+      Fin.foldl n f init := by
+  induction n generalizing init with
+  | zero =>
+      simp only [Fin.foldlM_zero, Fin.foldl_zero]
+      rfl
+  | succ n ih =>
+      simp only [Fin.foldlM_succ_last, Fin.foldl_succ_last]
+      change f ((Fin.foldlM (m := StateM σ) (n := n)
+        (f := fun (_ : Unit) i => do
+          modifyThe σ fun current => f current i.castSucc
+          pure ()) (init := ())).run init).2 (Fin.last n) =
+        f (Fin.foldl n (fun current i => f current i.castSucc) init) (Fin.last n)
+      rw [ih (f := fun current i => f current i.castSucc) (init := init)]
 
 variable {r : ℕ} [NeZero r]
 variable {L : Type} [Field L] [Fintype L] [DecidableEq L]
@@ -183,7 +206,284 @@ theorem computableNTTStage_eq_NTTStage (i : Fin ℓ) :
   simp_rw [computableTwiddleFactor_eq_twiddleFactor (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
     (R_rate := R_rate) (i := ⟨i, by omega⟩)]
 
-omit [DecidableEq 𝔽q] [Fact (Nat.Prime (ringChar 𝔽q))] [Fact (β 0 = 1)] in
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
+/-- In the binary-field setting, the subspace vanishing polynomials satisfy the
+runtime recurrence used by `evalWAtCachedConstants`. -/
+lemma W_eval_succ_eq_mul_add (i : Fin r) (h_i_add_1 : i + 1 < r) (x : L) :
+    (W (𝔽q := 𝔽q) (β := β) (i := i + 1)).eval x =
+      (W (𝔽q := 𝔽q) (β := β) (i := i)).eval x *
+        ((W (𝔽q := 𝔽q) (β := β) (i := i)).eval x +
+          (W (𝔽q := 𝔽q) (β := β) (i := i)).eval (β i)) := by
+  haveI : CharP 𝔽q 2 := charP_of_card_eq_prime hFq_card.out
+  haveI : CharP L 2 := (Algebra.charP_iff 𝔽q L 2).mp inferInstance
+  have h := W_linear_comp_decomposition (𝔽q := 𝔽q) (β := β) (i := i)
+    h_i_add_1 (p := C x)
+  have h_eval := congrArg (fun p : L[X] => p.eval 0) h
+  simp only [eval_comp, eval_C, eval_pow, eval_sub, eval_mul] at h_eval
+  rw [hFq_card.out] at h_eval
+  simp only [pow_two] at h_eval
+  rw [h_eval]
+  rw [CharTwo.sub_eq_add]
+  ring
+
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
+/-- The cached evaluator computes `W_i(x)` when the cache stores exactly
+`W_k(β_k)` for `k < i`. This is stated for the internal loop so later proofs can
+resume from a partially consumed cache. -/
+lemma evalWAtCachedConstantsLoop_eq_W_of_correct (constants : Array L) (i : Fin r)
+    (j : Nat) (x acc : L)
+    (hsize : constants.size = i.val) (hj_le : j ≤ i.val) (hj_lt_r : j < r)
+    (hacc : acc = (W (𝔽q := 𝔽q) (β := β) (i := ⟨j, hj_lt_r⟩)).eval x)
+    (hcorrect : ∀ k, j ≤ k → (hki : k < i.val) →
+      constants.getD k 0 =
+        (W (𝔽q := 𝔽q) (β := β) (i := ⟨k, Nat.lt_trans hki i.isLt⟩)).eval
+          (β ⟨k, Nat.lt_trans hki i.isLt⟩)) :
+    evalWAtCachedConstantsLoop constants j acc =
+      (W (𝔽q := 𝔽q) (β := β) (i := i)).eval x := by
+  generalize hn_eq : i.val - j = n
+  revert j acc
+  induction n with
+  | zero =>
+      intro j acc hj_le hj_lt_r hacc hcorrect hn_eq
+      have hji : j = i.val := by omega
+      unfold evalWAtCachedConstantsLoop
+      simp only [hsize, hji, lt_self_iff_false, ↓reduceDIte]
+      rw [hacc]
+      congr
+  | succ n ih =>
+      intro j acc hj_le hj_lt_r hacc hcorrect hn_eq
+      have hj_lt_i : j < i.val := by omega
+      have hj1_lt_r : j + 1 < r := by omega
+      unfold evalWAtCachedConstantsLoop
+      simp only [hsize, hj_lt_i, ↓reduceDIte]
+      exact ih (j + 1) (acc * (acc + constants.getD j 0)) (by omega) hj1_lt_r (by
+        rw [hacc, hcorrect j (by omega) hj_lt_i]
+        have hsucc : (⟨j, hj_lt_r⟩ : Fin r) + 1 = ⟨j + 1, hj1_lt_r⟩ := by
+          ext
+          exact Fin.val_add_one' (a := ⟨j, hj_lt_r⟩) (h_a_add_1 := hj1_lt_r)
+        simpa [hsucc] using (W_eval_succ_eq_mul_add (𝔽q := 𝔽q) (β := β)
+          (i := ⟨j, hj_lt_r⟩) (h_i_add_1 := by
+            simpa using hj1_lt_r) (x := x)).symm)
+        (by
+          intro k hk_ge hk_lt
+          exact hcorrect k (by omega) hk_lt)
+        (by omega)
+
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
+/-- The cached evaluator computes `W_i(x)` from a complete cache for stage `i`. -/
+lemma evalWAtCachedConstants_eq_W_of_correct (constants : Array L) (i : Fin r) (x : L)
+    (hsize : constants.size = i.val)
+    (hcorrect : ∀ k, (hki : k < i.val) →
+      constants.getD k 0 =
+        (W (𝔽q := 𝔽q) (β := β) (i := ⟨k, Nat.lt_trans hki i.isLt⟩)).eval
+          (β ⟨k, Nat.lt_trans hki i.isLt⟩)) :
+    evalWAtCachedConstants constants x =
+      (W (𝔽q := 𝔽q) (β := β) (i := i)).eval x := by
+  unfold evalWAtCachedConstants
+  exact evalWAtCachedConstantsLoop_eq_W_of_correct (𝔽q := 𝔽q) (β := β)
+    (constants := constants) (i := i) (j := 0) (x := x) (acc := x)
+    hsize (by omega) (NeZero.pos r) (by
+      change x = (W (𝔽q := 𝔽q) (β := β) (i := (0 : Fin r))).eval x
+      rw [W₀_eq_X (𝔽q := 𝔽q) (β := β)]
+      simp only [eval_X])
+    (by
+      intro k _ hk
+      exact hcorrect k hk)
+
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
+/-- The constants-array builder preserves the invariant that entry `k` stores
+`W_k(β_k)`, and finishes with one entry for every `k < i`. -/
+lemma subspacePolynomialConstantsArrayLoop_spec (i : Fin r) (k : Nat) (constants : Array L)
+    (hsize : constants.size = k) (hk_le : k ≤ i.val)
+    (hcorrect : ∀ m, (hmk : m < k) →
+      constants.getD m 0 =
+        (W (𝔽q := 𝔽q) (β := β) (i := ⟨m, by omega⟩)).eval (β ⟨m, by omega⟩)) :
+    let result := subspacePolynomialConstantsArrayLoop (β := β) (ℓ := ℓ)
+      (R_rate := R_rate) i k constants
+    result.size = i.val ∧
+      ∀ m, (hmi : m < i.val) →
+        result.getD m 0 =
+          (W (𝔽q := 𝔽q) (β := β) (i := ⟨m, Nat.lt_trans hmi i.isLt⟩)).eval
+            (β ⟨m, Nat.lt_trans hmi i.isLt⟩) := by
+  generalize hn_eq : i.val - k = n
+  revert k constants
+  induction n with
+  | zero =>
+      intro k constants hsize hk_le hcorrect hn_eq
+      have hki : k = i.val := by omega
+      unfold subspacePolynomialConstantsArrayLoop
+      simp only [hki, lt_self_iff_false, ↓reduceDIte]
+      constructor
+      · rw [hsize, hki]
+      · intro m hm
+        exact hcorrect m (by omega)
+  | succ n ih =>
+      intro k constants hsize hk_le hcorrect hn_eq
+      have hk_lt_i : k < i.val := by omega
+      have hk_lt_r : k < r := by omega
+      unfold subspacePolynomialConstantsArrayLoop
+      simp only [hk_lt_i, ↓reduceDIte]
+      exact ih (k + 1)
+        (constants.push (evalWAtCachedConstants constants (β ⟨k, by omega⟩)))
+        (by simp only [Array.size_push, hsize])
+        (by omega)
+        (by
+          intro m hm
+          by_cases hmk : m < k
+          · have hm_ne_size : m ≠ constants.size := by
+              rw [hsize]
+              omega
+            simp only [Array.getD_eq_getD_getElem?, Array.getElem?_push, hm_ne_size,
+              ↓reduceIte]
+            rw [← Array.getD_eq_getD_getElem?]
+            exact hcorrect m hmk
+          · have hmk_eq : m = k := by omega
+            subst m
+            simp only [hsize, Array.getD_eq_getD_getElem?, Array.getElem?_push,
+              ↓reduceIte, Option.getD_some]
+            simpa using evalWAtCachedConstants_eq_W_of_correct (𝔽q := 𝔽q) (β := β)
+              (constants := constants) (i := ⟨k, hk_lt_r⟩) (x := β ⟨k, hk_lt_r⟩)
+              hsize hcorrect)
+        (by omega)
+
+omit [NeZero r] [Fintype L] [DecidableEq L] [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
+lemma subspacePolynomialConstantsArrayLoop_size (i : Fin r) (k : Nat) (constants : Array L)
+    (hsize : constants.size = k) (hk_le : k ≤ i.val) :
+    (subspacePolynomialConstantsArrayLoop (β := β) (ℓ := ℓ)
+      (R_rate := R_rate) i k constants).size = i.val := by
+  generalize hn_eq : i.val - k = n
+  revert k constants
+  induction n with
+  | zero =>
+      intro k constants hsize hk_le hn_eq
+      have hki : k = i.val := by omega
+      unfold subspacePolynomialConstantsArrayLoop
+      simp only [hki, lt_self_iff_false, ↓reduceDIte]
+      rw [hsize, hki]
+  | succ n ih =>
+      intro k constants hsize hk_le hn_eq
+      have hk_lt_i : k < i.val := by omega
+      unfold subspacePolynomialConstantsArrayLoop
+      simp only [hk_lt_i, ↓reduceDIte]
+      exact ih (k + 1)
+        (constants.push (evalWAtCachedConstants constants (β ⟨k, by omega⟩)))
+        (by simp only [Array.size_push, hsize])
+        (by omega)
+        (by omega)
+
+omit [NeZero r] [Fintype L] [DecidableEq L] [DecidableEq 𝔽q] h_β₀_eq_1 in
+lemma subspacePolynomialConstantsArray_size (i : Fin r) :
+    (subspacePolynomialConstantsArray (β := β) (ℓ := ℓ) (R_rate := R_rate) i).size =
+      i.val := by
+  exact subspacePolynomialConstantsArrayLoop_size (β := β)
+    (ℓ := ℓ) (R_rate := R_rate) (i := i) (k := 0) (constants := #[])
+    rfl (Nat.zero_le _)
+
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
+lemma subspacePolynomialConstantsArray_getD (i : Fin r) (m : Nat) (hm : m < i.val) :
+    (subspacePolynomialConstantsArray (β := β) (ℓ := ℓ) (R_rate := R_rate) i).getD m 0 =
+      (W (𝔽q := 𝔽q) (β := β) (i := ⟨m, Nat.lt_trans hm i.isLt⟩)).eval
+        (β ⟨m, Nat.lt_trans hm i.isLt⟩) := by
+  exact (subspacePolynomialConstantsArrayLoop_spec (𝔽q := 𝔽q) (β := β)
+    (ℓ := ℓ) (R_rate := R_rate) (i := i) (k := 0) (constants := #[])
+    rfl (Nat.zero_le _) (by intro m hm; omega)).2 m hm
+
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
+lemma evalWAtCachedConstants_subspacePolynomialConstantsArray_eq_W (i : Fin r) (x : L) :
+    evalWAtCachedConstants
+      (subspacePolynomialConstantsArray (β := β) (ℓ := ℓ) (R_rate := R_rate) i) x =
+      (W (𝔽q := 𝔽q) (β := β) (i := i)).eval x := by
+  apply evalWAtCachedConstants_eq_W_of_correct (𝔽q := 𝔽q) (β := β)
+  · exact subspacePolynomialConstantsArray_size (β := β)
+      (ℓ := ℓ) (R_rate := R_rate) (i := i)
+  · intro k hk
+    exact subspacePolynomialConstantsArray_getD (𝔽q := 𝔽q) (β := β)
+      (ℓ := ℓ) (R_rate := R_rate) (i := i) k hk
+
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
+lemma computableNormalizedWValuesArray_getD (i : Fin ℓ)
+    (k : Fin (ℓ + R_rate - i - 1)) :
+    (computableNormalizedWValuesArray (β := β) (ℓ := ℓ) (R_rate := R_rate)
+      (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i)).getD k.val 0 =
+      (normalizedW (𝔽q := 𝔽q) (β := β) (i := ⟨i, by omega⟩)).eval
+        (β ⟨i + 1 + k.val, by omega⟩) := by
+  unfold computableNormalizedWValuesArray
+  simp [Array.getD_eq_getD_getElem?]
+  rw [evalWAtCachedConstants_subspacePolynomialConstantsArray_eq_W (𝔽q := 𝔽q) (β := β)]
+  rw [evalWAtCachedConstants_subspacePolynomialConstantsArray_eq_W (𝔽q := 𝔽q) (β := β)]
+  rw [normalizedW]
+  simp only [eval_mul, eval_C, one_div]
+  ring
+
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
+lemma computableTwiddleTableArray_getD (i : Fin ℓ)
+    (u : Fin (2 ^ (ℓ + R_rate - i - 1))) :
+    (computableTwiddleTableArray (β := β) (ℓ := ℓ) (R_rate := R_rate)
+      (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i)).getD u.val 0 =
+      twiddleFactor (𝔽q := 𝔽q) (L := L) (ℓ := ℓ) (R_rate := R_rate)
+        (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨i, by omega⟩) (u := u) := by
+  unfold computableTwiddleTableArray twiddleFactor
+  simp [Array.getD_eq_getD_getElem?]
+  apply Finset.sum_congr rfl
+  intro k _hk
+  by_cases h_bit : Nat.getBit k.val u.val = 1
+  · simpa [h_bit] using
+      (computableNormalizedWValuesArray_getD (𝔽q := 𝔽q) (β := β)
+        (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i) (k := k))
+  · simp [h_bit]
+
+omit [Fintype L] [DecidableEq L] [DecidableEq 𝔽q] h_β₀_eq_1 in
+lemma arrayToFinFunction_tileCoeffsArray (a : Fin (2 ^ ℓ) → L) :
+    arrayToFinFunction (2 ^ (ℓ + R_rate))
+      (tileCoeffsArray (L := L) (ℓ := ℓ) R_rate a) =
+      tileCoeffs (L := L) (ℓ := ℓ) (R_rate := R_rate) a := by
+  ext v
+  unfold arrayToFinFunction tileCoeffsArray tileCoeffs
+  simp [Array.getD_eq_getD_getElem?]
+
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
+lemma computableNTTStageArray_eq_computableNTTStage (i : Fin ℓ) (b : Array L) :
+    arrayToFinFunction (2 ^ (ℓ + R_rate))
+        (computableNTTStageArray (L := L) (ℓ := ℓ) (R_rate := R_rate)
+          (i := i)
+          (twiddles := computableTwiddleTableArray (β := β) (ℓ := ℓ)
+            (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i)) b) =
+      computableNTTStage (𝔽q := 𝔽q) (r := r) (L := L) (ℓ := ℓ) (R_rate := R_rate)
+        (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨i, by omega⟩)
+        (b := arrayToFinFunction (2 ^ (ℓ + R_rate)) b) := by
+  ext j
+  unfold computableNTTStageArray computableNTTStage arrayToFinFunction
+  simp [Array.getD_eq_getD_getElem?]
+  let u : Fin (2 ^ (ℓ + R_rate - i - 1)) := ⟨j.val / 2 ^ i.val / 2, by
+    rw [Nat.div_div_eq_div_mul]
+    have hpow : 2 ^ i.val * 2 = 2 ^ (i.val + 1) := by
+      rw [Nat.mul_comm, Nat.pow_succ']
+    rw [hpow]
+    have h_exp : ℓ + R_rate - i.val - 1 + (i.val + 1) = ℓ + R_rate := by omega
+    have h_j_lt :
+        j.val < 2 ^ (ℓ + R_rate - i.val - 1 + (i.val + 1)) := by
+      rw [h_exp]
+      exact j.isLt
+    exact div_two_pow_lt_two_pow (x := j.val) (i := ℓ + R_rate - i.val - 1)
+      (j := i.val + 1) h_j_lt⟩
+  have h_table :
+      (computableTwiddleTableArray (β := β) (ℓ := ℓ) (R_rate := R_rate)
+        (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i))[j.val / 2 ^ i.val / 2]?.getD 0 =
+        twiddleFactor (𝔽q := 𝔽q) (L := L) (ℓ := ℓ) (R_rate := R_rate)
+          (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨i, by omega⟩) (u := u) := by
+    simpa [u, Array.getD_eq_getD_getElem?] using
+      (computableTwiddleTableArray_getD (𝔽q := 𝔽q) (β := β)
+        (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i) (u := u))
+  have h_factor :
+      twiddleFactor (𝔽q := 𝔽q) (L := L) (ℓ := ℓ) (R_rate := R_rate)
+        (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨i, by omega⟩) (u := u) =
+        computableTwiddleFactor (r := r) (L := L) (ℓ := ℓ) (R_rate := R_rate)
+          (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨i, by omega⟩) (u := u) :=
+    (congrFun (computableTwiddleFactor_eq_twiddleFactor (𝔽q := 𝔽q) (β := β)
+      (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i)) u).symm
+  rw [h_table, h_factor]
+
+omit [DecidableEq 𝔽q] h_Fq_char_prime [Fact (β 0 = 1)] in
 /-- The proof-oriented computable additive NTT agrees with the abstract
 additive NTT specification. -/
 theorem computableAdditiveNTT_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
@@ -198,6 +498,30 @@ theorem computableAdditiveNTT_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
   rw [computableNTTStage_eq_NTTStage (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
     (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - i, by omega⟩)]
 
+omit [NeZero r] [Fintype L] [DecidableEq L] [Field 𝔽q] [Fintype 𝔽q] [DecidableEq 𝔽q]
+  h_Fq_char_prime hFq_card [Algebra 𝔽q L] hβ_lin_indep h_β₀_eq_1 in
+lemma computableAdditiveNTTFastAction_run_eq_fold (a : Fin (2 ^ ℓ) → L) :
+    ((computableAdditiveNTTFastAction (L := L) (r := r) (β := β)
+      (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) a).run #[]).1 =
+    Fin.foldl (n := ℓ) (f := fun current i =>
+      let stage : Fin ℓ := ⟨ℓ - 1 - i, by omega⟩
+      let twiddles := computableTwiddleTableArray (β := β) (ℓ := ℓ)
+        (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := stage)
+      computableNTTStageArray (ℓ := ℓ) (R_rate := R_rate)
+        (i := stage) (twiddles := twiddles) current)
+      (init := tileCoeffsArray (L := L) (ℓ := ℓ) R_rate a) := by
+  unfold computableAdditiveNTTFastAction computableAdditiveNTTFastStages
+  simp only [bind_assoc, StateT.run, MonadStateOf.set, getThe]
+  simpa using run_foldlM_modify_eq_foldl (σ := Array L) (n := ℓ)
+    (f := fun current i =>
+      let stage : Fin ℓ := ⟨ℓ - 1 - i, by omega⟩
+      let twiddles := computableTwiddleTableArray (β := β) (ℓ := ℓ)
+        (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := stage)
+      computableNTTStageArray (ℓ := ℓ) (R_rate := R_rate)
+        (i := stage) (twiddles := twiddles) current)
+    (init := tileCoeffsArray (L := L) (ℓ := ℓ) R_rate a)
+
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
 /-- The fast additive NTT array implementation is extensionally equal to the
 proof-oriented computable implementation after converting its output array to a
 `Fin`-indexed function.
@@ -211,8 +535,40 @@ theorem computableAdditiveNTTFast_eq_computableAdditiveNTT (a : Fin (2 ^ ℓ) �
         (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)) =
     computableAdditiveNTT (𝔽q := 𝔽q) (L := L) (r := r) (β := β)
       (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) := by
-  sorry
+  unfold computableAdditiveNTTFast computableAdditiveNTT
+  rw [computableAdditiveNTTFastAction_run_eq_fold (β := β)
+    (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)]
+  have h_fold : ∀ k, (hk_le : k ≤ ℓ) →
+      arrayToFinFunction (2 ^ (ℓ + R_rate))
+        (Fin.foldl (n := k) (f := fun current i =>
+          let stage : Fin ℓ := ⟨ℓ - 1 - i, by omega⟩
+          let twiddles := computableTwiddleTableArray (β := β) (ℓ := ℓ)
+            (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := stage)
+          computableNTTStageArray (ℓ := ℓ) (R_rate := R_rate)
+            (i := stage) (twiddles := twiddles) current)
+          (init := tileCoeffsArray (L := L) (ℓ := ℓ) R_rate a)) =
+      Fin.foldl (n := k) (f := fun current i =>
+        computableNTTStage (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (R_rate := R_rate)
+          (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - i, by omega⟩) (b := current))
+        (init := tileCoeffs (L := L) (ℓ := ℓ) (R_rate := R_rate) a) := by
+    intro k hk_le
+    induction k with
+    | zero =>
+        simp only [Fin.foldl_zero]
+        exact arrayToFinFunction_tileCoeffsArray (L := L) (ℓ := ℓ)
+          (R_rate := R_rate) (a := a)
+    | succ k ih =>
+        have hk_le' : k ≤ ℓ := by omega
+        simp only [Fin.foldl_succ_last, Fin.val_last, Fin.val_castSucc]
+        rw [computableNTTStageArray_eq_computableNTTStage (𝔽q := 𝔽q) (β := β)
+          (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - k, by omega⟩)]
+        exact congrArg (fun current =>
+          computableNTTStage (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (R_rate := R_rate)
+            (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - k, by omega⟩)
+            (b := current)) (ih hk_le')
+  simpa using h_fold ℓ (le_rfl)
 
+omit [DecidableEq 𝔽q] h_β₀_eq_1 in
 /-- The fast additive NTT array implementation is correct against the abstract
 additive NTT specification after converting its output array to a `Fin`-indexed
 function. -/

--- a/CompPoly/Fields/Binary/AdditiveNTT/Correctness.lean
+++ b/CompPoly/Fields/Binary/AdditiveNTT/Correctness.lean
@@ -198,33 +198,31 @@ theorem computableAdditiveNTT_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
   rw [computableNTTStage_eq_NTTStage (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
     (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - i, by omega⟩)]
 
-/-- The pure `StateT` specialization of the fast additive NTT is extensionally
-equal to the proof-oriented computable implementation after converting its
-output array to a `Fin`-indexed function.
+/-- The fast additive NTT array implementation is extensionally equal to the
+proof-oriented computable implementation after converting its output array to a
+`Fin`-indexed function.
 
 This is the preferred proof boundary for the fast path: once this theorem is
 proved, correctness against the abstract additive NTT specification follows from
-`computableAdditiveNTT_eq_additiveNTT`. The ST-backed runtime path shares the
-same monadic core, but `ST.Ref` itself is opaque, so this transparent `StateT`
-specialization is the kernel-checkable correctness surface. -/
-theorem computableAdditiveNTTFastState_eq_computableAdditiveNTT (a : Fin (2 ^ ℓ) → L) :
+`computableAdditiveNTT_eq_additiveNTT`. -/
+theorem computableAdditiveNTTFast_eq_computableAdditiveNTT (a : Fin (2 ^ ℓ) → L) :
     AdditiveNTT.arrayToFinFunction (2^(ℓ + R_rate))
-      (computableAdditiveNTTFastState (L := L) (r := r) (β := β)
+      (computableAdditiveNTTFast (L := L) (r := r) (β := β)
         (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)) =
     computableAdditiveNTT (𝔽q := 𝔽q) (L := L) (r := r) (β := β)
       (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) := by
   sorry
 
-/-- The pure `StateT` specialization of the fast additive NTT is correct against
-the abstract additive NTT specification after converting its output array to a
-`Fin`-indexed function. -/
-theorem computableAdditiveNTTFastState_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
+/-- The fast additive NTT array implementation is correct against the abstract
+additive NTT specification after converting its output array to a `Fin`-indexed
+function. -/
+theorem computableAdditiveNTTFast_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
     AdditiveNTT.arrayToFinFunction (2^(ℓ + R_rate))
-      (computableAdditiveNTTFastState (L := L) (r := r) (β := β)
+      (computableAdditiveNTTFast (L := L) (r := r) (β := β)
         (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)) =
     additiveNTT (𝔽q := 𝔽q) (L := L) (β := β)
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) := by
-  rw [computableAdditiveNTTFastState_eq_computableAdditiveNTT (𝔽q := 𝔽q) (β := β)
+  rw [computableAdditiveNTTFast_eq_computableAdditiveNTT (𝔽q := 𝔽q) (β := β)
     (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)]
   exact computableAdditiveNTT_eq_additiveNTT (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
     (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)

--- a/CompPoly/Fields/Binary/AdditiveNTT/Correctness.lean
+++ b/CompPoly/Fields/Binary/AdditiveNTT/Correctness.lean
@@ -198,31 +198,33 @@ theorem computableAdditiveNTT_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
   rw [computableNTTStage_eq_NTTStage (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
     (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - i, by omega⟩)]
 
-/-- The ST-backed fast additive NTT is extensionally equal to the proof-oriented
-computable implementation after running the ST action.
+/-- The pure `StateT` specialization of the fast additive NTT is extensionally
+equal to the proof-oriented computable implementation after converting its
+output array to a `Fin`-indexed function.
 
 This is the preferred proof boundary for the fast path: once this theorem is
 proved, correctness against the abstract additive NTT specification follows from
-`computableAdditiveNTT_eq_additiveNTT`. -/
-theorem computableAdditiveNTTFastST_eq_computableAdditiveNTT (a : Fin (2 ^ ℓ) → L) :
-    runST (fun σ =>
-      computableAdditiveNTTFastST (L := L) (r := r) (β := β)
-        (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
-        (σ := σ) (a := a)) =
+`computableAdditiveNTT_eq_additiveNTT`. The ST-backed runtime path shares the
+same monadic core, but `ST.Ref` itself is opaque, so this transparent `StateT`
+specialization is the kernel-checkable correctness surface. -/
+theorem computableAdditiveNTTFastState_eq_computableAdditiveNTT (a : Fin (2 ^ ℓ) → L) :
+    AdditiveNTT.arrayToFinFunction (2^(ℓ + R_rate))
+      (computableAdditiveNTTFastState (L := L) (r := r) (β := β)
+        (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)) =
     computableAdditiveNTT (𝔽q := 𝔽q) (L := L) (r := r) (β := β)
       (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) := by
   sorry
 
-/-- The ST-backed fast additive NTT is correct against the abstract additive NTT
-specification after running the ST action. -/
-theorem computableAdditiveNTTFastST_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
-    runST (fun σ =>
-      computableAdditiveNTTFastST (L := L) (r := r) (β := β)
-        (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
-        (σ := σ) (a := a)) =
+/-- The pure `StateT` specialization of the fast additive NTT is correct against
+the abstract additive NTT specification after converting its output array to a
+`Fin`-indexed function. -/
+theorem computableAdditiveNTTFastState_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
+    AdditiveNTT.arrayToFinFunction (2^(ℓ + R_rate))
+      (computableAdditiveNTTFastState (L := L) (r := r) (β := β)
+        (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)) =
     additiveNTT (𝔽q := 𝔽q) (L := L) (β := β)
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) := by
-  rw [computableAdditiveNTTFastST_eq_computableAdditiveNTT (𝔽q := 𝔽q) (β := β)
+  rw [computableAdditiveNTTFastState_eq_computableAdditiveNTT (𝔽q := 𝔽q) (β := β)
     (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)]
   exact computableAdditiveNTT_eq_additiveNTT (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
     (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a)

--- a/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
+++ b/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
@@ -6,6 +6,7 @@ Authors: Chung Thai Nguyen, Quang Dao
 
 import CompPoly.Fields.Binary.AdditiveNTT.Algorithm
 import CompPoly.Fields.Binary.Tower.Concrete.Basis
+import Init.Control.StateRef
 import Mathlib.Data.BitVec
 
 /-!
@@ -21,6 +22,10 @@ section HelperFunctions
 /-- Converts an Array to a Fin function of a specific size `n`. -/
 def Array.toFinVec {α : Type _} (n : ℕ) (arr : Array α) (h : arr.size = n) : Fin n → α :=
   fun i => arr[i]
+
+/-- Converts an array to a `Fin n` function, using `0` for missing entries. -/
+def arrayToFinFunction {α : Type _} [Zero α] (n : ℕ) (arr : Array α) : Fin n → α :=
+  fun i => arr.getD i.val 0
 
 /- The product of a function mapped over the list `0..n-1`. -/
 lemma List.prod_finRange_eq_finset_prod {M : Type*} [CommMonoid M] {n : ℕ} (f : Fin n → M) :
@@ -283,30 +288,53 @@ def computableNTTStageArrayInPlace (i : Fin ℓ) (twiddles : Array L) (b : Array
   termination_by blockCount - u
   loopU 0 b
 
-/-- ST-backed additive NTT that updates the stage buffer in place. -/
-def computableAdditiveNTTFastArrayST {σ : Type} (a : Fin (2 ^ ℓ) → L) :
-    ST σ (Array L) := do
-  let initial : Array L := tileCoeffsArray (ℓ := ℓ) R_rate a
-  let buffer : ST.Ref σ (Array L) ← ST.mkRef initial
-  let _ ← Fin.foldlM (m := ST σ) (n := ℓ) (f := fun (_ : Unit) i => do
+namespace Internal
+
+/-- Generic fast additive NTT stage driver over any monad with an `Array L` state.
+
+The state is expected to contain the initialized output buffer. Each stage
+updates that buffer using the same array transition as the ST fast path. This is
+the shared core used by the transparent `StateT` specialization and the
+reference-backed `ST` specialization. -/
+def computableAdditiveNTTFastStagesM {m : Type → Type} [Monad m]
+    [MonadStateOf (Array L) m] : m Unit := do
+  let _ ← Fin.foldlM (m := m) (n := ℓ) (f := fun (_ : Unit) i => do
     let stage : Fin ℓ := ⟨ℓ - 1 - i, by omega⟩
     let twiddles := computableTwiddleTableArray (β := β) (ℓ := ℓ)
       (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := stage)
-    buffer.modify fun current =>
+    modifyThe (Array L) fun current =>
       computableNTTStageArrayInPlace (ℓ := ℓ) (R_rate := R_rate)
         (i := stage) (twiddles := twiddles) current
     pure ()) (init := ())
-  buffer.get
+  pure ()
 
-/-- ST-backed fast additive NTT producer.
+end Internal
 
-The returned function closes over the materialized final array when the ST action
-is run before the function is consumed. -/
+/-- Generic fast additive NTT array producer over any monad with an `Array L` state. -/
+def computableAdditiveNTTFastArrayM {m : Type → Type} [Monad m]
+    [MonadStateOf (Array L) m] (a : Fin (2 ^ ℓ) → L) : m (Array L) := do
+  set (tileCoeffsArray (ℓ := ℓ) R_rate a)
+  Internal.computableAdditiveNTTFastStagesM (β := β) (ℓ := ℓ) (R_rate := R_rate)
+    (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+  getThe (Array L)
+
+/-- Pure `StateT`/`StateM` specialization of the fast additive NTT array producer.
+
+This is the proof-friendly entry point because `StateT` is the transparent
+tuple-threaded state implementation. -/
+def computableAdditiveNTTFastState (a : Fin (2 ^ ℓ) → L) : Array L :=
+  ((computableAdditiveNTTFastArrayM (β := β) (ℓ := ℓ)
+    (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+    (m := StateT (Array L) Id) a).run #[]).1
+
+/-- ST-backed fast additive NTT array producer. -/
 def computableAdditiveNTTFastST {σ : Type} (a : Fin (2 ^ ℓ) → L) :
-    ST σ (Fin (2^(ℓ + R_rate)) → L) := do
-  let b ← computableAdditiveNTTFastArrayST (β := β) (ℓ := ℓ)
-    (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) a
-  pure fun i => b.getD i.val 0
+    ST σ (Array L) := do
+  let action : StateRefT' σ (Array L) (ST σ) (Array L) :=
+    computableAdditiveNTTFastArrayM (β := β) (ℓ := ℓ) (R_rate := R_rate)
+      (h_ℓ_add_R_rate := h_ℓ_add_R_rate) a
+  let ref ← ST.mkRef #[]
+  action ref
 
 end Algorithm
 

--- a/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
+++ b/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
@@ -183,7 +183,7 @@ def computableAdditiveNTT (a : Fin (2 ^ ℓ) → L) : Fin (2^(ℓ + R_rate)) →
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - i, by omega⟩) (b:=current_b)
   ) (init:=b)
 
-/-- Array-backed coefficient tiling for the ST fast additive NTT path. -/
+/-- Array-backed coefficient tiling for the fast additive NTT path. -/
 def tileCoeffsArray (R_rate : ℕ) (a : Fin (2 ^ ℓ) → L) : Array L :=
   Array.ofFn (n := 2^(ℓ + R_rate)) fun v =>
     a ⟨v.val % (2^ℓ), Nat.mod_lt v.val (pow_pos (zero_lt_two) ℓ)⟩
@@ -192,27 +192,35 @@ def tileCoeffsArray (R_rate : ℕ) (a : Fin (2 ^ ℓ) → L) : Array L :=
 
 Starting from `W_0(x) = x`, each cached constant advances the recurrence
 `W_{k+1}(x) = W_k(x) * (W_k(x) + W_k(β_k))`. -/
+def evalWAtCachedConstantsLoop (constants : Array L) (j : Nat) (acc : L) : L :=
+  if _h_j : j < constants.size then
+    let c := constants.getD j 0
+    evalWAtCachedConstantsLoop constants (j + 1) (acc * (acc + c))
+  else
+    acc
+termination_by constants.size - j
+
+/-- Evaluate a subspace polynomial using cached constants `W_k(β_k)`.
+
+Starting from `W_0(x) = x`, each cached constant advances the recurrence
+`W_{k+1}(x) = W_k(x) * (W_k(x) + W_k(β_k))`. -/
 def evalWAtCachedConstants (constants : Array L) (x : L) : L :=
-  let rec loop (j : Nat) (acc : L) : L :=
-    if _h_j : j < constants.size then
-      let c := constants.getD j 0
-      loop (j + 1) (acc * (acc + c))
-    else
-      acc
-  termination_by constants.size - j
-  loop 0 x
+  evalWAtCachedConstantsLoop constants 0 x
+
+/-- Precompute the constants `W_k(β_k)` needed by the recursive subspace
+polynomial evaluator up to stage `i`. -/
+def subspacePolynomialConstantsArrayLoop (i : Fin r) (k : Nat) (constants : Array L) : Array L :=
+  if h_k : k < i.val then
+    let constant := evalWAtCachedConstants constants (β ⟨k, by omega⟩)
+    subspacePolynomialConstantsArrayLoop i (k + 1) (constants.push constant)
+  else
+    constants
+termination_by i.val - k
 
 /-- Precompute the constants `W_k(β_k)` needed by the recursive subspace
 polynomial evaluator up to stage `i`. -/
 def subspacePolynomialConstantsArray (i : Fin r) : Array L :=
-  let rec loop (k : Nat) (constants : Array L) : Array L :=
-    if h_k : k < i.val then
-      let constant := evalWAtCachedConstants constants (β ⟨k, by omega⟩)
-      loop (k + 1) (constants.push constant)
-    else
-      constants
-  termination_by i.val - k
-  loop 0 #[]
+  subspacePolynomialConstantsArrayLoop (β := β) (ℓ := ℓ) (R_rate := R_rate) i 0 #[]
 
 /-- Precompute normalized vanishing evaluations used by one stage's twiddle factors. -/
 def computableNormalizedWValuesArray (i : Fin ℓ) : Array L :=
@@ -225,80 +233,49 @@ def computableNormalizedWValuesArray (i : Fin ℓ) : Array L :=
 
 /-- Precompute all twiddle factors for one additive NTT stage.
 
-The table is built as subset sums of the cached normalized values. When bit `k`
-is added, the new entries `u + 2^k` are copied from `u` plus the `k`th
-normalized value. -/
+The table entry for `u` is the subset sum of the cached normalized values
+selected by the set bits of `u`. -/
 def computableTwiddleTableArray (i : Fin ℓ) : Array L :=
   let normalizedValues := computableNormalizedWValuesArray (β := β) (ℓ := ℓ)
     (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i)
   let numBits := ℓ + R_rate - i - 1
-  let tableSize := 2 ^ numBits
-  let initial : Array L := Array.replicate tableSize 0
-  let rec fillBit (k : Nat) (table : Array L) : Array L :=
-    if _h_k : k < numBits then
-      let bit := 2 ^ k
-      let value := normalizedValues.getD k 0
-      let rec fillBase (u : Nat) (table : Array L) : Array L :=
-        if _h_u : u < bit then
-          let baseValue := table.getD u 0
-          fillBase (u + 1) (table.set! (u + bit) (baseValue + value))
-        else
-          table
-      termination_by bit - u
-      fillBit (k + 1) (fillBase 0 table)
-    else
-      table
-  termination_by numBits - k
-  fillBit 0 initial
+  Array.ofFn (n := 2 ^ numBits) fun u =>
+    ∑ k : Fin numBits,
+      if Nat.getBit k.val u.val = 1 then normalizedValues.getD k.val 0 else 0
 
-/-- In-place array update for one additive NTT stage.
-
-The loop visits butterfly pairs directly by block and low-bit offset, avoiding
-the odd-index no-op iterations from a full output scan. `Array.set!` updates
-destructively when the array is uniquely owned by the runtime, which is the case
-targeted by the ST fast path.
+/-- Array update for one additive NTT stage.
 
 The `twiddles` array stores the values of `computableTwiddleFactor` for this
 stage, indexed by `u`. -/
-def computableNTTStageArrayInPlace (i : Fin ℓ) (twiddles : Array L) (b : Array L) : Array L :=
+def computableNTTStageArray (i : Fin ℓ) (twiddles : Array L) (b : Array L) : Array L :=
   let stride := 2^i.val
-  let blockSize := 2^(i.val + 1)
-  let blockCount := 2^(ℓ + R_rate - (i.val + 1))
-  let rec loopV (u v : Nat) (b : Array L) : Array L :=
-    if h_v : v < stride then
-      let evenIndex := u * blockSize + v
-      let oddIndex := evenIndex + stride
-      let twiddleFactor: L := twiddles.getD u 0
-      let x0 := twiddleFactor
-      let x1: L := x0 + 1
-      let evenValue := b.getD evenIndex 0
-      let oddValue := b.getD oddIndex 0
-      let newEven := evenValue + x0 * oddValue
-      let newOdd := evenValue + x1 * oddValue
-      loopV u (v + 1) ((b.set! evenIndex newEven).set! oddIndex newOdd)
+  Array.ofFn (n := 2^(ℓ + R_rate)) fun j =>
+    let u_b_v := j.val
+    let u_b := u_b_v / stride
+    let u := u_b / 2
+    let b_bit := u_b % 2
+    let twiddleFactor : L := twiddles.getD u 0
+    let x0 := twiddleFactor
+    let x1 : L := x0 + 1
+    if _h_b_bit_zero : b_bit = 0 then
+      let oddIndex := u_b_v + stride
+      b.getD u_b_v 0 + x0 * b.getD oddIndex 0
     else
-      b
-  termination_by stride - v
-  let rec loopU (u : Nat) (b : Array L) : Array L :=
-    if h_u : u < blockCount then
-      loopU (u + 1) (loopV u 0 b)
-    else
-      b
-  termination_by blockCount - u
-  loopU 0 b
+      let evenIndex := u_b_v ^^^ stride
+      b.getD evenIndex 0 + x1 * b.getD u_b_v 0
 
 /-- Fast additive NTT stage driver over an `Array L` state.
 
 The state is expected to contain the initialized output buffer. Each stage
 updates that buffer using the array transition from
-`computableNTTStageArrayInPlace`. -/
+`computableNTTStageArray`. -/
 def computableAdditiveNTTFastStages : StateM (Array L) Unit := do
   let _ ← Fin.foldlM (m := StateM (Array L)) (n := ℓ) (f := fun (_ : Unit) i => do
     let stage : Fin ℓ := ⟨ℓ - 1 - i, by omega⟩
     let twiddles := computableTwiddleTableArray (β := β) (ℓ := ℓ)
       (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := stage)
     modifyThe (Array L) fun current =>
-      computableNTTStageArrayInPlace (ℓ := ℓ) (R_rate := R_rate)
+      computableNTTStageArray (ℓ := ℓ) (R_rate := R_rate)
         (i := stage) (twiddles := twiddles) current
     pure ()) (init := ())
   pure ()

--- a/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
+++ b/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
@@ -6,7 +6,6 @@ Authors: Chung Thai Nguyen, Quang Dao
 
 import CompPoly.Fields.Binary.AdditiveNTT.Algorithm
 import CompPoly.Fields.Binary.Tower.Concrete.Basis
-import Init.Control.StateRef
 import Mathlib.Data.BitVec
 
 /-!
@@ -288,17 +287,13 @@ def computableNTTStageArrayInPlace (i : Fin ℓ) (twiddles : Array L) (b : Array
   termination_by blockCount - u
   loopU 0 b
 
-namespace Internal
-
-/-- Generic fast additive NTT stage driver over any monad with an `Array L` state.
+/-- Fast additive NTT stage driver over an `Array L` state.
 
 The state is expected to contain the initialized output buffer. Each stage
-updates that buffer using the same array transition as the ST fast path. This is
-the shared core used by the transparent `StateT` specialization and the
-reference-backed `ST` specialization. -/
-def computableAdditiveNTTFastStagesM {m : Type → Type} [Monad m]
-    [MonadStateOf (Array L) m] : m Unit := do
-  let _ ← Fin.foldlM (m := m) (n := ℓ) (f := fun (_ : Unit) i => do
+updates that buffer using the array transition from
+`computableNTTStageArrayInPlace`. -/
+def computableAdditiveNTTFastStages : StateM (Array L) Unit := do
+  let _ ← Fin.foldlM (m := StateM (Array L)) (n := ℓ) (f := fun (_ : Unit) i => do
     let stage : Fin ℓ := ⟨ℓ - 1 - i, by omega⟩
     let twiddles := computableTwiddleTableArray (β := β) (ℓ := ℓ)
       (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := stage)
@@ -308,33 +303,18 @@ def computableAdditiveNTTFastStagesM {m : Type → Type} [Monad m]
     pure ()) (init := ())
   pure ()
 
-end Internal
-
-/-- Generic fast additive NTT array producer over any monad with an `Array L` state. -/
-def computableAdditiveNTTFastArrayM {m : Type → Type} [Monad m]
-    [MonadStateOf (Array L) m] (a : Fin (2 ^ ℓ) → L) : m (Array L) := do
+/-- Fast additive NTT array producer as a state action. -/
+def computableAdditiveNTTFastAction (a : Fin (2 ^ ℓ) → L) :
+    StateM (Array L) (Array L) := do
   set (tileCoeffsArray (ℓ := ℓ) R_rate a)
-  Internal.computableAdditiveNTTFastStagesM (β := β) (ℓ := ℓ) (R_rate := R_rate)
+  computableAdditiveNTTFastStages (β := β) (ℓ := ℓ) (R_rate := R_rate)
     (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
   getThe (Array L)
 
-/-- Pure `StateT`/`StateM` specialization of the fast additive NTT array producer.
-
-This is the proof-friendly entry point because `StateT` is the transparent
-tuple-threaded state implementation. -/
-def computableAdditiveNTTFastState (a : Fin (2 ^ ℓ) → L) : Array L :=
-  ((computableAdditiveNTTFastArrayM (β := β) (ℓ := ℓ)
-    (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
-    (m := StateT (Array L) Id) a).run #[]).1
-
-/-- ST-backed fast additive NTT array producer. -/
-def computableAdditiveNTTFastST {σ : Type} (a : Fin (2 ^ ℓ) → L) :
-    ST σ (Array L) := do
-  let action : StateRefT' σ (Array L) (ST σ) (Array L) :=
-    computableAdditiveNTTFastArrayM (β := β) (ℓ := ℓ) (R_rate := R_rate)
-      (h_ℓ_add_R_rate := h_ℓ_add_R_rate) a
-  let ref ← ST.mkRef #[]
-  action ref
+/-- Fast additive NTT array producer. -/
+def computableAdditiveNTTFast (a : Fin (2 ^ ℓ) → L) : Array L :=
+  ((computableAdditiveNTTFastAction (β := β) (ℓ := ℓ)
+    (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) a).run #[]).1
 
 end Algorithm
 

--- a/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
+++ b/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
@@ -63,85 +63,6 @@ def bitsToU (i : Fin r) (k : Fin (2 ^ i.val)) :
     · exact Submodule.zero_mem _
   ⟩
 
-omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
-/-- The `bitsToU` mapping is a bijection: showing that iterating bits corresponds
-exactly to the linear span. -/
-theorem bitsToU_bijective (i : Fin r) :
-    Function.Bijective (bitsToU (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (R_rate := R_rate) i) := by
-  -- A map between finite sets of the same size is bijective iff it is injective.
-  apply (Fintype.bijective_iff_injective_and_card
-    (f := bitsToU (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (R_rate := R_rate) i)).mpr ?_
-  constructor
-  -- Part A: Injectivity (Linear Independence)
-  · intro k1 k2 h_eq
-    unfold bitsToU at h_eq
-    simp only [Subtype.mk.injEq] at h_eq
-    -- We define the coefficients c_j based on the bits of k
-    let c (k : ℕ) (j : Fin i) : 𝔽q :=
-      if (Nat.getBit (n := k) (k := j.val) == 1) then 1 else 0
-    -- The sum can be rewritten as a linear combination with coefficients in Fq
-    have h_sum (k : Fin (2^i.val)) :
-      (Finset.univ.sum fun (j : Fin i) =>
-        if (Nat.getBit (n := k.val) (k := j.val) == 1) then
-          β ⟨j, by omega⟩
-        else (0 : L)) =
-      Finset.univ.sum fun j => (c k.val j) • β ⟨j, by omega⟩ := by
-      apply Finset.sum_congr rfl
-      intro j _
-      dsimp [c]
-      split_ifs <;> simp
-    rw [h_sum k1, h_sum k2] at h_eq
-    -- 1. Move everything to LHS: sum (c1 - c2) * beta = 0
-    rw [←sub_eq_zero] at h_eq
-    rw [←Finset.sum_sub_distrib] at h_eq
-    simp_rw [←sub_smul] at h_eq
-    rw [←sub_eq_zero] at h_eq
-    -- 2. Establish that the first `i` basis elements are Linearly Independent
-    have h_lin_indep := hβ_lin_indep.out
-    -- We restrict the global independence (Fin r) to the subset (Fin i)
-    have h_indep_restricted := LinearIndependent.comp h_lin_indep
-      (Fin.castLE (Nat.le_of_lt_succ (by omega)) : Fin i → Fin r)
-      (Fin.castLE_injective _)
-    -- 3. Apply Linear Independence to show every coefficient is 0
-    -- This gives us: ∀ j, c k1 j - c k2 j = 0
-    simp only [sub_zero] at h_eq
-    have h_coeffs_zero : ∀ j : Fin i, j ∈ Finset.univ → c k1.val j - c k2.val j = 0 :=
-      linearIndependent_iff'.mp h_indep_restricted
-        (Finset.univ)
-        (fun j => c k1.val j - c k2.val j)
-        h_eq
-    -- 4. Prove k1 = k2 by showing all bits are equal
-    ext
-    apply Nat.eq_iff_eq_all_getBits.mpr
-    intro n
-    have h_bit_k1_lt_2 := Nat.getBit_lt_2 (n := k1) (k := n)
-    have h_bit_k2_lt_2 := Nat.getBit_lt_2 (n := k2) (k := n)
-    if hn : n < i.val then
-      let j : Fin i := ⟨n, hn⟩
-      have h_c_diff_zero := h_coeffs_zero j (Finset.mem_univ j)
-      simp only [sub_eq_zero] at h_c_diff_zero
-      dsimp only [beq_iff_eq, c] at h_c_diff_zero
-      interval_cases hk1: Nat.getBit (n := k1) (k := j)
-      · interval_cases hk2: Nat.getBit (n := k2) (k := j)
-        · rfl;
-        · simp only [Nat.reduceBEq, Bool.false_eq_true, ↓reduceIte, BEq.rfl,
-          zero_ne_one] at h_c_diff_zero;
-      · interval_cases hk2: Nat.getBit (n := k2) (k := j)
-        · simp only [BEq.rfl, ↓reduceIte, Nat.reduceBEq, Bool.false_eq_true,
-          one_ne_zero] at h_c_diff_zero;
-        · rfl
-    else
-      have h_k1 := Nat.getBit_of_lt_two_pow (n := i) (a := k1) (k := n)
-      have h_k2 := Nat.getBit_of_lt_two_pow (n := i) (a := k2) (k := n)
-      simp only [hn, ↓reduceIte] at h_k1 h_k2
-      rw [h_k1, h_k2]
-  -- Part B: Cardinality (Surjectivity check)
-  · -- ⊢ Fintype.card (Fin (2 ^ ↑i)) = Fintype.card ↥(U i)
-    rw [Fintype.card_fin]
-    rw [AdditiveNTT.U_card (𝔽q := 𝔽q)
-      (β := β) (i := i)]
-    rw [hFq_card.out]
-
 /-- Computes the elements of the subspace: `U_i = span({β_0, ..., β_{i-1}})`. -/
 def getUElements (i : Fin r) : List L :=
   (List.finRange (2^i.val)).map fun k =>
@@ -154,74 +75,12 @@ def getUElements (i : Fin r) : List L :=
 def evalWAt (i : Fin r) (x : L) : L :=
   ((getUElements (β := β) (ℓ := ℓ) (R_rate := R_rate) i).map (fun u => x - u)).prod
 
-omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
-/-- Prove that `evalWAt` equals the standard definition of `W_i(x)`. -/
-theorem evalWAt_eq_W (i : Fin r) (x : L) :
-    evalWAt (β := β) (ℓ := ℓ) (R_rate := R_rate) (i := i) x =
-    (W (𝔽q := 𝔽q) (β := β) (i := i)).eval x := by
-  -- 1. Convert implementation to mathematical product over Fin(2^i)
-  unfold evalWAt getUElements
-  rw [List.map_map]
-  rw [List.prod_finRange_eq_finset_prod] -- Now the pattern matches!
-  -- 2. Prepare RHS
-  rw [AdditiveNTT.W, Polynomial.eval_prod]
-  simp only [Polynomial.eval_sub, Polynomial.eval_X, Polynomial.eval_C]
-  -- 3. Use Finset.prod_bij to show equality via the bijection
-  -- LHS: ∏ k : Fin(2^i), (x - bitsToU k), RHS: ∏ u : U i,      (x - u)
-  apply Finset.prod_bij (s := ((Finset.univ (α := (Fin (2^(i.val)))))))
-    (t := (Finset.univ : Finset (U 𝔽q β i)))
-    (i := fun k _ =>
-      bitsToU (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (r := r) (R_rate := R_rate) (L := L) (i := i) k)
-    (hi := by
-      -- Proof that the map lands in the target set (Finset.univ)
-      intro a _
-      exact Finset.mem_univ _)
-    (i_inj := by
-      -- Proof of Injectivity (uses our previous theorem)
-      intro a₁ _ a₂ _ h_eq
-      exact (bitsToU_bijective (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
-        (r := r) (R_rate := R_rate) (L := L) (i := i)).1 h_eq)
-    (i_surj := by
-      -- Proof of Surjectivity (uses our previous theorem)
-      intro b _
-      -- We need to provide the element 'a' and the proof it is in the set
-      obtain ⟨a, ha_eq⟩ := (bitsToU_bijective (𝔽q := 𝔽q)
-        (β := β) (ℓ := ℓ) (r := r) (R_rate := R_rate) (L := L) (i := i)).2 b
-      use a
-      constructor
-      · exact ha_eq
-      · exact Finset.mem_univ a
-    )
-    (h := by -- Proof that the values are equal: (x - bitsToU k) = (x - (bitsToU k))
-      intro a ha_univ
-      rfl
-    )
-
 /-- Evaluates the normalized subspace vanishing polynomial `Ŵ_i(x) = W_i(x) / W_i(β_i)`. -/
 def evalNormalizedWAt (i : Fin r) (x : L) : L :=
   let W_x := evalWAt (r := r) (L := L) (ℓ := ℓ) (β := β) (R_rate := R_rate) (i := i) x
   let beta_i := β i
   let W_beta := evalWAt (β := β) (ℓ := ℓ) (R_rate := R_rate) (i := i) beta_i
   W_x * W_beta⁻¹
-
-omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
-/-- Prove that `evalNormalizedWAt` equals the standard definition of `Ŵ_i(x)`. -/
-theorem evalNormalizedWAt_eq_normalizedW (i : Fin r) (x : L) :
-    evalNormalizedWAt (β := β) (ℓ := ℓ) (R_rate := R_rate) (i := i) x
-    = (normalizedW (𝔽q := 𝔽q) (β := β) (i := i)).eval x := by
-  unfold evalNormalizedWAt
-  -- 3. Apply the correctness theorem we just proved (evalWAt_eq_standardWAt)
-  -- We apply it twice: once for 'x' and once for 'β i'
-  rw [evalWAt_eq_W (r := r) (L := L) (𝔽q := 𝔽q) (β := β) i x]
-  simp only
-  rw [evalWAt_eq_W (r := r) (L := L) (𝔽q := 𝔽q) (β := β) i (β i)]
-  -- normalizedW is defined as: C (eval (W i) (β i))⁻¹ * W i
-  rw [AdditiveNTT.normalizedW]
-  -- Property: (Constant * Poly).eval x = Constant * (Poly.eval x)
-  simp only [Polynomial.eval_mul, Polynomial.eval_C]
-  simp only [one_div]
-  -- LHS: (W.eval x) * (W.eval beta)⁻¹, RHS: (W.eval beta)⁻¹ * (W.eval x)
-  apply mul_comm
 
 /-- Computes the twiddle factor used in the butterfly operation.
 Corresponds to `AdditiveNTT.twiddleFactor`.
@@ -235,17 +94,6 @@ def computableTwiddleFactor (i : Fin ℓ) (u : Fin (2 ^ (ℓ + R_rate - i - 1)))
     (evalNormalizedWAt (β := β) (ℓ := ℓ) (R_rate := R_rate)
       (i := ⟨i, by omega⟩) (x := β ⟨i + 1 + k, by omega⟩))
   else 0
-
-omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
-/-- Prove that `computableTwiddleFactor` equals the standard definition of `twiddleFactor`. -/
-theorem computableTwiddleFactor_eq_twiddleFactor (i : Fin ℓ) :
-    computableTwiddleFactor (r := r) (ℓ := ℓ) (β := β) (L := L)
-    (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨i, by omega⟩) =
-  twiddleFactor (𝔽q := 𝔽q) (L := L) (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
-    (i := ⟨i, by omega⟩) := by
-  unfold computableTwiddleFactor twiddleFactor
-  simp_rw [evalNormalizedWAt_eq_normalizedW (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
-    (R_rate := R_rate) (i := ⟨i, by omega⟩)]
 
 /-- Performs one stage of the Additive NTT. This corresponds to `NTTStage` in the abstract
 definition: `b` is the array of coefficients. `i` is the stage index (0 to r-1). -/
@@ -321,18 +169,6 @@ def computableNTTStage [Fact (LinearIndependent 𝔽q β)]
       -- b j is now the odd refinement P₁,₍₁ᵥ₎⁽ⁱ⁺¹⁾(X),
       -- b (j - 2^i) stores the even refinement P₀,₍₀ᵥ₎⁽ⁱ⁺¹⁾(X)
       b ⟨even_split_index, h_lt⟩ + x1 * b j
-
-omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
-/-- Prove that `computableNTTStage` equals the standard definition of `NTTStage`. -/
-theorem computableNTTStage_eq_NTTStage (i : Fin ℓ) :
-    computableNTTStage (𝔽q := 𝔽q) (r := r) (L := L) (ℓ := ℓ) (β := β) (R_rate := R_rate)
-    (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨i, by omega⟩) =
-  NTTStage (𝔽q := 𝔽q) (L := L) (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
-    (i := ⟨i, by omega⟩) := by
-  unfold computableNTTStage NTTStage
-  simp only [Fin.eta]
-  simp_rw [computableTwiddleFactor_eq_twiddleFactor (𝔽q := 𝔽q) (β := β) (ℓ := ℓ)
-    (R_rate := R_rate) (i := ⟨i, by omega⟩)]
 
 /-- The main computable Additive NTT function. `a` is the input array of coefficients.
 `r` is the number of stages (dimension of the domain). The input array size must be at least 2^r. -/
@@ -471,19 +307,6 @@ def computableAdditiveNTTFastST {σ : Type} (a : Fin (2 ^ ℓ) → L) :
   let b ← computableAdditiveNTTFastArrayST (β := β) (ℓ := ℓ)
     (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) a
   pure fun i => b.getD i.val 0
-
-omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
-/-- Prove that `computableAdditiveNTT` equals the standard definition of `additiveNTT`. -/
-theorem computableAdditiveNTT_eq_additiveNTT (a : Fin (2 ^ ℓ) → L) :
-    computableAdditiveNTT (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (R_rate := R_rate)
-    (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) =
-  additiveNTT (𝔽q := 𝔽q) (L := L) (β := β) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (a := a) := by
-  unfold computableAdditiveNTT additiveNTT
-  simp only
-  congr
-  funext current_b i
-  rw [computableNTTStage_eq_NTTStage (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (R_rate := R_rate)
-    (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - i, by omega⟩)]
 
 end Algorithm
 

--- a/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
+++ b/CompPoly/Fields/Binary/AdditiveNTT/Impl.lean
@@ -25,6 +25,7 @@ def Array.toFinVec {α : Type _} (n : ℕ) (arr : Array α) (h : arr.size = n) :
 /- The product of a function mapped over the list `0..n-1`. -/
 lemma List.prod_finRange_eq_finset_prod {M : Type*} [CommMonoid M] {n : ℕ} (f : Fin n → M) :
     ((List.finRange n).map f).prod = ∏ i : Fin n, f i := rfl
+
 end HelperFunctions
 
 universe u
@@ -341,6 +342,135 @@ def computableAdditiveNTT (a : Fin (2 ^ ℓ) → L) : Fin (2^(ℓ + R_rate)) →
     computableNTTStage (𝔽q := 𝔽q) (β := β) (ℓ := ℓ) (R_rate := R_rate)
       (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := ⟨ℓ - 1 - i, by omega⟩) (b:=current_b)
   ) (init:=b)
+
+/-- Array-backed coefficient tiling for the ST fast additive NTT path. -/
+def tileCoeffsArray (R_rate : ℕ) (a : Fin (2 ^ ℓ) → L) : Array L :=
+  Array.ofFn (n := 2^(ℓ + R_rate)) fun v =>
+    a ⟨v.val % (2^ℓ), Nat.mod_lt v.val (pow_pos (zero_lt_two) ℓ)⟩
+
+/-- Evaluate a subspace polynomial using cached constants `W_k(β_k)`.
+
+Starting from `W_0(x) = x`, each cached constant advances the recurrence
+`W_{k+1}(x) = W_k(x) * (W_k(x) + W_k(β_k))`. -/
+def evalWAtCachedConstants (constants : Array L) (x : L) : L :=
+  let rec loop (j : Nat) (acc : L) : L :=
+    if _h_j : j < constants.size then
+      let c := constants.getD j 0
+      loop (j + 1) (acc * (acc + c))
+    else
+      acc
+  termination_by constants.size - j
+  loop 0 x
+
+/-- Precompute the constants `W_k(β_k)` needed by the recursive subspace
+polynomial evaluator up to stage `i`. -/
+def subspacePolynomialConstantsArray (i : Fin r) : Array L :=
+  let rec loop (k : Nat) (constants : Array L) : Array L :=
+    if h_k : k < i.val then
+      let constant := evalWAtCachedConstants constants (β ⟨k, by omega⟩)
+      loop (k + 1) (constants.push constant)
+    else
+      constants
+  termination_by i.val - k
+  loop 0 #[]
+
+/-- Precompute normalized vanishing evaluations used by one stage's twiddle factors. -/
+def computableNormalizedWValuesArray (i : Fin ℓ) : Array L :=
+  let stage : Fin r := ⟨i, by omega⟩
+  let constants := subspacePolynomialConstantsArray (β := β) (ℓ := ℓ) (R_rate := R_rate)
+    (i := stage)
+  let denominatorInv := (evalWAtCachedConstants constants (β stage))⁻¹
+  Array.ofFn (n := ℓ + R_rate - i - 1) fun k =>
+    evalWAtCachedConstants constants (β ⟨i + 1 + k.val, by omega⟩) * denominatorInv
+
+/-- Precompute all twiddle factors for one additive NTT stage.
+
+The table is built as subset sums of the cached normalized values. When bit `k`
+is added, the new entries `u + 2^k` are copied from `u` plus the `k`th
+normalized value. -/
+def computableTwiddleTableArray (i : Fin ℓ) : Array L :=
+  let normalizedValues := computableNormalizedWValuesArray (β := β) (ℓ := ℓ)
+    (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := i)
+  let numBits := ℓ + R_rate - i - 1
+  let tableSize := 2 ^ numBits
+  let initial : Array L := Array.replicate tableSize 0
+  let rec fillBit (k : Nat) (table : Array L) : Array L :=
+    if _h_k : k < numBits then
+      let bit := 2 ^ k
+      let value := normalizedValues.getD k 0
+      let rec fillBase (u : Nat) (table : Array L) : Array L :=
+        if _h_u : u < bit then
+          let baseValue := table.getD u 0
+          fillBase (u + 1) (table.set! (u + bit) (baseValue + value))
+        else
+          table
+      termination_by bit - u
+      fillBit (k + 1) (fillBase 0 table)
+    else
+      table
+  termination_by numBits - k
+  fillBit 0 initial
+
+/-- In-place array update for one additive NTT stage.
+
+The loop visits butterfly pairs directly by block and low-bit offset, avoiding
+the odd-index no-op iterations from a full output scan. `Array.set!` updates
+destructively when the array is uniquely owned by the runtime, which is the case
+targeted by the ST fast path.
+
+The `twiddles` array stores the values of `computableTwiddleFactor` for this
+stage, indexed by `u`. -/
+def computableNTTStageArrayInPlace (i : Fin ℓ) (twiddles : Array L) (b : Array L) : Array L :=
+  let stride := 2^i.val
+  let blockSize := 2^(i.val + 1)
+  let blockCount := 2^(ℓ + R_rate - (i.val + 1))
+  let rec loopV (u v : Nat) (b : Array L) : Array L :=
+    if h_v : v < stride then
+      let evenIndex := u * blockSize + v
+      let oddIndex := evenIndex + stride
+      let twiddleFactor: L := twiddles.getD u 0
+      let x0 := twiddleFactor
+      let x1: L := x0 + 1
+      let evenValue := b.getD evenIndex 0
+      let oddValue := b.getD oddIndex 0
+      let newEven := evenValue + x0 * oddValue
+      let newOdd := evenValue + x1 * oddValue
+      loopV u (v + 1) ((b.set! evenIndex newEven).set! oddIndex newOdd)
+    else
+      b
+  termination_by stride - v
+  let rec loopU (u : Nat) (b : Array L) : Array L :=
+    if h_u : u < blockCount then
+      loopU (u + 1) (loopV u 0 b)
+    else
+      b
+  termination_by blockCount - u
+  loopU 0 b
+
+/-- ST-backed additive NTT that updates the stage buffer in place. -/
+def computableAdditiveNTTFastArrayST {σ : Type} (a : Fin (2 ^ ℓ) → L) :
+    ST σ (Array L) := do
+  let initial : Array L := tileCoeffsArray (ℓ := ℓ) R_rate a
+  let buffer : ST.Ref σ (Array L) ← ST.mkRef initial
+  let _ ← Fin.foldlM (m := ST σ) (n := ℓ) (f := fun (_ : Unit) i => do
+    let stage : Fin ℓ := ⟨ℓ - 1 - i, by omega⟩
+    let twiddles := computableTwiddleTableArray (β := β) (ℓ := ℓ)
+      (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) (i := stage)
+    buffer.modify fun current =>
+      computableNTTStageArrayInPlace (ℓ := ℓ) (R_rate := R_rate)
+        (i := stage) (twiddles := twiddles) current
+    pure ()) (init := ())
+  buffer.get
+
+/-- ST-backed fast additive NTT producer.
+
+The returned function closes over the materialized final array when the ST action
+is run before the function is consumed. -/
+def computableAdditiveNTTFastST {σ : Type} (a : Fin (2 ^ ℓ) → L) :
+    ST σ (Fin (2^(ℓ + R_rate)) → L) := do
+  let b ← computableAdditiveNTTFastArrayST (β := β) (ℓ := ℓ)
+    (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate) a
+  pure fun i => b.getD i.val 0
 
 omit [DecidableEq 𝔽q] h_Fq_char_prime h_β₀_eq_1 in
 /-- Prove that `computableAdditiveNTT` equals the standard definition of `additiveNTT`. -/

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -754,12 +754,6 @@ private def checksumBtf3Output {n : Nat} (output : Fin (2 ^ n) → AdditiveNTT.B
 private def checksumBtf3OutputArray {n : Nat} (output : Array AdditiveNTT.BTF₃) : Nat :=
   checksumBtf3Output (AdditiveNTT.arrayToFinFunction (2 ^ n) output)
 
-/-- Checksum an ST-produced `BTF₃` additive NTT array after materializing it once. -/
-private def checksumBtf3OutputArrayST {n : Nat}
-    (output : (σ : Type) → ST σ (Array AdditiveNTT.BTF₃)) : Nat :=
-  let values := runST output
-  checksumBtf3OutputArray (n := n) values
-
 /-- Run an additive NTT over `BTF₃`. -/
 private def runBtf3Ntt (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
     (input : Fin (2 ^ ℓ) → AdditiveNTT.BTF₃) :
@@ -773,32 +767,20 @@ private def runBtf3Ntt (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^
     (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
     (β := AdditiveNTT.computableBasisExplicit (k := 3)) (a := input)
 
-/-- Run a State-backed fast additive NTT over `BTF₃`. -/
-private def runBtf3NttFastState (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
+/-- Run the fast additive NTT implementation over `BTF₃`. -/
+private def runBtf3NttFast (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
     (input : Fin (2 ^ ℓ) → AdditiveNTT.BTF₃) :
     Array AdditiveNTT.BTF₃ := by
   letI : Algebra (ConcreteBTField 0) AdditiveNTT.BTF₃ :=
     ConcreteBTFieldAlgebra (l := 0) (r := 3) (h_le := by omega)
-  exact AdditiveNTT.computableAdditiveNTTFastState
+  exact AdditiveNTT.computableAdditiveNTTFast
     (L := AdditiveNTT.BTF₃) (r := 2 ^ 3)
     (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
     (β := AdditiveNTT.computableBasisExplicit (k := 3)) (a := input)
 
-/-- Run an ST-backed fast additive NTT over `BTF₃`. -/
-private def runBtf3NttFastST (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
-    (input : Fin (2 ^ ℓ) → AdditiveNTT.BTF₃) :
-    (σ : Type) → ST σ (Array AdditiveNTT.BTF₃) := by
-  letI : Algebra (ConcreteBTField 0) AdditiveNTT.BTF₃ :=
-    ConcreteBTFieldAlgebra (l := 0) (r := 3) (h_le := by omega)
-  exact fun σ =>
-    AdditiveNTT.computableAdditiveNTTFastST
-      (σ := σ) (L := AdditiveNTT.BTF₃) (r := 2 ^ 3)
-      (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
-      (β := AdditiveNTT.computableBasisExplicit (k := 3)) (a := input)
-
 /-- Run one additive NTT benchmark case over `BTF₃`. -/
 private def runAdditiveNttCase (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
-    (currentName fastStateName fastStName : String) (warmup measured : Nat) (gen : StdGen) :
+    (currentName fastName : String) (warmup measured : Nat) (gen : StdGen) :
     IO (Array BenchRecord × StdGen) := do
   let inputSize := 2 ^ ℓ
   let outputSize := 2 ^ (ℓ + R_rate)
@@ -812,26 +794,20 @@ private def runAdditiveNttCase (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_ra
     fieldLabel inputShape warmup measured
     (fun _ ↦ runBtf3Ntt ℓ R_rate h_ℓ_add_R_rate input)
     (checksumBtf3Output (n := ℓ + R_rate))
-  let fastStateRecord ← runTimed
-    fastStateName "computableAdditiveNTTFastState" "computableAdditiveNTTFastState"
+  let fastRecord ← runTimed
+    fastName "computableAdditiveNTTFast" "computableAdditiveNTTFast"
     fieldLabel inputShape warmup measured
-    (fun _ ↦ runBtf3NttFastState ℓ R_rate h_ℓ_add_R_rate input)
+    (fun _ ↦ runBtf3NttFast ℓ R_rate h_ℓ_add_R_rate input)
     (checksumBtf3OutputArray (n := ℓ + R_rate))
-  let fastStRecord ← runTimed
-    fastStName "computableAdditiveNTTFastST" "computableAdditiveNTTFastST"
-    fieldLabel inputShape warmup measured
-    (fun _ ↦ runBtf3NttFastST ℓ R_rate h_ℓ_add_R_rate input)
-    (checksumBtf3OutputArrayST (n := ℓ + R_rate))
-  pure (#[currentRecord, fastStateRecord, fastStRecord], gen)
+  pure (#[currentRecord, fastRecord], gen)
 
 /-- Run the additive NTT benchmark. -/
 private def runAdditiveNtt (gen : StdGen) : IO (Array BenchRecord × StdGen) := do
   let (smallRecords, gen) ← runAdditiveNttCase 2 2 (by omega)
-    "additive-ntt-btf3" "additive-ntt-btf3-fast-state" "additive-ntt-btf3-fast-st"
+    "additive-ntt-btf3" "additive-ntt-btf3-fast"
     additiveNttWarmupIterations additiveNttMeasuredIterations gen
   let (widerRecords, gen) ← runAdditiveNttCase 4 2 (by omega)
-    "additive-ntt-btf3-l4-r2" "additive-ntt-btf3-l4-r2-fast-state"
-    "additive-ntt-btf3-l4-r2-fast-st" 2 10 gen
+    "additive-ntt-btf3-l4-r2" "additive-ntt-btf3-l4-r2-fast" 2 10 gen
   pure (appendRecords smallRecords widerRecords, gen)
 
 /-- Run the complete benchmark suite and write reports. -/

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -270,6 +270,10 @@ private def checksumZMod {modulus : Nat} (x : ZMod modulus) : Nat :=
 private def checksumBtf3 (x : AdditiveNTT.BTF₃) : Nat :=
   BitVec.toNat x
 
+/-- Convert a concrete binary-tower field element to a checksum word. -/
+private def checksumConcreteBtf {k : Nat} (x : ConcreteBTField k) : Nat :=
+  BitVec.toNat x
+
 /-- Time one benchmark closure and package its metadata and checksum. -/
 private def runTimed (name representation method field inputShape : String)
     (warmup measured : Nat) (run : Nat → α) (checksum : α → Nat) : IO BenchRecord := do
@@ -754,6 +758,14 @@ private def checksumBtf3Output {n : Nat} (output : Fin (2 ^ n) → AdditiveNTT.B
 private def checksumBtf3OutputArray {n : Nat} (output : Array AdditiveNTT.BTF₃) : Nat :=
   checksumBtf3Output (AdditiveNTT.arrayToFinFunction (2 ^ n) output)
 
+/-- Checksum a concrete binary-tower additive NTT output array. -/
+private def checksumConcreteBtfOutputArray {k n : Nat} (output : Array (ConcreteBTField k)) :
+    Nat :=
+  (List.finRange (2 ^ n)).foldl
+    (fun acc i ↦
+      mixChecksum acc
+        (checksumConcreteBtf ((AdditiveNTT.arrayToFinFunction (2 ^ n) output) i))) 0
+
 /-- Run an additive NTT over `BTF₃`. -/
 private def runBtf3Ntt (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
     (input : Fin (2 ^ ℓ) → AdditiveNTT.BTF₃) :
@@ -778,6 +790,20 @@ private def runBtf3NttFast (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate <
     (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
     (β := AdditiveNTT.computableBasisExplicit (k := 3)) (a := input)
 
+/-- Run the fast additive NTT implementation over a concrete binary-tower field. -/
+private def runConcreteBtfNttFast (k ℓ R_rate : Nat)
+    (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ k)
+    (input : Fin (2 ^ ℓ) → ConcreteBTField k) :
+    Array (ConcreteBTField k) := by
+  letI : Fintype (ConcreteBTField k) :=
+    Fintype.ofEquiv (Fin (2 ^ (2 ^ k))) (BitVec.equivFin (m := 2 ^ k)).symm.toEquiv
+  letI : Algebra (ConcreteBTField 0) (ConcreteBTField k) :=
+    ConcreteBTFieldAlgebra (l := 0) (r := k) (h_le := by omega)
+  exact AdditiveNTT.computableAdditiveNTTFast
+    (L := ConcreteBTField k) (r := 2 ^ k)
+    (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+    (β := AdditiveNTT.computableBasisExplicit (k := k)) (a := input)
+
 /-- Run one additive NTT benchmark case over `BTF₃`. -/
 private def runAdditiveNttCase (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
     (currentName fastName : String) (warmup measured : Nat) (gen : StdGen) :
@@ -801,6 +827,24 @@ private def runAdditiveNttCase (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_ra
     (checksumBtf3OutputArray (n := ℓ + R_rate))
   pure (#[currentRecord, fastRecord], gen)
 
+/-- Run one larger fast-only additive NTT benchmark over a concrete binary-tower field. -/
+private def runAdditiveNttFastLargeCase (k ℓ R_rate : Nat)
+    (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ k) (fastName : String)
+    (warmup measured : Nat) (gen : StdGen) : IO (BenchRecord × StdGen) := do
+  let inputSize := 2 ^ ℓ
+  let outputSize := 2 ^ (ℓ + R_rate)
+  let (values, gen) := (randomNatArray inputSize (2 ^ (2 ^ k) - 1)).run gen
+  let input : Fin (2 ^ ℓ) → ConcreteBTField k :=
+    fun i ↦ ConcreteBinaryTower.fromNat (k := k) (values.getD i.val 0)
+  let fieldLabel := s!"ConcreteBTField 0 -> BTF{k}, l={ℓ}, R_rate={R_rate}"
+  let inputShape := s!"{inputSize} input coeffs, {outputSize} output evals"
+  let fastRecord ← runTimed
+    fastName "computableAdditiveNTTFast" "computableAdditiveNTTFast"
+    fieldLabel inputShape warmup measured
+    (fun _ ↦ runConcreteBtfNttFast k ℓ R_rate h_ℓ_add_R_rate input)
+    (checksumConcreteBtfOutputArray (k := k) (n := ℓ + R_rate))
+  pure (fastRecord, gen)
+
 /-- Run the additive NTT benchmark. -/
 private def runAdditiveNtt (gen : StdGen) : IO (Array BenchRecord × StdGen) := do
   let (smallRecords, gen) ← runAdditiveNttCase 2 2 (by omega)
@@ -808,7 +852,9 @@ private def runAdditiveNtt (gen : StdGen) : IO (Array BenchRecord × StdGen) := 
     additiveNttWarmupIterations additiveNttMeasuredIterations gen
   let (widerRecords, gen) ← runAdditiveNttCase 4 2 (by omega)
     "additive-ntt-btf3-l4-r2" "additive-ntt-btf3-l4-r2-fast" 2 10 gen
-  pure (appendRecords smallRecords widerRecords, gen)
+  let (largerFastRecord, gen) ← runAdditiveNttFastLargeCase 4 7 2 (by omega)
+    "additive-ntt-btf4-l7-r2-fast" 1 10 gen
+  pure ((appendRecords smallRecords widerRecords).push largerFastRecord, gen)
 
 /-- Run the complete benchmark suite and write reports. -/
 def run : IO UInt32 := do

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -38,8 +38,8 @@ private def measuredIterations : Nat := 5000
 /-- Number of warmup iterations for the slower additive NTT benchmark. -/
 private def additiveNttWarmupIterations : Nat := 10
 
-/-- Number of measured iterations for the slower additive NTT benchmark. -/
-private def additiveNttMeasuredIterations : Nat := 100
+/-- Number of measured iterations for the smaller additive NTT benchmark. -/
+private def additiveNttMeasuredIterations : Nat := 1000
 
 /-- Number of variables used by multivariate evaluation benchmarks. -/
 private def multivariateVars : Nat := 5
@@ -745,35 +745,73 @@ private def runBivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := do
   records := appendRecords records bn254Records
   pure (records, finalGen)
 
-/-- Checksum all output values from the `BTF₃` additive NTT benchmark. -/
-private def checksumBtf3Output (output : Fin (2 ^ (2 + 2)) → AdditiveNTT.BTF₃) : Nat :=
-  (List.finRange (2 ^ (2 + 2))).foldl
+/-- Checksum all output values from a `BTF₃` additive NTT benchmark. -/
+private def checksumBtf3Output {n : Nat} (output : Fin (2 ^ n) → AdditiveNTT.BTF₃) : Nat :=
+  (List.finRange (2 ^ n)).foldl
     (fun acc i ↦ mixChecksum acc (checksumBtf3 (output i))) 0
 
-/-- Run the configured additive NTT over `BTF₃`. -/
-private def runBtf3Ntt (input : Fin 4 → AdditiveNTT.BTF₃) :
-    Fin (2 ^ (2 + 2)) → AdditiveNTT.BTF₃ := by
+/-- Checksum an ST-produced `BTF₃` additive NTT output after materializing it once. -/
+private def checksumBtf3OutputST {n : Nat}
+    (output : (σ : Type) → ST σ (Fin (2 ^ n) → AdditiveNTT.BTF₃)) : Nat :=
+  let f := runST output
+  checksumBtf3Output f
+
+/-- Run an additive NTT over `BTF₃`. -/
+private def runBtf3Ntt (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
+    (input : Fin (2 ^ ℓ) → AdditiveNTT.BTF₃) :
+    Fin (2 ^ (ℓ + R_rate)) → AdditiveNTT.BTF₃ := by
   letI : Algebra (ConcreteBTField 0) AdditiveNTT.BTF₃ :=
     ConcreteBTFieldAlgebra (l := 0) (r := 3) (h_le := by omega)
   haveI : Fact (LinearIndependent (ConcreteBTField 0) (AdditiveNTT.computableBasisExplicit 3)) :=
     { out := AdditiveNTT.hβ_lin_indep_concrete 3 }
   exact AdditiveNTT.computableAdditiveNTT
     (𝔽q := ConcreteBTField 0) (L := AdditiveNTT.BTF₃) (r := 2 ^ 3)
-    (ℓ := 2) (R_rate := 2) (h_ℓ_add_R_rate := by omega)
+    (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
     (β := AdditiveNTT.computableBasisExplicit (k := 3)) (a := input)
+
+/-- Run an ST-backed fast additive NTT over `BTF₃`. -/
+private def runBtf3NttFastST (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
+    (input : Fin (2 ^ ℓ) → AdditiveNTT.BTF₃) :
+    (σ : Type) → ST σ (Fin (2 ^ (ℓ + R_rate)) → AdditiveNTT.BTF₃) := by
+  letI : Algebra (ConcreteBTField 0) AdditiveNTT.BTF₃ :=
+    ConcreteBTFieldAlgebra (l := 0) (r := 3) (h_le := by omega)
+  exact fun σ =>
+    AdditiveNTT.computableAdditiveNTTFastST
+      (σ := σ) (L := AdditiveNTT.BTF₃) (r := 2 ^ 3)
+      (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+      (β := AdditiveNTT.computableBasisExplicit (k := 3)) (a := input)
+
+/-- Run one additive NTT benchmark case over `BTF₃`. -/
+private def runAdditiveNttCase (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
+    (currentName fastName : String) (warmup measured : Nat) (gen : StdGen) :
+    IO (Array BenchRecord × StdGen) := do
+  let inputSize := 2 ^ ℓ
+  let outputSize := 2 ^ (ℓ + R_rate)
+  let (values, gen) := (randomNatArray inputSize 255).run gen
+  let input : Fin (2 ^ ℓ) → AdditiveNTT.BTF₃ :=
+    fun i ↦ ConcreteBinaryTower.fromNat (k := 3) (values.getD i.val 0)
+  let fieldLabel := s!"ConcreteBTField 0 -> BTF3, l={ℓ}, R_rate={R_rate}"
+  let inputShape := s!"{inputSize} input coeffs, {outputSize} output evals"
+  let currentRecord ← runTimed
+    currentName "computableAdditiveNTT" "computableAdditiveNTT"
+    fieldLabel inputShape warmup measured
+    (fun _ ↦ runBtf3Ntt ℓ R_rate h_ℓ_add_R_rate input)
+    (checksumBtf3Output (n := ℓ + R_rate))
+  let fastStRecord ← runTimed
+    fastName "computableAdditiveNTTFastST" "computableAdditiveNTTFastST"
+    fieldLabel inputShape warmup measured
+    (fun _ ↦ runBtf3NttFastST ℓ R_rate h_ℓ_add_R_rate input)
+    (checksumBtf3OutputST (n := ℓ + R_rate))
+  pure (#[currentRecord, fastStRecord], gen)
 
 /-- Run the additive NTT benchmark. -/
 private def runAdditiveNtt (gen : StdGen) : IO (Array BenchRecord × StdGen) := do
-  let (values, gen) := (randomNatArray 4 255).run gen
-  let input : Fin 4 → AdditiveNTT.BTF₃ :=
-    fun i ↦ ConcreteBinaryTower.fromNat (k := 3) (values.getD i.val 0)
-  let record ← runTimed
-    "additive-ntt-btf3" "computableAdditiveNTT" "computableAdditiveNTT"
-    "ConcreteBTField 0 -> BTF3, l=2, R_rate=2"
-    "4 input coeffs, 16 output evals" additiveNttWarmupIterations additiveNttMeasuredIterations
-    (fun _ ↦ runBtf3Ntt input)
-    checksumBtf3Output
-  pure (#[record], gen)
+  let (smallRecords, gen) ← runAdditiveNttCase 2 2 (by omega)
+    "additive-ntt-btf3" "additive-ntt-btf3-fast-st"
+    additiveNttWarmupIterations additiveNttMeasuredIterations gen
+  let (widerRecords, gen) ← runAdditiveNttCase 4 2 (by omega)
+    "additive-ntt-btf3-l4-r2" "additive-ntt-btf3-l4-r2-fast-st" 2 10 gen
+  pure (appendRecords smallRecords widerRecords, gen)
 
 /-- Run the complete benchmark suite and write reports. -/
 def run : IO UInt32 := do

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -750,11 +750,15 @@ private def checksumBtf3Output {n : Nat} (output : Fin (2 ^ n) → AdditiveNTT.B
   (List.finRange (2 ^ n)).foldl
     (fun acc i ↦ mixChecksum acc (checksumBtf3 (output i))) 0
 
-/-- Checksum an ST-produced `BTF₃` additive NTT output after materializing it once. -/
-private def checksumBtf3OutputST {n : Nat}
-    (output : (σ : Type) → ST σ (Fin (2 ^ n) → AdditiveNTT.BTF₃)) : Nat :=
-  let f := runST output
-  checksumBtf3Output f
+/-- Checksum a `BTF₃` additive NTT output array. -/
+private def checksumBtf3OutputArray {n : Nat} (output : Array AdditiveNTT.BTF₃) : Nat :=
+  checksumBtf3Output (AdditiveNTT.arrayToFinFunction (2 ^ n) output)
+
+/-- Checksum an ST-produced `BTF₃` additive NTT array after materializing it once. -/
+private def checksumBtf3OutputArrayST {n : Nat}
+    (output : (σ : Type) → ST σ (Array AdditiveNTT.BTF₃)) : Nat :=
+  let values := runST output
+  checksumBtf3OutputArray (n := n) values
 
 /-- Run an additive NTT over `BTF₃`. -/
 private def runBtf3Ntt (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
@@ -769,10 +773,21 @@ private def runBtf3Ntt (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^
     (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
     (β := AdditiveNTT.computableBasisExplicit (k := 3)) (a := input)
 
+/-- Run a State-backed fast additive NTT over `BTF₃`. -/
+private def runBtf3NttFastState (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
+    (input : Fin (2 ^ ℓ) → AdditiveNTT.BTF₃) :
+    Array AdditiveNTT.BTF₃ := by
+  letI : Algebra (ConcreteBTField 0) AdditiveNTT.BTF₃ :=
+    ConcreteBTFieldAlgebra (l := 0) (r := 3) (h_le := by omega)
+  exact AdditiveNTT.computableAdditiveNTTFastState
+    (L := AdditiveNTT.BTF₃) (r := 2 ^ 3)
+    (ℓ := ℓ) (R_rate := R_rate) (h_ℓ_add_R_rate := h_ℓ_add_R_rate)
+    (β := AdditiveNTT.computableBasisExplicit (k := 3)) (a := input)
+
 /-- Run an ST-backed fast additive NTT over `BTF₃`. -/
 private def runBtf3NttFastST (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
     (input : Fin (2 ^ ℓ) → AdditiveNTT.BTF₃) :
-    (σ : Type) → ST σ (Fin (2 ^ (ℓ + R_rate)) → AdditiveNTT.BTF₃) := by
+    (σ : Type) → ST σ (Array AdditiveNTT.BTF₃) := by
   letI : Algebra (ConcreteBTField 0) AdditiveNTT.BTF₃ :=
     ConcreteBTFieldAlgebra (l := 0) (r := 3) (h_le := by omega)
   exact fun σ =>
@@ -783,7 +798,7 @@ private def runBtf3NttFastST (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate
 
 /-- Run one additive NTT benchmark case over `BTF₃`. -/
 private def runAdditiveNttCase (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_rate < 2 ^ 3)
-    (currentName fastName : String) (warmup measured : Nat) (gen : StdGen) :
+    (currentName fastStateName fastStName : String) (warmup measured : Nat) (gen : StdGen) :
     IO (Array BenchRecord × StdGen) := do
   let inputSize := 2 ^ ℓ
   let outputSize := 2 ^ (ℓ + R_rate)
@@ -797,20 +812,26 @@ private def runAdditiveNttCase (ℓ R_rate : Nat) (h_ℓ_add_R_rate : ℓ + R_ra
     fieldLabel inputShape warmup measured
     (fun _ ↦ runBtf3Ntt ℓ R_rate h_ℓ_add_R_rate input)
     (checksumBtf3Output (n := ℓ + R_rate))
+  let fastStateRecord ← runTimed
+    fastStateName "computableAdditiveNTTFastState" "computableAdditiveNTTFastState"
+    fieldLabel inputShape warmup measured
+    (fun _ ↦ runBtf3NttFastState ℓ R_rate h_ℓ_add_R_rate input)
+    (checksumBtf3OutputArray (n := ℓ + R_rate))
   let fastStRecord ← runTimed
-    fastName "computableAdditiveNTTFastST" "computableAdditiveNTTFastST"
+    fastStName "computableAdditiveNTTFastST" "computableAdditiveNTTFastST"
     fieldLabel inputShape warmup measured
     (fun _ ↦ runBtf3NttFastST ℓ R_rate h_ℓ_add_R_rate input)
-    (checksumBtf3OutputST (n := ℓ + R_rate))
-  pure (#[currentRecord, fastStRecord], gen)
+    (checksumBtf3OutputArrayST (n := ℓ + R_rate))
+  pure (#[currentRecord, fastStateRecord, fastStRecord], gen)
 
 /-- Run the additive NTT benchmark. -/
 private def runAdditiveNtt (gen : StdGen) : IO (Array BenchRecord × StdGen) := do
   let (smallRecords, gen) ← runAdditiveNttCase 2 2 (by omega)
-    "additive-ntt-btf3" "additive-ntt-btf3-fast-st"
+    "additive-ntt-btf3" "additive-ntt-btf3-fast-state" "additive-ntt-btf3-fast-st"
     additiveNttWarmupIterations additiveNttMeasuredIterations gen
   let (widerRecords, gen) ← runAdditiveNttCase 4 2 (by omega)
-    "additive-ntt-btf3-l4-r2" "additive-ntt-btf3-l4-r2-fast-st" 2 10 gen
+    "additive-ntt-btf3-l4-r2" "additive-ntt-btf3-l4-r2-fast-state"
+    "additive-ntt-btf3-l4-r2-fast-st" 2 10 gen
   pure (appendRecords smallRecords widerRecords, gen)
 
 /-- Run the complete benchmark suite and write reports. -/


### PR DESCRIPTION
I made some experiments with making a faster version of `computableAdditiveNTT`

### Overview

This PR includes:

- A fast array-backed implementation: `computableAdditiveNTTFast`
- Proofs about `computableAdditiveNTT` are moved to a new file `Correctness.lean`
- Equivalence lemmas showing `computableAdditiveNTTFast` agrees with `computableAdditiveNTT` and `additiveNTT` added to `Correctness.lean`
- Benchmarks comparing `computableAdditiveNTT` and `computableAdditiveNTTFast`

### Algorithmic improvements

`computableAdditiveNTTFast` implements multiple improvements compared to `computableAdditiveNTT`:

- The fast implementation works with arrays (`Array L`) rather than functions (`Fin n → L`). The original `computableAdditiveNTT` represents each stage as a function whose body refers to the previous-stage function. This defers computation: if the final function is evaluated at several indices, shared intermediate stage values can be recomputed multiple times. With the array representation, each full stage is computed once, and later stages read already-computed values from the array.
- The fast implementation uses a more efficient way to compute evaluation of subspace vanishing polynomials (`evalWAt` in the old implementation), relying on a recurrence relation that these polynomials satisfy. Relevant lemma: `W_eval_succ_eq_mul_add`.
- The fast implementation pre-computes twiddle factors. The key observation is that `computableTwiddleFactor` depends on the stage `i` and the high-bit index `u`, but not on the branch bit `b` or the low bits `v`. Precomputing these values with `computableTwiddleTableArray` avoids recomputing the same twiddle factor for different `b` and `v`. Relevant lemma: `computableTwiddleTableArray_getD`.

### Results

Performance comparison of old and fast implementations (form the CI run):

| Benchmark | Runs | Total | Average | Checksum |
|---|---:|---:|---:|---:|
| additive-ntt-btf3 | 1000 | 16766851036 | 16766851 | 9142728802972324038 |
| additive-ntt-btf3-fast | 1000 | 1335327366 | 1335327 | 9142728802972324038 |
| additive-ntt-btf3-l4-r2 | 10 | 15062702085 | 1506270208 | 18264915302553168182 |
| additive-ntt-btf3-l4-r2-fast | 10 | 81194805 | 8119480 | 18264915302553168182 |
