### PR TITLE
feat(multivariate): add npowBySq and prove equivalence with npow

### DIFF
--- a/CompPoly/Multivariate/Lawful.lean
+++ b/CompPoly/Multivariate/Lawful.lean
@@ -159,10 +159,31 @@ def mul [Mul R] [Add R] (p₁ p₂ : Lawful n R) : Lawful n R :=
 
 instance [Mul R] [Add R] [Zero R] : Mul (Lawful n R) := ⟨mul⟩
 
-/-- Polynomial exponentiation. -/
+/-- Polynomial exponentiation via repeated multiplication. `O(k)` multiplications.
+
+This is the specification; `npowBySq` is the efficient `O(log k)` implementation
+used by the `NatPow` instance once the equivalence with this naive form has been
+proven. -/
 def npow [NatCast R] [Add R] [Mul R] : ℕ → Lawful n R → Lawful n R
   | .zero  , _ => 1
   | .succ n, p => (npow n p) * p
+
+/-- Polynomial exponentiation via repeated squaring. `O(log k)` multiplications
+instead of `O(k)`.
+
+For `k > 0`, computes `p ^ k` by recursing on `k / 2`:
+* If `k` is even: `(p ^ (k / 2))²`
+* If `k` is odd:  `p · (p ^ (k / 2))²`
+
+Equivalent to `npow` (see `npowBySq_eq_npow`). -/
+@[inline, specialize]
+def npowBySq [NatCast R] [Add R] [Mul R] (p : Lawful n R) : ℕ → Lawful n R
+  | 0 => 1
+  | k + 1 =>
+    let half := npowBySq p ((k + 1) / 2)
+    let sq := half * half
+    if (k + 1) % 2 = 0 then sq else p * sq
+  decreasing_by omega
 
 instance [NatCast R] [Add R] [Mul R] : NatPow (Lawful n R) := ⟨fun e b ↦ npow b e⟩
 

--- a/CompPoly/Multivariate/Operations.lean
+++ b/CompPoly/Multivariate/Operations.lean
@@ -456,4 +456,57 @@ attribute [grind =]
 
 end CMvPolynomial
 
+namespace Lawful
+
+/-! ### Equivalence between `npow` and `npowBySq`
+
+`Lawful.npow` (defined in `Multivariate/Lawful.lean`) is the naive `O(k)`
+specification; `Lawful.npowBySq` is the `O(log k)` repeated-squaring
+implementation. We prove pointwise equality here so that the `NatPow` instance
+can be safely routed through the fast version.
+
+The proofs need `mul_assoc` / `mul_one` / `mul_comm`, which are only available
+once the `CommSemiring (CMvPolynomial n R)` instance has been built — that is
+why these lemmas live in `Operations.lean` rather than in `Lawful.lean`. -/
+
+variable {n : ℕ} {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R]
+
+/-- Additive law for the naive `npow`: $p^{a+b} = p^a \cdot p^b$. -/
+lemma npow_add (p : Lawful n R) (a b : ℕ) :
+    npow (a + b) p = npow a p * npow b p := by
+  induction b with
+  | zero => simp [npow, mul_one]
+  | succ b ih =>
+    show npow (a + b + 1) p = npow a p * npow (b + 1) p
+    show npow (a + b) p * p = npow a p * (npow b p * p)
+    rw [ih, mul_assoc]
+
+/-- The fast repeated-squaring `npowBySq` agrees pointwise with the naive
+`npow`. This is the equivalence that lets the `NatPow (Lawful n R)` instance
+be routed through `npowBySq` without changing observable behavior. -/
+theorem npowBySq_eq_npow (p : Lawful n R) : ∀ k : ℕ, npowBySq p k = npow k p
+  | 0 => by unfold npowBySq; rfl
+  | k + 1 => by
+    unfold npowBySq
+    have ih : npowBySq p ((k + 1) / 2) = npow ((k + 1) / 2) p :=
+      npowBySq_eq_npow p ((k + 1) / 2)
+    rw [ih]
+    have hsq : npow ((k + 1) / 2) p * npow ((k + 1) / 2) p =
+        npow ((k + 1) / 2 + (k + 1) / 2) p := (npow_add p _ _).symm
+    by_cases heven : (k + 1) % 2 = 0
+    · simp only [heven, ↓reduceIte, hsq]
+      congr 1; omega
+    · simp only [heven, ↓reduceIte, hsq]
+      have hodd : (k + 1) / 2 + (k + 1) / 2 + 1 = k + 1 := by omega
+      -- Goal: p * npow ((k+1)/2 + (k+1)/2) p = npow (k+1) p.
+      -- Rewriting (k+1) on the right-hand side as the explicit successor unfolds
+      -- npow once into npow _ p * p, after which the equality is just commutativity.
+      conv_rhs => rw [← hodd]
+      show p * npow _ p = npow _ p * p
+      exact mul_comm _ _
+  termination_by k => k
+  decreasing_by omega
+
+end Lawful
+
 end CPoly


### PR DESCRIPTION
## PR Summary

First PR of Multivariate Exponentiation Optimization: Apply the repeated-squaring pattern (similar to the one in merged PR #187 (univariate)) to the multivariate `Lawful n R` / `CMvPolynomial n R` types.

Adds the fast repeated-squaring `npowBySq` for `Lawful n R` and proves it pointwise equal to the existing naive `npow`.

## Changes

- `CompPoly/Multivariate/Lawful.lean` — added `npowBySq, upgraded the docstring on the existing `npow`.
- `CompPoly/Multivariate/Operations.lean` — added two lemmas in  `namespace CPoly.Lawful`:
  - `npow_add`
  - `npowBySq_eq_npow` (main result): proved by structural recursion on `k`

The proofs live in `Operations.lean` (not `Lawful.lean`) because they need `mul_assoc` / `mul_one` / `mul_comm`, which are only available once the `CommSemiring (CMvPolynomial n R)` instance has been built — and that instance lives downstream of `Lawful.lean`.

Follow-up PR will route the `NatPow` and `CommSemiring` instances through `npowBySq`.