### PR TITLE
feat(Operations, EvalLemmas): add aeval_zero/one/pow/neg/sub and eval_pow

### DIFF
--- a/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
+++ b/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
@@ -40,6 +40,11 @@ lemma eval_add (p q : CMvPolynomial n R) :
 lemma eval_mul (p q : CMvPolynomial n R) :
     (p * q).eval vals = p.eval vals * q.eval vals := by simp [eval_equiv]
 
+@[simp]
+lemma eval_pow (p : CMvPolynomial n R) (k : ℕ) :
+    (p ^ k).eval vals = (p.eval vals) ^ k := by
+  simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_pow p k
+
 end
 
 section
@@ -59,6 +64,7 @@ lemma eval_sub (p q : CMvPolynomial n R) :
 
 end
 
-attribute [grind =] eval_zero eval_one eval_C eval_add eval_mul eval_neg eval_sub
+attribute [grind =]
+  eval_zero eval_one eval_C eval_add eval_mul eval_pow eval_neg eval_sub
 
 end CPoly

--- a/CompPoly/Multivariate/Operations.lean
+++ b/CompPoly/Multivariate/Operations.lean
@@ -159,6 +159,51 @@ def aeval {n : ℕ} {R σ : Type*} [CommSemiring R] [CommSemiring σ] [Algebra R
   simpa [CMvPolynomial.eval₂Hom_apply] using
     (CMvPolynomial.eval₂Hom (S := σ) (algebraMap R σ) f).map_mul p q
 
+@[simp] lemma aeval_zero {n : ℕ} {R σ : Type*}
+    [CommSemiring R] [BEq R] [LawfulBEq R]
+    [CommSemiring σ] [Algebra R σ]
+    (f : Fin n → σ) :
+    aeval f (0 : CMvPolynomial n R) = 0 := by
+  unfold aeval
+  simpa [CMvPolynomial.eval₂Hom_apply] using
+    (CMvPolynomial.eval₂Hom (S := σ) (algebraMap R σ) f).map_zero
+
+@[simp] lemma aeval_one {n : ℕ} {R σ : Type*}
+    [CommSemiring R] [BEq R] [LawfulBEq R]
+    [CommSemiring σ] [Algebra R σ]
+    (f : Fin n → σ) :
+    aeval f (1 : CMvPolynomial n R) = 1 := by
+  unfold aeval
+  simpa [CMvPolynomial.eval₂Hom_apply] using
+    (CMvPolynomial.eval₂Hom (S := σ) (algebraMap R σ) f).map_one
+
+@[simp] lemma aeval_pow {n : ℕ} {R σ : Type*}
+    [CommSemiring R] [BEq R] [LawfulBEq R]
+    [CommSemiring σ] [Algebra R σ]
+    (f : Fin n → σ) (p : CMvPolynomial n R) (k : ℕ) :
+    aeval f (p ^ k) = (aeval f p) ^ k := by
+  unfold aeval
+  simpa [CMvPolynomial.eval₂Hom_apply] using
+    (CMvPolynomial.eval₂Hom (S := σ) (algebraMap R σ) f).map_pow p k
+
+@[simp] lemma aeval_neg {n : ℕ} {R σ : Type*}
+    [CommRing R] [BEq R] [LawfulBEq R]
+    [CommRing σ] [Algebra R σ]
+    (f : Fin n → σ) (p : CMvPolynomial n R) :
+    aeval f (-p) = -(aeval f p) := by
+  unfold aeval
+  simpa [CMvPolynomial.eval₂Hom_apply] using
+    (CMvPolynomial.eval₂Hom (S := σ) (algebraMap R σ) f).map_neg p
+
+@[simp] lemma aeval_sub {n : ℕ} {R σ : Type*}
+    [CommRing R] [BEq R] [LawfulBEq R]
+    [CommRing σ] [Algebra R σ]
+    (f : Fin n → σ) (p q : CMvPolynomial n R) :
+    aeval f (p - q) = aeval f p - aeval f q := by
+  unfold aeval
+  simpa [CMvPolynomial.eval₂Hom_apply] using
+    (CMvPolynomial.eval₂Hom (S := σ) (algebraMap R σ) f).map_sub p q
+
 /-- Substitution: substitutes polynomials for variables.
 
   Given `f : Fin n → CMvPolynomial m R`, substitutes `f i` for variable `X i`.
@@ -404,6 +449,10 @@ lemma sumToIter_add {n : ℕ} {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R]
     (p : CMvPolynomial n R) :
     sumToIter (sumToIter p) = sumToIter p := by
   simp [sumToIter_eq]
+
+attribute [grind =]
+  aeval_C aeval_X aeval_add aeval_mul
+  aeval_zero aeval_one aeval_pow aeval_neg aeval_sub
 
 end CMvPolynomial
 


### PR DESCRIPTION
This PR adds five `@[simp]` lemmas alongside the existing `aeval_C`/`aeval_X`/`aeval_add`/`aeval_mul` in `CompPoly/Multivariate/Operations.lean`:

- `aeval_zero`, `aeval_one`, `aeval_pow` (CommSemiring)
- `aeval_neg`, `aeval_sub` (CommRing)

These are derivable mechanically from the `RingHom` structure of `eval₂Hom`, but downstream code working through `aeval` ends up rewriting the same boilerplate every time — for example I have local copies in [`kim-em/sos`](https://github.com/kim-em/sos/blob/main/SOS/Verifier.lean) at the moment, which I'd like to drop once this lands.

Style matches the existing `aeval_add` / `aeval_mul` lemmas exactly (`simpa [eval₂Hom_apply] using (...).map_X`).

Also includes (added on review):

- `CMvPolynomial.eval_pow` in `CMvPolynomialEvalLemmas.lean`, so the plain-`eval` API mirrors the new `aeval` lemmas (the `eval_*` family already had zero/one/C/add/mul/neg/sub but no `pow`).
- `@[grind =]` tags for both the new `aeval_*` family and `eval_pow`, matching the existing `[grind =]` cluster on the other `eval_*` lemmas.

`lake build CompPoly.Multivariate.Operations CompPoly.Multivariate.CMvPolynomialEvalLemmas` succeeds locally.

🤖 Prepared with Claude Code