### PR TITLE
feat(univariate): efficient evaluation on a batch of points using subproduct-tree algorithm

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -83,7 +83,9 @@ import CompPoly.ToMathlib.Polynomial.BivariateWeightedDegree
 import CompPoly.Univariate.Basic
 import CompPoly.Univariate.BatchEval
 import CompPoly.Univariate.BatchEval.Context
+import CompPoly.Univariate.BatchEval.Correctness
 import CompPoly.Univariate.BatchEval.Naive
+import CompPoly.Univariate.BatchEval.SubproductTree
 import CompPoly.Univariate.Lagrange
 import CompPoly.Univariate.Linear
 import CompPoly.Univariate.NTT.BabyBear

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -92,6 +92,7 @@ import CompPoly.Univariate.Linear
 import CompPoly.Univariate.NTT.BabyBear
 import CompPoly.Univariate.NTT.Domain
 import CompPoly.Univariate.NTT.FastMul
+import CompPoly.Univariate.NTT.FastMulLow
 import CompPoly.Univariate.NTT.Forward
 import CompPoly.Univariate.NTT.Inverse
 import CompPoly.Univariate.NTT.KoalaBear

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -81,6 +81,9 @@ import CompPoly.ToMathlib.Polynomial.BivariateEvaluation
 import CompPoly.ToMathlib.Polynomial.BivariateMultiplicity
 import CompPoly.ToMathlib.Polynomial.BivariateWeightedDegree
 import CompPoly.Univariate.Basic
+import CompPoly.Univariate.BatchEval
+import CompPoly.Univariate.BatchEval.Context
+import CompPoly.Univariate.BatchEval.Naive
 import CompPoly.Univariate.Lagrange
 import CompPoly.Univariate.Linear
 import CompPoly.Univariate.NTT.BabyBear

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -86,6 +86,7 @@ import CompPoly.Univariate.BatchEval.Context
 import CompPoly.Univariate.BatchEval.Correctness
 import CompPoly.Univariate.BatchEval.Naive
 import CompPoly.Univariate.BatchEval.SubproductTree
+import CompPoly.Univariate.DivisionCorrectness
 import CompPoly.Univariate.Lagrange
 import CompPoly.Univariate.Linear
 import CompPoly.Univariate.NTT.BabyBear

--- a/CompPoly/Univariate/Basic.lean
+++ b/CompPoly/Univariate/Basic.lean
@@ -704,15 +704,16 @@ def modByMonic [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomi
   ⟨(Raw.modByMonic p.val q.val).trim, Trim.isCanonical_trim (Raw.modByMonic p.val q.val)⟩
 
 /-- Remainder of `p` modulo a monic polynomial `q`, using a remainder-only implementation. -/
-def modByMonicFast [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomial R :=
+def modByMonicRemainderOnly [Field R] [BEq R] [LawfulBEq R]
+    (p q : CPolynomial R) : CPolynomial R :=
   ⟨(Raw.modByMonicRemainderOnly p.val q.val).trim,
     Trim.isCanonical_trim (Raw.modByMonicRemainderOnly p.val q.val)⟩
 
 /-- The remainder-only monic remainder agrees with the canonical monic remainder. -/
-theorem modByMonicFast_eq_modByMonic [Field R] [BEq R] [LawfulBEq R]
-    (p q : CPolynomial R) : modByMonicFast p q = modByMonic p q := by
+theorem modByMonicRemainderOnly_eq_modByMonic [Field R] [BEq R] [LawfulBEq R]
+    (p q : CPolynomial R) : modByMonicRemainderOnly p q = modByMonic p q := by
   apply CPolynomial.ext
-  simp [modByMonicFast, modByMonic, Raw.modByMonicRemainderOnly_eq_modByMonic]
+  simp [modByMonicRemainderOnly, modByMonic, Raw.modByMonicRemainderOnly_eq_modByMonic]
 
 /-- Quotient of `p` by `q` (when `R` is a field). -/
 def div [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomial R :=

--- a/CompPoly/Univariate/Basic.lean
+++ b/CompPoly/Univariate/Basic.lean
@@ -703,6 +703,17 @@ def divByMonic [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomi
 def modByMonic [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomial R :=
   ⟨(Raw.modByMonic p.val q.val).trim, Trim.isCanonical_trim (Raw.modByMonic p.val q.val)⟩
 
+/-- Remainder of `p` modulo a monic polynomial `q`, using a remainder-only implementation. -/
+def modByMonicFast [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomial R :=
+  ⟨(Raw.modByMonicRemainderOnly p.val q.val).trim,
+    Trim.isCanonical_trim (Raw.modByMonicRemainderOnly p.val q.val)⟩
+
+/-- The remainder-only monic remainder agrees with the canonical monic remainder. -/
+theorem modByMonicFast_eq_modByMonic [Field R] [BEq R] [LawfulBEq R]
+    (p q : CPolynomial R) : modByMonicFast p q = modByMonic p q := by
+  apply CPolynomial.ext
+  simp [modByMonicFast, modByMonic, Raw.modByMonicRemainderOnly_eq_modByMonic]
+
 /-- Quotient of `p` by `q` (when `R` is a field). -/
 def div [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomial R :=
   ⟨(Raw.div p.val q.val).trim, Trim.isCanonical_trim (Raw.div p.val q.val)⟩

--- a/CompPoly/Univariate/Basic.lean
+++ b/CompPoly/Univariate/Basic.lean
@@ -709,11 +709,24 @@ def modByMonicRemainderOnly [Field R] [BEq R] [LawfulBEq R]
   ⟨(Raw.modByMonicRemainderOnly p.val q.val).trim,
     Trim.isCanonical_trim (Raw.modByMonicRemainderOnly p.val q.val)⟩
 
+/-- Remainder of `p` modulo a monic polynomial `q`, using reversal and low products. -/
+def modByMonicByReversal [Field R] [BEq R] [LawfulBEq R]
+    (M : Raw.MulLowContext R) (p q : CPolynomial R) : CPolynomial R :=
+  ⟨(Raw.modByMonicByReversal M p.val q.val).trim,
+    Trim.isCanonical_trim (Raw.modByMonicByReversal M p.val q.val)⟩
+
 /-- The remainder-only monic remainder agrees with the canonical monic remainder. -/
 theorem modByMonicRemainderOnly_eq_modByMonic [Field R] [BEq R] [LawfulBEq R]
     (p q : CPolynomial R) : modByMonicRemainderOnly p q = modByMonic p q := by
   apply CPolynomial.ext
   simp [modByMonicRemainderOnly, modByMonic, Raw.modByMonicRemainderOnly_eq_modByMonic]
+
+/-- The reversal monic remainder agrees with the canonical monic remainder. -/
+theorem modByMonicByReversal_eq_modByMonic [Field R] [BEq R] [LawfulBEq R]
+    (M : Raw.MulLowContext R) (p q : CPolynomial R) :
+    modByMonicByReversal M p q = modByMonic p q := by
+  apply CPolynomial.ext
+  simp [modByMonicByReversal, modByMonic, Raw.modByMonicByReversal_eq_modByMonic]
 
 /-- Quotient of `p` by `q` (when `R` is a field). -/
 def div [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomial R :=

--- a/CompPoly/Univariate/Basic.lean
+++ b/CompPoly/Univariate/Basic.lean
@@ -721,13 +721,6 @@ theorem modByMonicRemainderOnly_eq_modByMonic [Field R] [BEq R] [LawfulBEq R]
   apply CPolynomial.ext
   simp [modByMonicRemainderOnly, modByMonic, Raw.modByMonicRemainderOnly_eq_modByMonic]
 
-/-- The reversal monic remainder agrees with the canonical monic remainder. -/
-theorem modByMonicByReversal_eq_modByMonic [Field R] [BEq R] [LawfulBEq R]
-    (M : Raw.MulLowContext R) (p q : CPolynomial R) :
-    modByMonicByReversal M p q = modByMonic p q := by
-  apply CPolynomial.ext
-  simp [modByMonicByReversal, modByMonic, Raw.modByMonicByReversal_eq_modByMonic]
-
 /-- Quotient of `p` by `q` (when `R` is a field). -/
 def div [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomial R :=
   ⟨(Raw.div p.val q.val).trim, Trim.isCanonical_trim (Raw.div p.val q.val)⟩

--- a/CompPoly/Univariate/Basic.lean
+++ b/CompPoly/Univariate/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles
+Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles, Valerii Huhnin
 -/
 import Mathlib.Algebra.Tropical.Basic
 import Mathlib.RingTheory.Polynomial.Basic

--- a/CompPoly/Univariate/BatchEval.lean
+++ b/CompPoly/Univariate/BatchEval.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Derek Sorensen
 -/
 import CompPoly.Univariate.BatchEval.Context
+import CompPoly.Univariate.BatchEval.Correctness
 import CompPoly.Univariate.BatchEval.Naive
 
 /-!

--- a/CompPoly/Univariate/BatchEval.lean
+++ b/CompPoly/Univariate/BatchEval.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Derek Sorensen
+Authors: Valerii Huhnin
 -/
 import CompPoly.Univariate.BatchEval.Context
 import CompPoly.Univariate.BatchEval.Naive

--- a/CompPoly/Univariate/BatchEval.lean
+++ b/CompPoly/Univariate/BatchEval.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Derek Sorensen
 -/
 import CompPoly.Univariate.BatchEval.Context
-import CompPoly.Univariate.BatchEval.Correctness
 import CompPoly.Univariate.BatchEval.Naive
 import CompPoly.Univariate.BatchEval.SubproductTree
+import CompPoly.Univariate.BatchEval.Correctness
 
 /-!
 # Univariate Batch Evaluation

--- a/CompPoly/Univariate/BatchEval.lean
+++ b/CompPoly/Univariate/BatchEval.lean
@@ -6,6 +6,7 @@ Authors: Derek Sorensen
 import CompPoly.Univariate.BatchEval.Context
 import CompPoly.Univariate.BatchEval.Correctness
 import CompPoly.Univariate.BatchEval.Naive
+import CompPoly.Univariate.BatchEval.SubproductTree
 
 /-!
 # Univariate Batch Evaluation

--- a/CompPoly/Univariate/BatchEval.lean
+++ b/CompPoly/Univariate/BatchEval.lean
@@ -1,0 +1,13 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Univariate.BatchEval.Context
+import CompPoly.Univariate.BatchEval.Naive
+
+/-!
+# Univariate Batch Evaluation
+
+Executable batch-evaluation APIs for canonical univariate polynomials.
+-/

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -74,9 +74,9 @@ def naive [Field R] [BEq R] [LawfulBEq R] : ModContext R where
   modByMonic_eq_modByMonic _ _ := rfl
 
 /-- A remainder-only compiled backend for monic remainders. -/
-def fast [Field R] [BEq R] [LawfulBEq R] : ModContext R where
-  modByMonic p q := CPolynomial.modByMonicFast p q
-  modByMonic_eq_modByMonic p q := CPolynomial.modByMonicFast_eq_modByMonic p q
+def remainderOnly [Field R] [BEq R] [LawfulBEq R] : ModContext R where
+  modByMonic p q := CPolynomial.modByMonicRemainderOnly p q
+  modByMonic_eq_modByMonic p q := CPolynomial.modByMonicRemainderOnly_eq_modByMonic p q
 
 end ModContext
 

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Derek Sorensen
+Authors: Valerii Huhnin
 -/
 import CompPoly.Univariate.DivisionCorrectness
 import CompPoly.Univariate.NTT.FastMul

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Derek Sorensen
 -/
-import CompPoly.Univariate.Basic
+import CompPoly.Univariate.DivisionCorrectness
 import CompPoly.Univariate.NTT.FastMul
 
 /-!

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -39,29 +39,6 @@ def naive [Semiring R] [BEq R] [LawfulBEq R] : MulContext R where
   mul p q := p * q
   mul_eq_mul _ _ := rfl
 
-private def nttMul [Field R] [BEq R] [LawfulBEq R]
-    (bestDomainForLength? : (requiredLen : Nat) →
-      Option (NTT.FittingDomain R requiredLen))
-    (p q : CPolynomial R) : CPolynomial R :=
-  let requiredLen := NTT.Domain.requiredLength p.val q.val
-  match bestDomainForLength? requiredLen with
-  | some ⟨D, _⟩ => NTT.FastMul.fastMulImpl D p q
-  | none => p * q
-
-private theorem nttMul_eq_mul [Field R] [BEq R] [LawfulBEq R]
-    (bestDomainForLength? : (requiredLen : Nat) →
-      Option (NTT.FittingDomain R requiredLen))
-    (p q : CPolynomial R) :
-    nttMul bestDomainForLength? p q = p * q := by
-  let requiredLen := NTT.Domain.requiredLength p.val q.val
-  cases hdomain : bestDomainForLength? requiredLen with
-  | none =>
-      simp [nttMul, requiredLen, hdomain]
-  | some fitted =>
-      rcases fitted with ⟨D, hfit⟩
-      simp [nttMul, requiredLen, hdomain, NTT.FastMul.fastMulImpl_eq_mul D p q (by
-        simpa [NTT.Domain.fits] using hfit)]
-
 /--
 NTT-backed multiplication context with canonical multiplication as a fallback.
 
@@ -73,8 +50,8 @@ def ntt [Field R] [BEq R] [LawfulBEq R]
     (bestDomainForLength? : (requiredLen : Nat) →
       Option (NTT.FittingDomain R requiredLen)) :
     MulContext R where
-  mul := nttMul bestDomainForLength?
-  mul_eq_mul := nttMul_eq_mul bestDomainForLength?
+  mul := NTT.FastMul.withFallback bestDomainForLength?
+  mul_eq_mul := NTT.FastMul.withFallback_eq_mul bestDomainForLength?
 
 end MulContext
 

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -19,10 +19,10 @@ variable {R : Type*}
 /-- Explicit multiplication backend for algorithms that should not replace the canonical `Mul`
 instance on `CPolynomial R`. -/
 structure MulContext (R : Type*) [Semiring R] [BEq R] [LawfulBEq R] where
-  /-- Multiply two canonical polynomials. -/
-  mul : CPolynomial R → CPolynomial R → CPolynomial R
-  /-- The backend agrees with canonical polynomial multiplication. -/
-  mul_eq_mul : ∀ p q, mul p q = p * q
+  /-- Multiply two canonical polynomials while seeing the subproduct-tree level. -/
+  mulAtLevel : Nat → CPolynomial R → CPolynomial R → CPolynomial R
+  /-- The backend agrees with canonical polynomial multiplication at every level. -/
+  mulAtLevel_eq_mul : ∀ level p q, mulAtLevel level p q = p * q
 
 /-- Explicit remainder backend for algorithms that only need reduction modulo monic divisors. -/
 structure ModContext (R : Type*) [Field R] [BEq R] [LawfulBEq R] where
@@ -35,8 +35,8 @@ namespace MulContext
 
 /-- The default multiplication context, backed by canonical `CPolynomial` multiplication. -/
 def naive [Semiring R] [BEq R] [LawfulBEq R] : MulContext R where
-  mul p q := p * q
-  mul_eq_mul _ _ := rfl
+  mulAtLevel _ p q := p * q
+  mulAtLevel_eq_mul _ _ _ := rfl
 
 end MulContext
 

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -20,10 +20,10 @@ variable {R : Type*}
 /-- Explicit multiplication backend for algorithms that should not replace the canonical `Mul`
 instance on `CPolynomial R`. -/
 structure MulContext (R : Type*) [Semiring R] [BEq R] [LawfulBEq R] where
-  /-- Multiply two canonical polynomials while seeing the subproduct-tree level. -/
-  mulAtLevel : Nat → CPolynomial R → CPolynomial R → CPolynomial R
-  /-- The backend agrees with canonical polynomial multiplication at every level. -/
-  mulAtLevel_eq_mul : ∀ level p q, mulAtLevel level p q = p * q
+  /-- Multiply two canonical polynomials. -/
+  mul : CPolynomial R → CPolynomial R → CPolynomial R
+  /-- The backend agrees with canonical polynomial multiplication. -/
+  mul_eq_mul : ∀ p q, mul p q = p * q
 
 /-- Explicit remainder backend for algorithms that only need reduction modulo monic divisors. -/
 structure ModContext (R : Type*) [Field R] [BEq R] [LawfulBEq R] where
@@ -36,33 +36,45 @@ namespace MulContext
 
 /-- The default multiplication context, backed by canonical `CPolynomial` multiplication. -/
 def naive [Semiring R] [BEq R] [LawfulBEq R] : MulContext R where
-  mulAtLevel _ p q := p * q
-  mulAtLevel_eq_mul _ _ _ := rfl
+  mul p q := p * q
+  mul_eq_mul _ _ := rfl
+
+private def nttMul [Field R] [BEq R] [LawfulBEq R]
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (NTT.FittingDomain R requiredLen))
+    (p q : CPolynomial R) : CPolynomial R :=
+  let requiredLen := NTT.Domain.requiredLength p.val q.val
+  match bestDomainForLength? requiredLen with
+  | some ⟨D, _⟩ => NTT.FastMul.fastMulImpl D p q
+  | none => p * q
+
+private theorem nttMul_eq_mul [Field R] [BEq R] [LawfulBEq R]
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (NTT.FittingDomain R requiredLen))
+    (p q : CPolynomial R) :
+    nttMul bestDomainForLength? p q = p * q := by
+  let requiredLen := NTT.Domain.requiredLength p.val q.val
+  cases hdomain : bestDomainForLength? requiredLen with
+  | none =>
+      simp [nttMul, requiredLen, hdomain]
+  | some fitted =>
+      rcases fitted with ⟨D, hfit⟩
+      simp [nttMul, requiredLen, hdomain, NTT.FastMul.fastMulImpl_eq_mul D p q (by
+        simpa [NTT.Domain.fits] using hfit)]
 
 /--
-Subproduct-tree NTT-backed multiplication context with canonical multiplication as a fallback.
+NTT-backed multiplication context with canonical multiplication as a fallback.
 
-At subproduct-tree level `level`, this context uses an NTT domain with
-`logN = min (level + 2) maxLogN`. If the selected domain is still too small for
-the current operands, the backend falls back to ordinary `CPolynomial`
-multiplication.
+The context asks for the smallest supported domain that fits the current
+operands. If no supported domain is available, it falls back to ordinary
+`CPolynomial` multiplication.
 -/
 def ntt [Field R] [BEq R] [LawfulBEq R]
-    (maxLogN : Nat) (domainOfLogN : (logN : Nat) → logN ≤ maxLogN → NTT.Domain R) :
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (NTT.FittingDomain R requiredLen)) :
     MulContext R where
-  mulAtLevel level p q :=
-    let D := domainOfLogN (min (level + 2) maxLogN) (Nat.min_le_right _ _)
-    if hfit : NTT.Domain.requiredLength p.val q.val ≤ 2 ^ D.logN then
-      NTT.FastMul.fastMulImpl D p q
-    else
-      p * q
-  mulAtLevel_eq_mul level p q := by
-    let D := domainOfLogN (min (level + 2) maxLogN) (Nat.min_le_right _ _)
-    by_cases hfit :
-        NTT.Domain.requiredLength p.val q.val ≤ 2 ^ D.logN
-    · simp [D, hfit, NTT.FastMul.fastMulImpl_eq_mul D p q (by
-        simpa [NTT.Domain.fits, NTT.Domain.n] using hfit)]
-    · simp [D, hfit]
+  mul := nttMul bestDomainForLength?
+  mul_eq_mul := nttMul_eq_mul bestDomainForLength?
 
 end MulContext
 

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -17,8 +17,7 @@ namespace CPolynomial
 
 variable {R : Type*}
 
-/-- Explicit multiplication backend for algorithms that should not replace the canonical `Mul`
-instance on `CPolynomial R`. -/
+/-- Explicit multiplication backend for batch-evaluation algorithms. -/
 structure MulContext (R : Type*) [Semiring R] [BEq R] [LawfulBEq R] where
   /-- Multiply two canonical polynomials. -/
   mul : CPolynomial R → CPolynomial R → CPolynomial R
@@ -42,9 +41,9 @@ def naive [Semiring R] [BEq R] [LawfulBEq R] : MulContext R where
 /--
 NTT-backed multiplication context with canonical multiplication as a fallback.
 
-The context asks for the smallest supported domain that fits the current
-operands. If no supported domain is available, it falls back to ordinary
-`CPolynomial` multiplication.
+The context asks the selector for a domain that fits the current operands. If no
+supported domain is available, it falls back to ordinary `CPolynomial`
+multiplication.
 -/
 def ntt [Field R] [BEq R] [LawfulBEq R]
     (bestDomainForLength? : (requiredLen : Nat) →
@@ -62,7 +61,7 @@ def naive [Field R] [BEq R] [LawfulBEq R] : ModContext R where
   modByMonic p q := CPolynomial.modByMonic p q
   modByMonic_eq_modByMonic _ _ := rfl
 
-/-- A remainder-only compiled backend for monic remainders. -/
+/-- A remainder-only backend for monic remainders. -/
 def remainderOnly [Field R] [BEq R] [LawfulBEq R] : ModContext R where
   modByMonic p q := CPolynomial.modByMonicRemainderOnly p q
   modByMonic_eq_modByMonic p q := CPolynomial.modByMonicRemainderOnly_eq_modByMonic p q

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -90,6 +90,12 @@ def remainderOnly [Field R] [BEq R] [LawfulBEq R] : ModContext R where
   modByMonic p q := CPolynomial.modByMonicRemainderOnly p q
   modByMonic_eq_modByMonic p q := CPolynomial.modByMonicRemainderOnly_eq_modByMonic p q
 
+/-- A reversal-based monic-remainder backend parameterized by low-product multiplication. -/
+def reversal [Field R] [BEq R] [LawfulBEq R]
+    (M : Raw.MulLowContext R) : ModContext R where
+  modByMonic p q := CPolynomial.modByMonicByReversal M p q
+  modByMonic_eq_modByMonic p q := CPolynomial.modByMonicByReversal_eq_modByMonic M p q
+
 end ModContext
 
 end CPolynomial

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Univariate.Basic
+
+/-!
+# Batch Evaluation Contexts
+
+Algorithm dictionaries for univariate batch-evaluation implementations.
+-/
+
+namespace CompPoly
+namespace CPolynomial
+
+variable {R : Type*}
+
+/-- Explicit multiplication backend for algorithms that should not replace the canonical `Mul`
+instance on `CPolynomial R`. -/
+structure MulContext (R : Type*) [Semiring R] [BEq R] [LawfulBEq R] where
+  /-- Multiply two canonical polynomials. -/
+  mul : CPolynomial R → CPolynomial R → CPolynomial R
+  /-- The backend agrees with canonical polynomial multiplication. -/
+  mul_eq_mul : ∀ p q, mul p q = p * q
+
+/-- Explicit remainder backend for algorithms that only need reduction modulo monic divisors. -/
+structure ModContext (R : Type*) [Field R] [BEq R] [LawfulBEq R] where
+  /-- Reduce the first polynomial modulo the second, assuming the divisor is monic. -/
+  modByMonic : CPolynomial R → CPolynomial R → CPolynomial R
+  /-- The backend agrees with the canonical monic-remainder operation. -/
+  modByMonic_eq_modByMonic : ∀ p q, modByMonic p q = CPolynomial.modByMonic p q
+
+namespace MulContext
+
+/-- The default multiplication context, backed by canonical `CPolynomial` multiplication. -/
+def naive [Semiring R] [BEq R] [LawfulBEq R] : MulContext R where
+  mul p q := p * q
+  mul_eq_mul _ _ := rfl
+
+end MulContext
+
+namespace ModContext
+
+/-- The default monic-remainder context, backed by `CPolynomial.modByMonic`. -/
+def naive [Field R] [BEq R] [LawfulBEq R] : ModContext R where
+  modByMonic p q := CPolynomial.modByMonic p q
+  modByMonic_eq_modByMonic _ _ := rfl
+
+end ModContext
+
+end CPolynomial
+end CompPoly

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Derek Sorensen
 -/
 import CompPoly.Univariate.Basic
+import CompPoly.Univariate.NTT.FastMul
 
 /-!
 # Batch Evaluation Contexts
@@ -37,6 +38,31 @@ namespace MulContext
 def naive [Semiring R] [BEq R] [LawfulBEq R] : MulContext R where
   mulAtLevel _ p q := p * q
   mulAtLevel_eq_mul _ _ _ := rfl
+
+/--
+Subproduct-tree NTT-backed multiplication context with canonical multiplication as a fallback.
+
+At subproduct-tree level `level`, this context uses an NTT domain with
+`logN = min (level + 2) maxLogN`. If the selected domain is still too small for
+the current operands, the backend falls back to ordinary `CPolynomial`
+multiplication.
+-/
+def ntt [Field R] [BEq R] [LawfulBEq R]
+    (maxLogN : Nat) (domainOfLogN : (logN : Nat) → logN ≤ maxLogN → NTT.Domain R) :
+    MulContext R where
+  mulAtLevel level p q :=
+    let D := domainOfLogN (min (level + 2) maxLogN) (Nat.min_le_right _ _)
+    if hfit : NTT.Domain.requiredLength p.val q.val ≤ 2 ^ D.logN then
+      NTT.FastMul.fastMulImpl D p q
+    else
+      p * q
+  mulAtLevel_eq_mul level p q := by
+    let D := domainOfLogN (min (level + 2) maxLogN) (Nat.min_le_right _ _)
+    by_cases hfit :
+        NTT.Domain.requiredLength p.val q.val ≤ 2 ^ D.logN
+    · simp [D, hfit, NTT.FastMul.fastMulImpl_eq_mul D p q (by
+        simpa [NTT.Domain.fits, NTT.Domain.n] using hfit)]
+    · simp [D, hfit]
 
 end MulContext
 

--- a/CompPoly/Univariate/BatchEval/Context.lean
+++ b/CompPoly/Univariate/BatchEval/Context.lean
@@ -47,6 +47,11 @@ def naive [Field R] [BEq R] [LawfulBEq R] : ModContext R where
   modByMonic p q := CPolynomial.modByMonic p q
   modByMonic_eq_modByMonic _ _ := rfl
 
+/-- A remainder-only compiled backend for monic remainders. -/
+def fast [Field R] [BEq R] [LawfulBEq R] : ModContext R where
+  modByMonic p q := CPolynomial.modByMonicFast p q
+  modByMonic_eq_modByMonic p q := CPolynomial.modByMonicFast_eq_modByMonic p q
+
 end ModContext
 
 end CPolynomial

--- a/CompPoly/Univariate/BatchEval/Correctness.lean
+++ b/CompPoly/Univariate/BatchEval/Correctness.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Univariate.BatchEval.Naive
+
+/-!
+# Batch Evaluation Correctness
+
+Correctness theorems for univariate batch-evaluation implementations.
+-/
+
+namespace CompPoly
+namespace CPolynomial
+
+variable {R : Type*}
+
+/-- Batched Horner evaluation agrees with the direct batched evaluator. -/
+theorem evalBatchHorner_eq_evalBatch [Semiring R] (p : CPolynomial R) (xs : Array R) :
+    evalBatchHorner p xs = evalBatch p xs := by
+  simp [evalBatchHorner, evalBatch, eval_horner_eq_eval]
+
+end CPolynomial
+end CompPoly

--- a/CompPoly/Univariate/BatchEval/Correctness.lean
+++ b/CompPoly/Univariate/BatchEval/Correctness.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Derek Sorensen
+Authors: Valerii Huhnin
 -/
 import CompPoly.Univariate.BatchEval.SubproductTree
 import CompPoly.Univariate.ToPoly.Impl

--- a/CompPoly/Univariate/BatchEval/Correctness.lean
+++ b/CompPoly/Univariate/BatchEval/Correctness.lean
@@ -39,12 +39,13 @@ private def pointsList [Zero R] : List (SubproductTree R) → List R
   | [] => []
   | tree :: trees => points tree ++ pointsList trees
 
-private def Valid [Semiring R] : SubproductTree R → Prop
+/-- A subproduct tree is valid when every stored polynomial vanishes on its leaves. -/
+private def isValid [Semiring R] : SubproductTree R → Prop
   | leaf x poly => ∀ y, y ∈ [x] → poly.eval y = 0
   | node poly left right =>
-      (∀ x, x ∈ points left ++ points right → poly.eval x = 0) ∧ Valid left ∧ Valid right
+      (∀ x, x ∈ points left ++ points right → poly.eval x = 0) ∧ isValid left ∧ isValid right
 
-private theorem valid_root [Semiring R] {tree : SubproductTree R} (h : Valid tree)
+private theorem valid_root [Semiring R] {tree : SubproductTree R} (h : isValid tree)
     {x : R} (hx : x ∈ points tree) :
     tree.poly.eval x = 0 := by
   cases tree with
@@ -54,15 +55,15 @@ private theorem valid_root [Semiring R] {tree : SubproductTree R} (h : Valid tre
       exact h.1 x (by simpa [points] using hx)
 
 private theorem valid_leafFor [Field R] [BEq R] [LawfulBEq R] (x : R) :
-    Valid (leafFor x) := by
+    isValid (leafFor x) := by
   intro y hy
   simp at hy
   subst y
   exact eval_linearFactor x
 
 private theorem valid_combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
-    {left right : SubproductTree R} (hleft : Valid left) (hright : Valid right) :
-    Valid (combine M left right) := by
+    {left right : SubproductTree R} (hleft : isValid left) (hright : isValid right) :
+    isValid (combine M left right) := by
   constructor
   · intro x hx
     rw [M.mul_eq_mul, eval_mul]
@@ -74,8 +75,8 @@ private theorem valid_combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
   · exact ⟨hleft, hright⟩
 
 private theorem valid_combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
-    ∀ {trees : List (SubproductTree R)}, List.Forall Valid trees →
-      List.Forall Valid (combinePairs M trees)
+    ∀ {trees : List (SubproductTree R)}, List.Forall isValid trees →
+      List.Forall isValid (combinePairs M trees)
   | [], _ => by
       simp [combinePairs]
   | [_], h => by
@@ -112,11 +113,11 @@ private theorem length_combinePairs_pair_le [Field R] [BEq R] [LawfulBEq R]
     (combinePairs M (left :: right :: rest)).length ≤ rest.length + 1 := by
   simpa [combinePairs] using Nat.succ_le_succ (length_combinePairs_le M rest)
 
-private theorem combinePairs_ne_nil_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
+private theorem combinePairs_nonempty [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) :
-    ∀ {trees : List (SubproductTree R)}, trees ≠ [] → combinePairs M trees ≠ []
+    ∀ {trees : List (SubproductTree R)}, 0 < trees.length → 0 < (combinePairs M trees).length
   | [], h => by
-      contradiction
+      simp at h
   | [_], _ => by
       simp [combinePairs]
   | _ :: _ :: _, _ => by
@@ -124,14 +125,14 @@ private theorem combinePairs_ne_nil_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
 
 private theorem buildFromTrees_exists_of_length_le [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) :
-    ∀ (fuel : ℕ) (trees : List (SubproductTree R)), trees ≠ [] →
+    ∀ (fuel : ℕ) (trees : List (SubproductTree R)), 0 < trees.length →
       trees.length ≤ fuel + 1 → ∃ tree, buildFromTrees M fuel trees = some tree := by
   intro fuel
   induction fuel with
   | zero =>
       intro trees hne hlen
       cases trees with
-      | nil => contradiction
+      | nil => simp at hne
       | cons tree rest =>
           cases rest with
           | nil => exact ⟨tree, rfl⟩
@@ -139,7 +140,7 @@ private theorem buildFromTrees_exists_of_length_le [Field R] [BEq R] [LawfulBEq 
   | succ fuel ih =>
       intro trees hne hlen
       cases trees with
-      | nil => contradiction
+      | nil => simp at hne
       | cons left rest =>
           cases rest with
           | nil => exact ⟨left, rfl⟩
@@ -149,24 +150,22 @@ private theorem buildFromTrees_exists_of_length_le [Field R] [BEq R] [LawfulBEq 
                 have hlen_rest : rest.length + 2 ≤ fuel + 2 := by
                   simpa using hlen
                 omega
-              have hne' : combinePairs M (left :: right :: rest) ≠ [] :=
-                combinePairs_ne_nil_of_ne_nil M (by simp)
+              have hne' : 0 < (combinePairs M (left :: right :: rest)).length :=
+                combinePairs_nonempty M (by simp)
               simpa [buildFromTrees] using
                 ih (combinePairs M (left :: right :: rest)) hne' hlen'
 
-private theorem buildList_exists_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
-    (M : MulContext R) {xs : List R} (hxs : xs ≠ []) :
+private theorem buildList_exists_of_nonempty [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) {xs : List R} (hxs : 0 < xs.length) :
     ∃ tree, buildList M xs = some tree := by
-  have hleaves : xs.map leafFor ≠ [] := by
-    cases xs with
-    | nil => contradiction
-    | cons _ _ => simp
+  have hleaves : 0 < (xs.map leafFor).length := by
+    simpa using hxs
   simpa [buildList] using
     buildFromTrees_exists_of_length_le M (xs.map leafFor).length (xs.map leafFor)
       hleaves (Nat.le_succ _)
 
 private theorem valid_leafFor_list [Field R] [BEq R] [LawfulBEq R] :
-    ∀ xs : List R, List.Forall Valid (xs.map leafFor)
+    ∀ xs : List R, List.Forall isValid (xs.map leafFor)
   | [] => by
       simp
   | x :: xs => by
@@ -181,8 +180,8 @@ private theorem pointsList_map_leafFor [Field R] [BEq R] [LawfulBEq R] :
 private theorem buildFromTrees_valid_points [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) :
     ∀ (fuel : ℕ) (trees : List (SubproductTree R)) (tree : SubproductTree R),
-      buildFromTrees M fuel trees = some tree → List.Forall Valid trees →
-        Valid tree ∧ points tree = pointsList trees := by
+      buildFromTrees M fuel trees = some tree → List.Forall isValid trees →
+        isValid tree ∧ points tree = pointsList trees := by
   intro fuel
   induction fuel with
   | zero =>
@@ -194,7 +193,7 @@ private theorem buildFromTrees_valid_points [Field R] [BEq R] [LawfulBEq R]
           | nil =>
               simp [buildFromTrees] at hbuild
               subst hbuild
-              have hhead : Valid head := by
+              have hhead : isValid head := by
                 simpa using hvalid
               exact ⟨hhead, by simp [pointsList]⟩
           | cons _ _ => simp [buildFromTrees] at hbuild
@@ -207,12 +206,12 @@ private theorem buildFromTrees_valid_points [Field R] [BEq R] [LawfulBEq R]
           | nil =>
               simp [buildFromTrees] at hbuild
               subst hbuild
-              have hhead : Valid head := by
+              have hhead : isValid head := by
                 simpa using hvalid
               exact ⟨hhead, by simp [pointsList]⟩
           | cons second rest =>
               have hnext :
-                  Valid tree ∧ points tree =
+                  isValid tree ∧ points tree =
                     pointsList (combinePairs M (head :: second :: rest)) :=
                 ih (combinePairs M (head :: second :: rest)) tree
                   (by simpa [buildFromTrees] using hbuild)
@@ -223,7 +222,7 @@ private theorem buildFromTrees_valid_points [Field R] [BEq R] [LawfulBEq R]
 private theorem buildList_valid_points [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) {xs : List R} {tree : SubproductTree R}
     (hbuild : buildList M xs = some tree) :
-    Valid tree ∧ points tree = xs := by
+    isValid tree ∧ points tree = xs := by
   have h :=
     buildFromTrees_valid_points M (xs.map leafFor).length (xs.map leafFor) tree
       (by simpa [buildList] using hbuild) (valid_leafFor_list xs)
@@ -232,13 +231,13 @@ private theorem buildList_valid_points [Field R] [BEq R] [LawfulBEq R]
 private theorem buildArray_valid_points [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) {xs : Array R} {tree : SubproductTree R}
     (hbuild : buildArray M xs = some tree) :
-    Valid tree ∧ points tree = xs.toList := by
+    isValid tree ∧ points tree = xs.toList := by
   exact buildList_valid_points M (by simpa [buildArray] using hbuild)
 
 private theorem map_eval_modContext_eq_map_eval [Field R] [BEq R] [LawfulBEq R]
     (D : ModContext R) (p q : CPolynomial R) :
     ∀ xs : List R, (∀ x, x ∈ xs → q.eval x = 0) →
-      xs.map (fun x => (D.modByMonic p q).eval x) = xs.map (fun x => p.eval x)
+      xs.map (fun x ↦ (D.modByMonic p q).eval x) = xs.map (fun x ↦ p.eval x)
   | [], _ => by
       simp
   | x :: xs, hroot => by
@@ -251,34 +250,34 @@ private theorem map_eval_modContext_eq_map_eval [Field R] [BEq R] [LawfulBEq R]
 
 private theorem evalList_eq_map_eval [Field R] [BEq R] [LawfulBEq R]
     (D : ModContext R) :
-    ∀ (p : CPolynomial R) (tree : SubproductTree R), Valid tree →
-      evalList D p tree = (points tree).map fun x => p.eval x
+    ∀ (p : CPolynomial R) (tree : SubproductTree R), isValid tree →
+      evalList D p tree = (points tree).map fun x ↦ p.eval x
   | p, leaf x leafPoly, hvalid => by
       have hroot : leafPoly.eval x = 0 :=
         valid_root hvalid (by simp [points])
       have hmod := eval_modContext_eq_self_of_eval_eq_zero D p leafPoly hroot
       simp [evalList, points, eval_horner_eq_eval, hmod]
   | p, node _ left right, hvalid => by
-      have hleft : Valid left := by
-        simpa [Valid] using hvalid.2.1
-      have hright : Valid right := by
-        simpa [Valid] using hvalid.2.2
+      have hleft : isValid left := by
+        simpa [isValid] using hvalid.2.1
+      have hright : isValid right := by
+        simpa [isValid] using hvalid.2.2
       calc
         evalList D p (node _ left right)
             = evalList D (D.modByMonic p left.poly) left ++
                 evalList D (D.modByMonic p right.poly) right := by
               rfl
-        _ = (points left).map (fun x => (D.modByMonic p left.poly).eval x) ++
-              (points right).map (fun x => (D.modByMonic p right.poly).eval x) := by
+        _ = (points left).map (fun x ↦ (D.modByMonic p left.poly).eval x) ++
+              (points right).map (fun x ↦ (D.modByMonic p right.poly).eval x) := by
               rw [evalList_eq_map_eval D (D.modByMonic p left.poly) left hleft,
                 evalList_eq_map_eval D (D.modByMonic p right.poly) right hright]
-        _ = (points left).map (fun x => p.eval x) ++
-              (points right).map (fun x => p.eval x) := by
+        _ = (points left).map (fun x ↦ p.eval x) ++
+              (points right).map (fun x ↦ p.eval x) := by
               rw [map_eval_modContext_eq_map_eval D p left.poly (points left)
-                  (fun x hx => valid_root hleft hx),
+                  (fun x hx ↦ valid_root hleft hx),
                 map_eval_modContext_eq_map_eval D p right.poly (points right)
-                  (fun x hx => valid_root hright hx)]
-        _ = (points (node _ left right)).map (fun x => p.eval x) := by
+                  (fun x hx ↦ valid_root hright hx)]
+        _ = (points (node _ left right)).map (fun x ↦ p.eval x) := by
               simp [points, List.map_append]
 
 end SubproductTree
@@ -298,7 +297,11 @@ theorem evalBatchSubproduct_eq_evalBatch [Field R] [BEq R] [LawfulBEq R]
   | none =>
       have hnil : xs.toList = [] := by
         by_contra hne
-        obtain ⟨tree, htree⟩ := SubproductTree.buildList_exists_of_ne_nil M hne
+        have hnonempty : 0 < xs.toList.length := by
+          cases hxs : xs.toList with
+          | nil => exact False.elim (hne hxs)
+          | cons _ _ => simp
+        obtain ⟨tree, htree⟩ := SubproductTree.buildList_exists_of_nonempty M hnonempty
         simp [SubproductTree.buildArray, htree] at hbuild
       simp [evalBatch, hnil]
   | some tree =>

--- a/CompPoly/Univariate/BatchEval/Correctness.lean
+++ b/CompPoly/Univariate/BatchEval/Correctness.lean
@@ -61,11 +61,12 @@ private theorem valid_leafFor [Field R] [BEq R] [LawfulBEq R] (x : R) :
   exact eval_linearFactor x
 
 private theorem valid_combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
+    (level : Nat)
     {left right : SubproductTree R} (hleft : Valid left) (hright : Valid right) :
-    Valid (combine M left right) := by
+    Valid (combine M level left right) := by
   constructor
   · intro x hx
-    rw [M.mul_eq_mul, eval_mul]
+    rw [M.mulAtLevel_eq_mul, eval_mul]
     rcases List.mem_append.mp hx with hx | hx
     · rw [valid_root hleft hx]
       simp
@@ -73,30 +74,31 @@ private theorem valid_combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
       simp
   · exact ⟨hleft, hright⟩
 
-private theorem valid_combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
+private theorem valid_combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
+    (level : Nat) :
     ∀ {trees : List (SubproductTree R)}, List.Forall Valid trees →
-      List.Forall Valid (combinePairs M trees)
+      List.Forall Valid (combinePairs M level trees)
   | [], _ => by
       simp [combinePairs]
   | [_], h => by
       simpa [combinePairs] using h
   | left :: right :: rest, h => by
       simp [combinePairs] at h ⊢
-      exact ⟨valid_combine M h.1 h.2.1, valid_combinePairs M h.2.2⟩
+      exact ⟨valid_combine M level h.1 h.2.1, valid_combinePairs M level h.2.2⟩
 
 private theorem pointsList_combinePairs [Field R] [BEq R] [LawfulBEq R]
-    (M : MulContext R) :
+    (M : MulContext R) (level : Nat) :
     ∀ trees : List (SubproductTree R),
-      pointsList (combinePairs M trees) = pointsList trees
+      pointsList (combinePairs M level trees) = pointsList trees
   | [] => rfl
   | [_] => rfl
   | left :: right :: rest => by
-      simp [combinePairs, combine, pointsList, points, pointsList_combinePairs M rest,
+      simp [combinePairs, combine, pointsList, points, pointsList_combinePairs M level rest,
         List.append_assoc]
 
 private theorem length_combinePairs_le [Field R] [BEq R] [LawfulBEq R]
-    (M : MulContext R) :
-    ∀ trees : List (SubproductTree R), (combinePairs M trees).length ≤ trees.length
+    (M : MulContext R) (level : Nat) :
+    ∀ trees : List (SubproductTree R), (combinePairs M level trees).length ≤ trees.length
   | [] => by
       simp [combinePairs]
   | [_] => by
@@ -104,16 +106,17 @@ private theorem length_combinePairs_le [Field R] [BEq R] [LawfulBEq R]
   | _ :: _ :: rest => by
       simpa [combinePairs] using
         Nat.succ_le_succ
-          (Nat.le_trans (length_combinePairs_le M rest) (Nat.le_succ rest.length))
+          (Nat.le_trans (length_combinePairs_le M level rest) (Nat.le_succ rest.length))
 
 private theorem length_combinePairs_pair_le [Field R] [BEq R] [LawfulBEq R]
-    (M : MulContext R) (left right : SubproductTree R) (rest : List (SubproductTree R)) :
-    (combinePairs M (left :: right :: rest)).length ≤ rest.length + 1 := by
-  simpa [combinePairs] using Nat.succ_le_succ (length_combinePairs_le M rest)
+    (M : MulContext R) (level : Nat) (left right : SubproductTree R)
+    (rest : List (SubproductTree R)) :
+    (combinePairs M level (left :: right :: rest)).length ≤ rest.length + 1 := by
+  simpa [combinePairs] using Nat.succ_le_succ (length_combinePairs_le M level rest)
 
 private theorem combinePairs_ne_nil_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
-    (M : MulContext R) :
-    ∀ {trees : List (SubproductTree R)}, trees ≠ [] → combinePairs M trees ≠ []
+    (M : MulContext R) (level : Nat) :
+    ∀ {trees : List (SubproductTree R)}, trees ≠ [] → combinePairs M level trees ≠ []
   | [], h => by
       contradiction
   | [_], _ => by
@@ -123,10 +126,10 @@ private theorem combinePairs_ne_nil_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
 
 private theorem buildFromTrees_exists_of_length_le [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) :
-    ∀ (fuel : ℕ) (trees : List (SubproductTree R)), trees ≠ [] →
-      trees.length ≤ fuel + 1 → ∃ tree, buildFromTrees M fuel trees = some tree := by
-  intro fuel
-  induction fuel with
+    ∀ (level fuel : ℕ) (trees : List (SubproductTree R)), trees ≠ [] →
+      trees.length ≤ fuel + 1 → ∃ tree, buildFromTrees M level fuel trees = some tree := by
+  intro level fuel
+  induction fuel generalizing level with
   | zero =>
       intro trees hne hlen
       cases trees with
@@ -143,14 +146,15 @@ private theorem buildFromTrees_exists_of_length_le [Field R] [BEq R] [LawfulBEq 
           cases rest with
           | nil => exact ⟨left, rfl⟩
           | cons right rest =>
-              have hlen' : (combinePairs M (left :: right :: rest)).length ≤ fuel + 1 := by
-                have hpair := length_combinePairs_pair_le M left right rest
+              have hlen' : (combinePairs M level (left :: right :: rest)).length ≤ fuel + 1 := by
+                have hpair := length_combinePairs_pair_le M level left right rest
                 have hlen_rest : rest.length + 2 ≤ fuel + 2 := by
                   simpa using hlen
                 omega
-              have hne' : combinePairs M (left :: right :: rest) ≠ [] :=
-                combinePairs_ne_nil_of_ne_nil M (by simp)
-              simpa [buildFromTrees] using ih (combinePairs M (left :: right :: rest)) hne' hlen'
+              have hne' : combinePairs M level (left :: right :: rest) ≠ [] :=
+                combinePairs_ne_nil_of_ne_nil M level (by simp)
+              simpa [buildFromTrees] using
+                ih (level + 1) (combinePairs M level (left :: right :: rest)) hne' hlen'
 
 private theorem buildList_exists_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) {xs : List R} (hxs : xs ≠ []) :
@@ -160,7 +164,7 @@ private theorem buildList_exists_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
     | nil => contradiction
     | cons _ _ => simp
   simpa [buildList] using
-    buildFromTrees_exists_of_length_le M (xs.map leafFor).length (xs.map leafFor)
+    buildFromTrees_exists_of_length_le M 0 (xs.map leafFor).length (xs.map leafFor)
       hleaves (Nat.le_succ _)
 
 private theorem valid_leafFor_list [Field R] [BEq R] [LawfulBEq R] :
@@ -178,11 +182,11 @@ private theorem pointsList_map_leafFor [Field R] [BEq R] [LawfulBEq R] :
 
 private theorem buildFromTrees_valid_points [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) :
-    ∀ (fuel : ℕ) (trees : List (SubproductTree R)) (tree : SubproductTree R),
-      buildFromTrees M fuel trees = some tree → List.Forall Valid trees →
+    ∀ (level fuel : ℕ) (trees : List (SubproductTree R)) (tree : SubproductTree R),
+      buildFromTrees M level fuel trees = some tree → List.Forall Valid trees →
         Valid tree ∧ points tree = pointsList trees := by
-  intro fuel
-  induction fuel with
+  intro level fuel
+  induction fuel generalizing level with
   | zero =>
       intro trees tree hbuild hvalid
       cases trees with
@@ -210,18 +214,20 @@ private theorem buildFromTrees_valid_points [Field R] [BEq R] [LawfulBEq R]
               exact ⟨hhead, by simp [pointsList]⟩
           | cons second rest =>
               have hnext :
-                  Valid tree ∧ points tree = pointsList (combinePairs M (head :: second :: rest)) :=
-                ih (combinePairs M (head :: second :: rest)) tree
+                  Valid tree ∧ points tree =
+                    pointsList (combinePairs M level (head :: second :: rest)) :=
+                ih (level + 1) (combinePairs M level (head :: second :: rest)) tree
                   (by simpa [buildFromTrees] using hbuild)
-                  (valid_combinePairs M hvalid)
-              exact ⟨hnext.1, hnext.2.trans (pointsList_combinePairs M (head :: second :: rest))⟩
+                  (valid_combinePairs M level hvalid)
+              exact ⟨hnext.1,
+                hnext.2.trans (pointsList_combinePairs M level (head :: second :: rest))⟩
 
 private theorem buildList_valid_points [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) {xs : List R} {tree : SubproductTree R}
     (hbuild : buildList M xs = some tree) :
     Valid tree ∧ points tree = xs := by
   have h :=
-    buildFromTrees_valid_points M (xs.map leafFor).length (xs.map leafFor) tree
+    buildFromTrees_valid_points M 0 (xs.map leafFor).length (xs.map leafFor) tree
       (by simpa [buildList] using hbuild) (valid_leafFor_list xs)
   exact ⟨h.1, h.2.trans (pointsList_map_leafFor xs)⟩
 

--- a/CompPoly/Univariate/BatchEval/Correctness.lean
+++ b/CompPoly/Univariate/BatchEval/Correctness.lean
@@ -61,12 +61,11 @@ private theorem valid_leafFor [Field R] [BEq R] [LawfulBEq R] (x : R) :
   exact eval_linearFactor x
 
 private theorem valid_combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
-    (level : Nat)
     {left right : SubproductTree R} (hleft : Valid left) (hright : Valid right) :
-    Valid (combine M level left right) := by
+    Valid (combine M left right) := by
   constructor
   · intro x hx
-    rw [M.mulAtLevel_eq_mul, eval_mul]
+    rw [M.mul_eq_mul, eval_mul]
     rcases List.mem_append.mp hx with hx | hx
     · rw [valid_root hleft hx]
       simp
@@ -74,31 +73,30 @@ private theorem valid_combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
       simp
   · exact ⟨hleft, hright⟩
 
-private theorem valid_combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
-    (level : Nat) :
+private theorem valid_combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
     ∀ {trees : List (SubproductTree R)}, List.Forall Valid trees →
-      List.Forall Valid (combinePairs M level trees)
+      List.Forall Valid (combinePairs M trees)
   | [], _ => by
       simp [combinePairs]
   | [_], h => by
       simpa [combinePairs] using h
   | left :: right :: rest, h => by
       simp [combinePairs] at h ⊢
-      exact ⟨valid_combine M level h.1 h.2.1, valid_combinePairs M level h.2.2⟩
+      exact ⟨valid_combine M h.1 h.2.1, valid_combinePairs M h.2.2⟩
 
 private theorem pointsList_combinePairs [Field R] [BEq R] [LawfulBEq R]
-    (M : MulContext R) (level : Nat) :
+    (M : MulContext R) :
     ∀ trees : List (SubproductTree R),
-      pointsList (combinePairs M level trees) = pointsList trees
+      pointsList (combinePairs M trees) = pointsList trees
   | [] => rfl
   | [_] => rfl
   | left :: right :: rest => by
-      simp [combinePairs, combine, pointsList, points, pointsList_combinePairs M level rest,
+      simp [combinePairs, combine, pointsList, points, pointsList_combinePairs M rest,
         List.append_assoc]
 
 private theorem length_combinePairs_le [Field R] [BEq R] [LawfulBEq R]
-    (M : MulContext R) (level : Nat) :
-    ∀ trees : List (SubproductTree R), (combinePairs M level trees).length ≤ trees.length
+    (M : MulContext R) :
+    ∀ trees : List (SubproductTree R), (combinePairs M trees).length ≤ trees.length
   | [] => by
       simp [combinePairs]
   | [_] => by
@@ -106,17 +104,17 @@ private theorem length_combinePairs_le [Field R] [BEq R] [LawfulBEq R]
   | _ :: _ :: rest => by
       simpa [combinePairs] using
         Nat.succ_le_succ
-          (Nat.le_trans (length_combinePairs_le M level rest) (Nat.le_succ rest.length))
+          (Nat.le_trans (length_combinePairs_le M rest) (Nat.le_succ rest.length))
 
 private theorem length_combinePairs_pair_le [Field R] [BEq R] [LawfulBEq R]
-    (M : MulContext R) (level : Nat) (left right : SubproductTree R)
+    (M : MulContext R) (left right : SubproductTree R)
     (rest : List (SubproductTree R)) :
-    (combinePairs M level (left :: right :: rest)).length ≤ rest.length + 1 := by
-  simpa [combinePairs] using Nat.succ_le_succ (length_combinePairs_le M level rest)
+    (combinePairs M (left :: right :: rest)).length ≤ rest.length + 1 := by
+  simpa [combinePairs] using Nat.succ_le_succ (length_combinePairs_le M rest)
 
 private theorem combinePairs_ne_nil_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
-    (M : MulContext R) (level : Nat) :
-    ∀ {trees : List (SubproductTree R)}, trees ≠ [] → combinePairs M level trees ≠ []
+    (M : MulContext R) :
+    ∀ {trees : List (SubproductTree R)}, trees ≠ [] → combinePairs M trees ≠ []
   | [], h => by
       contradiction
   | [_], _ => by
@@ -126,10 +124,10 @@ private theorem combinePairs_ne_nil_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
 
 private theorem buildFromTrees_exists_of_length_le [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) :
-    ∀ (level fuel : ℕ) (trees : List (SubproductTree R)), trees ≠ [] →
-      trees.length ≤ fuel + 1 → ∃ tree, buildFromTrees M level fuel trees = some tree := by
-  intro level fuel
-  induction fuel generalizing level with
+    ∀ (fuel : ℕ) (trees : List (SubproductTree R)), trees ≠ [] →
+      trees.length ≤ fuel + 1 → ∃ tree, buildFromTrees M fuel trees = some tree := by
+  intro fuel
+  induction fuel with
   | zero =>
       intro trees hne hlen
       cases trees with
@@ -146,15 +144,15 @@ private theorem buildFromTrees_exists_of_length_le [Field R] [BEq R] [LawfulBEq 
           cases rest with
           | nil => exact ⟨left, rfl⟩
           | cons right rest =>
-              have hlen' : (combinePairs M level (left :: right :: rest)).length ≤ fuel + 1 := by
-                have hpair := length_combinePairs_pair_le M level left right rest
+              have hlen' : (combinePairs M (left :: right :: rest)).length ≤ fuel + 1 := by
+                have hpair := length_combinePairs_pair_le M left right rest
                 have hlen_rest : rest.length + 2 ≤ fuel + 2 := by
                   simpa using hlen
                 omega
-              have hne' : combinePairs M level (left :: right :: rest) ≠ [] :=
-                combinePairs_ne_nil_of_ne_nil M level (by simp)
+              have hne' : combinePairs M (left :: right :: rest) ≠ [] :=
+                combinePairs_ne_nil_of_ne_nil M (by simp)
               simpa [buildFromTrees] using
-                ih (level + 1) (combinePairs M level (left :: right :: rest)) hne' hlen'
+                ih (combinePairs M (left :: right :: rest)) hne' hlen'
 
 private theorem buildList_exists_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) {xs : List R} (hxs : xs ≠ []) :
@@ -164,7 +162,7 @@ private theorem buildList_exists_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
     | nil => contradiction
     | cons _ _ => simp
   simpa [buildList] using
-    buildFromTrees_exists_of_length_le M 0 (xs.map leafFor).length (xs.map leafFor)
+    buildFromTrees_exists_of_length_le M (xs.map leafFor).length (xs.map leafFor)
       hleaves (Nat.le_succ _)
 
 private theorem valid_leafFor_list [Field R] [BEq R] [LawfulBEq R] :
@@ -182,11 +180,11 @@ private theorem pointsList_map_leafFor [Field R] [BEq R] [LawfulBEq R] :
 
 private theorem buildFromTrees_valid_points [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) :
-    ∀ (level fuel : ℕ) (trees : List (SubproductTree R)) (tree : SubproductTree R),
-      buildFromTrees M level fuel trees = some tree → List.Forall Valid trees →
+    ∀ (fuel : ℕ) (trees : List (SubproductTree R)) (tree : SubproductTree R),
+      buildFromTrees M fuel trees = some tree → List.Forall Valid trees →
         Valid tree ∧ points tree = pointsList trees := by
-  intro level fuel
-  induction fuel generalizing level with
+  intro fuel
+  induction fuel with
   | zero =>
       intro trees tree hbuild hvalid
       cases trees with
@@ -215,19 +213,19 @@ private theorem buildFromTrees_valid_points [Field R] [BEq R] [LawfulBEq R]
           | cons second rest =>
               have hnext :
                   Valid tree ∧ points tree =
-                    pointsList (combinePairs M level (head :: second :: rest)) :=
-                ih (level + 1) (combinePairs M level (head :: second :: rest)) tree
+                    pointsList (combinePairs M (head :: second :: rest)) :=
+                ih (combinePairs M (head :: second :: rest)) tree
                   (by simpa [buildFromTrees] using hbuild)
-                  (valid_combinePairs M level hvalid)
+                  (valid_combinePairs M hvalid)
               exact ⟨hnext.1,
-                hnext.2.trans (pointsList_combinePairs M level (head :: second :: rest))⟩
+                hnext.2.trans (pointsList_combinePairs M (head :: second :: rest))⟩
 
 private theorem buildList_valid_points [Field R] [BEq R] [LawfulBEq R]
     (M : MulContext R) {xs : List R} {tree : SubproductTree R}
     (hbuild : buildList M xs = some tree) :
     Valid tree ∧ points tree = xs := by
   have h :=
-    buildFromTrees_valid_points M 0 (xs.map leafFor).length (xs.map leafFor) tree
+    buildFromTrees_valid_points M (xs.map leafFor).length (xs.map leafFor) tree
       (by simpa [buildList] using hbuild) (valid_leafFor_list xs)
   exact ⟨h.1, h.2.trans (pointsList_map_leafFor xs)⟩
 

--- a/CompPoly/Univariate/BatchEval/Correctness.lean
+++ b/CompPoly/Univariate/BatchEval/Correctness.lean
@@ -3,7 +3,8 @@ Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Derek Sorensen
 -/
-import CompPoly.Univariate.BatchEval.Naive
+import CompPoly.Univariate.BatchEval.SubproductTree
+import CompPoly.Univariate.ToPoly.Impl
 
 /-!
 # Batch Evaluation Correctness
@@ -16,10 +17,290 @@ namespace CPolynomial
 
 variable {R : Type*}
 
+private theorem eval_linearFactor [Field R] [BEq R] [LawfulBEq R] (x : R) :
+    (linearFactor x).eval x = 0 := by
+  rw [eval_toPoly]
+  simp [linearFactor, toPoly_sub, X_toPoly, C_toPoly]
+
+private theorem eval_modContext_eq_self_of_eval_eq_zero
+    [Field R] [BEq R] [LawfulBEq R] (D : ModContext R) (p q : CPolynomial R)
+    {x : R} (hq : q.eval x = 0) :
+    (D.modByMonic p q).eval x = p.eval x := by
+  rw [D.modByMonic_eq_modByMonic]
+  exact eval_modByMonic_eq_self_of_eval_eq_zero p q hq
+
+namespace SubproductTree
+
+private def points [Zero R] : SubproductTree R → List R
+  | leaf x _ => [x]
+  | node _ left right => points left ++ points right
+
+private def pointsList [Zero R] : List (SubproductTree R) → List R
+  | [] => []
+  | tree :: trees => points tree ++ pointsList trees
+
+private def Valid [Semiring R] : SubproductTree R → Prop
+  | leaf x poly => ∀ y, y ∈ [x] → poly.eval y = 0
+  | node poly left right =>
+      (∀ x, x ∈ points left ++ points right → poly.eval x = 0) ∧ Valid left ∧ Valid right
+
+private theorem valid_root [Semiring R] {tree : SubproductTree R} (h : Valid tree)
+    {x : R} (hx : x ∈ points tree) :
+    tree.poly.eval x = 0 := by
+  cases tree with
+  | leaf y poly =>
+      exact h x (by simpa [points] using hx)
+  | node poly left right =>
+      exact h.1 x (by simpa [points] using hx)
+
+private theorem valid_leafFor [Field R] [BEq R] [LawfulBEq R] (x : R) :
+    Valid (leafFor x) := by
+  intro y hy
+  simp at hy
+  subst y
+  exact eval_linearFactor x
+
+private theorem valid_combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
+    {left right : SubproductTree R} (hleft : Valid left) (hright : Valid right) :
+    Valid (combine M left right) := by
+  constructor
+  · intro x hx
+    rw [M.mul_eq_mul, eval_mul]
+    rcases List.mem_append.mp hx with hx | hx
+    · rw [valid_root hleft hx]
+      simp
+    · rw [valid_root hright hx]
+      simp
+  · exact ⟨hleft, hright⟩
+
+private theorem valid_combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
+    ∀ {trees : List (SubproductTree R)}, List.Forall Valid trees →
+      List.Forall Valid (combinePairs M trees)
+  | [], _ => by
+      simp [combinePairs]
+  | [_], h => by
+      simpa [combinePairs] using h
+  | left :: right :: rest, h => by
+      simp [combinePairs] at h ⊢
+      exact ⟨valid_combine M h.1 h.2.1, valid_combinePairs M h.2.2⟩
+
+private theorem pointsList_combinePairs [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) :
+    ∀ trees : List (SubproductTree R),
+      pointsList (combinePairs M trees) = pointsList trees
+  | [] => rfl
+  | [_] => rfl
+  | left :: right :: rest => by
+      simp [combinePairs, combine, pointsList, points, pointsList_combinePairs M rest,
+        List.append_assoc]
+
+private theorem length_combinePairs_le [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) :
+    ∀ trees : List (SubproductTree R), (combinePairs M trees).length ≤ trees.length
+  | [] => by
+      simp [combinePairs]
+  | [_] => by
+      simp [combinePairs]
+  | _ :: _ :: rest => by
+      simpa [combinePairs] using
+        Nat.succ_le_succ
+          (Nat.le_trans (length_combinePairs_le M rest) (Nat.le_succ rest.length))
+
+private theorem length_combinePairs_pair_le [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) (left right : SubproductTree R) (rest : List (SubproductTree R)) :
+    (combinePairs M (left :: right :: rest)).length ≤ rest.length + 1 := by
+  simpa [combinePairs] using Nat.succ_le_succ (length_combinePairs_le M rest)
+
+private theorem combinePairs_ne_nil_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) :
+    ∀ {trees : List (SubproductTree R)}, trees ≠ [] → combinePairs M trees ≠ []
+  | [], h => by
+      contradiction
+  | [_], _ => by
+      simp [combinePairs]
+  | _ :: _ :: _, _ => by
+      simp [combinePairs]
+
+private theorem buildFromTrees_exists_of_length_le [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) :
+    ∀ (fuel : ℕ) (trees : List (SubproductTree R)), trees ≠ [] →
+      trees.length ≤ fuel + 1 → ∃ tree, buildFromTrees M fuel trees = some tree := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro trees hne hlen
+      cases trees with
+      | nil => contradiction
+      | cons tree rest =>
+          cases rest with
+          | nil => exact ⟨tree, rfl⟩
+          | cons _ _ => simp at hlen
+  | succ fuel ih =>
+      intro trees hne hlen
+      cases trees with
+      | nil => contradiction
+      | cons left rest =>
+          cases rest with
+          | nil => exact ⟨left, rfl⟩
+          | cons right rest =>
+              have hlen' : (combinePairs M (left :: right :: rest)).length ≤ fuel + 1 := by
+                have hpair := length_combinePairs_pair_le M left right rest
+                have hlen_rest : rest.length + 2 ≤ fuel + 2 := by
+                  simpa using hlen
+                omega
+              have hne' : combinePairs M (left :: right :: rest) ≠ [] :=
+                combinePairs_ne_nil_of_ne_nil M (by simp)
+              simpa [buildFromTrees] using ih (combinePairs M (left :: right :: rest)) hne' hlen'
+
+private theorem buildList_exists_of_ne_nil [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) {xs : List R} (hxs : xs ≠ []) :
+    ∃ tree, buildList M xs = some tree := by
+  have hleaves : xs.map leafFor ≠ [] := by
+    cases xs with
+    | nil => contradiction
+    | cons _ _ => simp
+  simpa [buildList] using
+    buildFromTrees_exists_of_length_le M (xs.map leafFor).length (xs.map leafFor)
+      hleaves (Nat.le_succ _)
+
+private theorem valid_leafFor_list [Field R] [BEq R] [LawfulBEq R] :
+    ∀ xs : List R, List.Forall Valid (xs.map leafFor)
+  | [] => by
+      simp
+  | x :: xs => by
+      simp [valid_leafFor x, valid_leafFor_list xs]
+
+private theorem pointsList_map_leafFor [Field R] [BEq R] [LawfulBEq R] :
+    ∀ xs : List R, pointsList (xs.map leafFor) = xs
+  | [] => rfl
+  | _ :: xs => by
+      simp [pointsList, points, leafFor, pointsList_map_leafFor xs]
+
+private theorem buildFromTrees_valid_points [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) :
+    ∀ (fuel : ℕ) (trees : List (SubproductTree R)) (tree : SubproductTree R),
+      buildFromTrees M fuel trees = some tree → List.Forall Valid trees →
+        Valid tree ∧ points tree = pointsList trees := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro trees tree hbuild hvalid
+      cases trees with
+      | nil => simp [buildFromTrees] at hbuild
+      | cons head rest =>
+          cases rest with
+          | nil =>
+              simp [buildFromTrees] at hbuild
+              subst hbuild
+              have hhead : Valid head := by
+                simpa using hvalid
+              exact ⟨hhead, by simp [pointsList]⟩
+          | cons _ _ => simp [buildFromTrees] at hbuild
+  | succ fuel ih =>
+      intro trees tree hbuild hvalid
+      cases trees with
+      | nil => simp [buildFromTrees] at hbuild
+      | cons head rest =>
+          cases rest with
+          | nil =>
+              simp [buildFromTrees] at hbuild
+              subst hbuild
+              have hhead : Valid head := by
+                simpa using hvalid
+              exact ⟨hhead, by simp [pointsList]⟩
+          | cons second rest =>
+              have hnext :
+                  Valid tree ∧ points tree = pointsList (combinePairs M (head :: second :: rest)) :=
+                ih (combinePairs M (head :: second :: rest)) tree
+                  (by simpa [buildFromTrees] using hbuild)
+                  (valid_combinePairs M hvalid)
+              exact ⟨hnext.1, hnext.2.trans (pointsList_combinePairs M (head :: second :: rest))⟩
+
+private theorem buildList_valid_points [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) {xs : List R} {tree : SubproductTree R}
+    (hbuild : buildList M xs = some tree) :
+    Valid tree ∧ points tree = xs := by
+  have h :=
+    buildFromTrees_valid_points M (xs.map leafFor).length (xs.map leafFor) tree
+      (by simpa [buildList] using hbuild) (valid_leafFor_list xs)
+  exact ⟨h.1, h.2.trans (pointsList_map_leafFor xs)⟩
+
+private theorem buildArray_valid_points [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) {xs : Array R} {tree : SubproductTree R}
+    (hbuild : buildArray M xs = some tree) :
+    Valid tree ∧ points tree = xs.toList := by
+  exact buildList_valid_points M (by simpa [buildArray] using hbuild)
+
+private theorem map_eval_modContext_eq_map_eval [Field R] [BEq R] [LawfulBEq R]
+    (D : ModContext R) (p q : CPolynomial R) :
+    ∀ xs : List R, (∀ x, x ∈ xs → q.eval x = 0) →
+      xs.map (fun x => (D.modByMonic p q).eval x) = xs.map (fun x => p.eval x)
+  | [], _ => by
+      simp
+  | x :: xs, hroot => by
+      have hx : q.eval x = 0 := hroot x (by simp)
+      have htail : ∀ y, y ∈ xs → q.eval y = 0 := by
+        intro y hy
+        exact hroot y (by simp [hy])
+      simp [eval_modContext_eq_self_of_eval_eq_zero D p q hx,
+        map_eval_modContext_eq_map_eval D p q xs htail]
+
+private theorem evalList_eq_map_eval [Field R] [BEq R] [LawfulBEq R]
+    (D : ModContext R) :
+    ∀ (p : CPolynomial R) (tree : SubproductTree R), Valid tree →
+      evalList D p tree = (points tree).map fun x => p.eval x
+  | p, leaf x leafPoly, hvalid => by
+      have hroot : leafPoly.eval x = 0 :=
+        valid_root hvalid (by simp [points])
+      have hmod := eval_modContext_eq_self_of_eval_eq_zero D p leafPoly hroot
+      simp [evalList, points, eval_horner_eq_eval, hmod]
+  | p, node _ left right, hvalid => by
+      have hleft : Valid left := by
+        simpa [Valid] using hvalid.2.1
+      have hright : Valid right := by
+        simpa [Valid] using hvalid.2.2
+      calc
+        evalList D p (node _ left right)
+            = evalList D (D.modByMonic p left.poly) left ++
+                evalList D (D.modByMonic p right.poly) right := by
+              rfl
+        _ = (points left).map (fun x => (D.modByMonic p left.poly).eval x) ++
+              (points right).map (fun x => (D.modByMonic p right.poly).eval x) := by
+              rw [evalList_eq_map_eval D (D.modByMonic p left.poly) left hleft,
+                evalList_eq_map_eval D (D.modByMonic p right.poly) right hright]
+        _ = (points left).map (fun x => p.eval x) ++
+              (points right).map (fun x => p.eval x) := by
+              rw [map_eval_modContext_eq_map_eval D p left.poly (points left)
+                  (fun x hx => valid_root hleft hx),
+                map_eval_modContext_eq_map_eval D p right.poly (points right)
+                  (fun x hx => valid_root hright hx)]
+        _ = (points (node _ left right)).map (fun x => p.eval x) := by
+              simp [points, List.map_append]
+
+end SubproductTree
+
 /-- Batched Horner evaluation agrees with the direct batched evaluator. -/
 theorem evalBatchHorner_eq_evalBatch [Semiring R] (p : CPolynomial R) (xs : Array R) :
     evalBatchHorner p xs = evalBatch p xs := by
   simp [evalBatchHorner, evalBatch, eval_horner_eq_eval]
+
+/-- Subproduct-tree batch evaluation agrees with the direct batched evaluator. -/
+theorem evalBatchSubproduct_eq_evalBatch [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) (D : ModContext R) (p : CPolynomial R) (xs : Array R) :
+    evalBatchSubproduct M D p xs = evalBatch p xs := by
+  apply Array.toList_inj.mp
+  unfold evalBatchSubproduct
+  cases hbuild : SubproductTree.buildArray M xs with
+  | none =>
+      have hnil : xs.toList = [] := by
+        by_contra hne
+        obtain ⟨tree, htree⟩ := SubproductTree.buildList_exists_of_ne_nil M hne
+        simp [SubproductTree.buildArray, htree] at hbuild
+      simp [evalBatch, hnil]
+  | some tree =>
+      have htree := SubproductTree.buildArray_valid_points M hbuild
+      have heval := SubproductTree.evalList_eq_map_eval D p tree htree.1
+      simp [evalBatch, heval, htree.2]
 
 end CPolynomial
 end CompPoly

--- a/CompPoly/Univariate/BatchEval/Naive.lean
+++ b/CompPoly/Univariate/BatchEval/Naive.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Univariate.Basic
+
+/-!
+# Naive Batch Evaluation
+
+Specification-level batch evaluators for canonical univariate polynomials.
+-/
+
+namespace CompPoly
+namespace CPolynomial
+
+variable {R : Type*}
+
+/-- Evaluate a polynomial at every point using the direct sum-of-powers evaluator. -/
+def evalBatch [Semiring R] (p : CPolynomial R) (xs : Array R) : Array R :=
+  xs.map fun x => p.eval x
+
+/-- Evaluate a polynomial at every point using Horner evaluation. -/
+@[inline, specialize]
+def evalBatchHorner [Semiring R] (p : CPolynomial R) (xs : Array R) : Array R :=
+  xs.map fun x => p.evalHorner x
+
+end CPolynomial
+end CompPoly

--- a/CompPoly/Univariate/BatchEval/Naive.lean
+++ b/CompPoly/Univariate/BatchEval/Naive.lean
@@ -18,12 +18,12 @@ variable {R : Type*}
 
 /-- Evaluate a polynomial at every point using the direct sum-of-powers evaluator. -/
 def evalBatch [Semiring R] (p : CPolynomial R) (xs : Array R) : Array R :=
-  xs.map fun x => p.eval x
+  xs.map fun x ↦ p.eval x
 
 /-- Evaluate a polynomial at every point using Horner evaluation. -/
 @[inline, specialize]
 def evalBatchHorner [Semiring R] (p : CPolynomial R) (xs : Array R) : Array R :=
-  xs.map fun x => p.evalHorner x
+  xs.map fun x ↦ p.evalHorner x
 
 end CPolynomial
 end CompPoly

--- a/CompPoly/Univariate/BatchEval/Naive.lean
+++ b/CompPoly/Univariate/BatchEval/Naive.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Derek Sorensen
+Authors: Valerii Huhnin
 -/
 import CompPoly.Univariate.Basic
 

--- a/CompPoly/Univariate/BatchEval/SubproductTree.lean
+++ b/CompPoly/Univariate/BatchEval/SubproductTree.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Univariate.BatchEval.Context
+import CompPoly.Univariate.BatchEval.Naive
+
+/-!
+# Subproduct-Tree Batch Evaluation
+
+Executable subproduct-tree construction and descent for univariate batch
+evaluation.
+-/
+
+namespace CompPoly
+namespace CPolynomial
+
+variable {R : Type*}
+
+/-- The linear factor `X - C x` used as a subproduct-tree leaf. -/
+def linearFactor [Field R] [BEq R] [LawfulBEq R] (x : R) : CPolynomial R :=
+  X - C x
+
+/-- A subproduct tree stores the product polynomial at every node. -/
+inductive SubproductTree (R : Type*) [Zero R] where
+  /-- A leaf for one evaluation point. The polynomial is `X - C x`. -/
+  | leaf (x : R) (poly : CPolynomial R)
+  /-- An internal node stores the product of its children. -/
+  | node (poly : CPolynomial R) (left right : SubproductTree R)
+
+namespace SubproductTree
+
+/-- The product polynomial stored at the root of a subproduct tree. -/
+def poly [Zero R] : SubproductTree R → CPolynomial R
+  | leaf _ p => p
+  | node p _ _ => p
+
+/-- Build a leaf for one evaluation point. -/
+def leafFor [Field R] [BEq R] [LawfulBEq R] (x : R) : SubproductTree R :=
+  leaf x (linearFactor x)
+
+/-- Combine two neighboring trees using the selected multiplication backend. -/
+def combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
+    (left right : SubproductTree R) : SubproductTree R :=
+  node (M.mul left.poly right.poly) left right
+
+/-- Pair adjacent trees into the next subproduct-tree level. -/
+def combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
+    List (SubproductTree R) → List (SubproductTree R)
+  | [] => []
+  | [tree] => [tree]
+  | left :: right :: rest => combine M left right :: combinePairs M rest
+
+/-- Repeatedly combine tree levels, bounded by fuel for straightforward termination. -/
+def buildFromTrees [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
+    Nat → List (SubproductTree R) → Option (SubproductTree R)
+  | 0, [tree] => some tree
+  | 0, _ => none
+  | _ + 1, [] => none
+  | _ + 1, [tree] => some tree
+  | fuel + 1, trees => buildFromTrees M fuel (combinePairs M trees)
+
+/-- Build a subproduct tree from an ordered list of evaluation points. -/
+def buildList [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
+    (xs : List R) : Option (SubproductTree R) :=
+  let leaves := xs.map leafFor
+  buildFromTrees M leaves.length leaves
+
+/-- Build a subproduct tree from an ordered array of evaluation points. -/
+def buildArray [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
+    (xs : Array R) : Option (SubproductTree R) :=
+  buildList M xs.toList
+
+/-- Descend a subproduct tree with remainders and return values in leaf order. -/
+def evalList [Field R] [BEq R] [LawfulBEq R] (D : ModContext R)
+    (p : CPolynomial R) : SubproductTree R → List R
+  | leaf x leafPoly =>
+      let rem := D.modByMonic p leafPoly
+      [rem.evalHorner x]
+  | node _ left right =>
+      evalList D (D.modByMonic p left.poly) left ++
+        evalList D (D.modByMonic p right.poly) right
+
+end SubproductTree
+
+/-- Evaluate a polynomial at many points using a subproduct tree. -/
+def evalBatchSubproduct [Field R] [BEq R] [LawfulBEq R]
+    (M : MulContext R) (D : ModContext R) (p : CPolynomial R) (xs : Array R) : Array R :=
+  match SubproductTree.buildArray M xs with
+  | none => #[]
+  | some tree => (SubproductTree.evalList D p tree).toArray
+
+end CPolynomial
+end CompPoly

--- a/CompPoly/Univariate/BatchEval/SubproductTree.lean
+++ b/CompPoly/Univariate/BatchEval/SubproductTree.lean
@@ -40,32 +40,32 @@ def poly [Zero R] : SubproductTree R → CPolynomial R
 def leafFor [Field R] [BEq R] [LawfulBEq R] (x : R) : SubproductTree R :=
   leaf x (linearFactor x)
 
-/-- Combine two neighboring trees using the selected multiplication backend. -/
+/-- Combine two neighboring trees using the selected multiplication backend at this level. -/
 def combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
-    (left right : SubproductTree R) : SubproductTree R :=
-  node (M.mul left.poly right.poly) left right
+    (level : Nat) (left right : SubproductTree R) : SubproductTree R :=
+  node (M.mulAtLevel level left.poly right.poly) left right
 
 /-- Pair adjacent trees into the next subproduct-tree level. -/
-def combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
+def combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) (level : Nat) :
     List (SubproductTree R) → List (SubproductTree R)
   | [] => []
   | [tree] => [tree]
-  | left :: right :: rest => combine M left right :: combinePairs M rest
+  | left :: right :: rest => combine M level left right :: combinePairs M level rest
 
 /-- Repeatedly combine tree levels, bounded by fuel for straightforward termination. -/
-def buildFromTrees [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
+def buildFromTrees [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) (level : Nat) :
     Nat → List (SubproductTree R) → Option (SubproductTree R)
   | 0, [tree] => some tree
   | 0, _ => none
   | _ + 1, [] => none
   | _ + 1, [tree] => some tree
-  | fuel + 1, trees => buildFromTrees M fuel (combinePairs M trees)
+  | fuel + 1, trees => buildFromTrees M (level + 1) fuel (combinePairs M level trees)
 
 /-- Build a subproduct tree from an ordered list of evaluation points. -/
 def buildList [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
     (xs : List R) : Option (SubproductTree R) :=
   let leaves := xs.map leafFor
-  buildFromTrees M leaves.length leaves
+  buildFromTrees M 0 leaves.length leaves
 
 /-- Build a subproduct tree from an ordered array of evaluation points. -/
 def buildArray [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)

--- a/CompPoly/Univariate/BatchEval/SubproductTree.lean
+++ b/CompPoly/Univariate/BatchEval/SubproductTree.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Derek Sorensen
+Authors: Valerii Huhnin
 -/
 import CompPoly.Univariate.BatchEval.Context
 import CompPoly.Univariate.BatchEval.Naive

--- a/CompPoly/Univariate/BatchEval/SubproductTree.lean
+++ b/CompPoly/Univariate/BatchEval/SubproductTree.lean
@@ -40,32 +40,32 @@ def poly [Zero R] : SubproductTree R → CPolynomial R
 def leafFor [Field R] [BEq R] [LawfulBEq R] (x : R) : SubproductTree R :=
   leaf x (linearFactor x)
 
-/-- Combine two neighboring trees using the selected multiplication backend at this level. -/
+/-- Combine two neighboring trees using the selected multiplication backend. -/
 def combine [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
-    (level : Nat) (left right : SubproductTree R) : SubproductTree R :=
-  node (M.mulAtLevel level left.poly right.poly) left right
+    (left right : SubproductTree R) : SubproductTree R :=
+  node (M.mul left.poly right.poly) left right
 
 /-- Pair adjacent trees into the next subproduct-tree level. -/
-def combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) (level : Nat) :
+def combinePairs [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
     List (SubproductTree R) → List (SubproductTree R)
   | [] => []
   | [tree] => [tree]
-  | left :: right :: rest => combine M level left right :: combinePairs M level rest
+  | left :: right :: rest => combine M left right :: combinePairs M rest
 
 /-- Repeatedly combine tree levels, bounded by fuel for straightforward termination. -/
-def buildFromTrees [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) (level : Nat) :
+def buildFromTrees [Field R] [BEq R] [LawfulBEq R] (M : MulContext R) :
     Nat → List (SubproductTree R) → Option (SubproductTree R)
   | 0, [tree] => some tree
   | 0, _ => none
   | _ + 1, [] => none
   | _ + 1, [tree] => some tree
-  | fuel + 1, trees => buildFromTrees M (level + 1) fuel (combinePairs M level trees)
+  | fuel + 1, trees => buildFromTrees M fuel (combinePairs M trees)
 
 /-- Build a subproduct tree from an ordered list of evaluation points. -/
 def buildList [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)
     (xs : List R) : Option (SubproductTree R) :=
   let leaves := xs.map leafFor
-  buildFromTrees M 0 leaves.length leaves
+  buildFromTrees M leaves.length leaves
 
 /-- Build a subproduct tree from an ordered array of evaluation points. -/
 def buildArray [Field R] [BEq R] [LawfulBEq R] (M : MulContext R)

--- a/CompPoly/Univariate/DivisionCorrectness.lean
+++ b/CompPoly/Univariate/DivisionCorrectness.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Derek Sorensen
+Authors: Valerii Huhnin
 -/
 import Mathlib.Algebra.Polynomial.Div
 import Mathlib.Algebra.Polynomial.Reverse

--- a/CompPoly/Univariate/DivisionCorrectness.lean
+++ b/CompPoly/Univariate/DivisionCorrectness.lean
@@ -1,0 +1,738 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import Mathlib.Algebra.Polynomial.Div
+import Mathlib.Algebra.Polynomial.Reverse
+import Mathlib.Tactic.Ring
+import CompPoly.Univariate.ToPoly.Impl
+
+/-!
+# Univariate Division Correctness
+
+Correctness theorems for division-style univariate polynomial algorithms.
+-/
+
+namespace CompPoly
+namespace CPolynomial
+
+open Raw
+open Polynomial
+
+variable {R : Type*}
+
+section Division
+
+variable [Field R] [BEq R] [LawfulBEq R]
+
+private def LowEq (k : Nat) (p q : R[X]) : Prop :=
+  ∀ i, i < k → p.coeff i = q.coeff i
+
+omit [BEq R] [LawfulBEq R] in
+private lemma toPoly_truncate_coeff (k : Nat) (p : Raw R) (i : Nat) :
+    (truncate k p).toPoly.coeff i = if i < k then p.toPoly.coeff i else 0 := by
+  rw [Raw.coeff_toPoly, Raw.truncate_coeff, Raw.coeff_toPoly]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma toPoly_reverse_coeff (n : Nat) (p : Raw R) (i : Nat) :
+    (reverse n p).toPoly.coeff i =
+      if i < n then p.toPoly.coeff (n - 1 - i) else 0 := by
+  rw [Raw.coeff_toPoly, Raw.reverse_coeff, Raw.coeff_toPoly]
+
+private lemma toPoly_mulLow_coeff (M : MulLowContext R) (k : Nat)
+    (p q : Raw R) (i : Nat) :
+    (M.mulLow k p q).toPoly.coeff i =
+      if i < k then (p.toPoly * q.toPoly).coeff i else 0 := by
+  rw [Raw.coeff_toPoly, Raw.mulLow_coeff]
+  by_cases hi : i < k
+  · simpa [hi, Raw.coeff_toPoly] using (Raw.toPoly_mul_coeff p q i)
+  · simp [hi]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma toPoly_truncate_lowEq (k : Nat) (p : Raw R) :
+    LowEq k (truncate k p).toPoly p.toPoly := by
+  intro i hi
+  simp [toPoly_truncate_coeff, hi]
+
+private lemma toPoly_mulLow_lowEq (M : MulLowContext R) (k : Nat)
+    (p q : Raw R) :
+    LowEq k (M.mulLow k p q).toPoly (p.toPoly * q.toPoly) := by
+  intro i hi
+  simp [toPoly_mulLow_coeff, hi]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.refl (k : Nat) (p : R[X]) : LowEq k p p := by
+  intro _ _
+  rfl
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.symm {k : Nat} {p q : R[X]} (h : LowEq k p q) :
+    LowEq k q p := by
+  intro i hi
+  exact (h i hi).symm
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.trans {k : Nat} {p q r : R[X]} (hpq : LowEq k p q)
+    (hqr : LowEq k q r) : LowEq k p r := by
+  intro i hi
+  exact (hpq i hi).trans (hqr i hi)
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.of_le {k l : Nat} {p q : R[X]} (hle : k ≤ l)
+    (h : LowEq l p q) : LowEq k p q := by
+  intro i hi
+  exact h i (lt_of_lt_of_le hi hle)
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.add {k : Nat} {p₁ p₂ q₁ q₂ : R[X]}
+    (h₁ : LowEq k p₁ q₁) (h₂ : LowEq k p₂ q₂) :
+    LowEq k (p₁ + p₂) (q₁ + q₂) := by
+  intro i hi
+  simp [h₁ i hi, h₂ i hi]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.neg {k : Nat} {p q : R[X]} (h : LowEq k p q) :
+    LowEq k (-p) (-q) := by
+  intro i hi
+  simp [h i hi]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.sub {k : Nat} {p₁ p₂ q₁ q₂ : R[X]}
+    (h₁ : LowEq k p₁ q₁) (h₂ : LowEq k p₂ q₂) :
+    LowEq k (p₁ - p₂) (q₁ - q₂) := by
+  exact h₁.add h₂.neg
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.mul_left {k : Nat} {p q : R[X]} (r : R[X])
+    (h : LowEq k p q) : LowEq k (r * p) (r * q) := by
+  intro i hi
+  rw [Polynomial.coeff_mul, Polynomial.coeff_mul]
+  apply Finset.sum_congr rfl
+  intro x hx
+  rcases x with ⟨a, b⟩
+  have hab : a + b = i := Finset.mem_antidiagonal.mp hx
+  have hb : b < k := by omega
+  rw [h b hb]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.mul_right {k : Nat} {p q : R[X]} (r : R[X])
+    (h : LowEq k p q) : LowEq k (p * r) (q * r) := by
+  intro i hi
+  calc
+    (p * r).coeff i = (r * p).coeff i := by rw [_root_.mul_comm p r]
+    _ = (r * q).coeff i := LowEq.mul_left (k := k) (p := p) (q := q) r h i hi
+    _ = (q * r).coeff i := by rw [_root_.mul_comm q r]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma polynomial_C_two : Polynomial.C (2 : R) = (2 : R[X]) := by
+  exact Polynomial.C_eq_natCast 2
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.eq_one_of_sub {k : Nat} {p : R[X]}
+    (h : LowEq k (p - 1) 0) : LowEq k p 1 := by
+  intro i hi
+  exact sub_eq_zero.mp (by simpa [Polynomial.coeff_sub] using h i hi)
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.mul_self_zero {n : Nat} {p : R[X]}
+    (h : LowEq n p 0) : LowEq (2 * n) (p * p) 0 := by
+  intro i hi
+  rw [Polynomial.coeff_mul]
+  apply Finset.sum_eq_zero
+  intro x hx
+  rcases x with ⟨a, b⟩
+  have hab : a + b = i := Finset.mem_antidiagonal.mp hx
+  have hsmall : a < n ∨ b < n := by omega
+  rcases hsmall with ha | hb
+  · rw [h a ha]
+    simp
+  · rw [h b hb]
+    simp
+
+omit [BEq R] [LawfulBEq R] in
+private lemma LowEq.newton_step {n next : Nat} {p g fg correction g' : R[X]}
+    (hnext : next ≤ 2 * n)
+    (hfg : LowEq next fg (p * g))
+    (hcorrection : LowEq next correction (Polynomial.C (2 : R) - fg))
+    (hg' : LowEq next g' (g * correction))
+    (h : LowEq n (p * g) 1) :
+    LowEq next (p * g') 1 := by
+  have hpg : LowEq next (p * g') (p * (g * correction)) :=
+    LowEq.mul_left p hg'
+  have hcorrection' : LowEq next correction (Polynomial.C (2 : R) - p * g) := by
+    intro i hi
+    have h1 := hcorrection i hi
+    have h2 := hfg i hi
+    simp [h1, h2]
+  have hpgcorrection :
+      LowEq next (p * (g * correction)) ((p * g) * (Polynomial.C (2 : R) - p * g)) := by
+    intro i hi
+    rw [← _root_.mul_assoc p g correction]
+    exact LowEq.mul_left (p * g) hcorrection' i hi
+  have hE : LowEq n (p * g - 1) 0 := by
+    intro i hi
+    have hcoeff := h i hi
+    simp [Polynomial.coeff_sub, hcoeff]
+  have hE2 : LowEq next ((p * g - 1) * (p * g - 1)) 0 := by
+    exact (LowEq.mul_self_zero hE).of_le hnext
+  have hmain : LowEq next (((p * g) * (Polynomial.C (2 : R) - p * g)) - 1) 0 := by
+    have hpoly :
+        ((p * g) * (Polynomial.C (2 : R) - p * g)) - 1 =
+          -((p * g - 1) * (p * g - 1)) := by
+      rw [polynomial_C_two (R := R)]
+      ring
+    rw [hpoly]
+    simpa using hE2.neg
+  exact hpg.trans (hpgcorrection.trans (LowEq.eq_one_of_sub hmain))
+
+private lemma min_mul_two_pow_le_min_min_mul (k n fuel : Nat) :
+    Nat.min k (n * 2 ^ (fuel + 1)) ≤
+      Nat.min k (Nat.min k (2 * n) * 2 ^ fuel) := by
+  by_cases h : 2 * n < k
+  · have hmin : Nat.min k (2 * n) = 2 * n := Nat.min_eq_right (le_of_lt h)
+    rw [hmin]
+    have harith : n * 2 ^ (fuel + 1) = (2 * n) * 2 ^ fuel := by
+      rw [_root_.pow_succ]
+      ring
+    rw [← harith]
+  · have hmin : Nat.min k (2 * n) = k := Nat.min_eq_left (by omega)
+    rw [hmin]
+    have hp : 0 < 2 ^ fuel := Nat.pow_pos (a := 2) (by omega)
+    have hle : k ≤ k * 2 ^ fuel := Nat.le_mul_of_pos_right (n := k) hp
+    simp [Nat.min_eq_left hle]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma inverseModX_base_lowEq (p : Raw R)
+    (h0 : p.toPoly.coeff 0 ≠ 0) :
+    LowEq 1 (p.toPoly * (Raw.C (p.coeff 0)⁻¹).toPoly) 1 := by
+  intro i hi
+  have hi0 : i = 0 := by omega
+  subst i
+  rw [Raw.toPoly_C]
+  rw [Polynomial.coeff_mul]
+  simp [Raw.coeff_toPoly] at h0 ⊢
+  exact mul_inv_cancel₀ h0
+
+private lemma inverseModX_go_lowEq (M : MulLowContext R) (k : Nat) (p : Raw R) :
+    ∀ fuel n g,
+      LowEq n (p.toPoly * g.toPoly) 1 →
+      LowEq (Nat.min k (n * 2 ^ fuel))
+        (p.toPoly * (Raw.inverseModX.go M k p fuel n g).toPoly) 1 := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro n g h
+      unfold Raw.inverseModX.go
+      have hg :
+          LowEq (Nat.min k n) (truncate k g).toPoly g.toPoly :=
+        (toPoly_truncate_lowEq k g).of_le (Nat.min_le_left k n)
+      simpa using
+        (LowEq.mul_left p.toPoly hg).trans (h.of_le (Nat.min_le_right k n))
+  | succ fuel ih =>
+      intro n g h
+      unfold Raw.inverseModX.go
+      by_cases hkn : k ≤ n
+      · simp [hkn]
+        have hg :
+            LowEq k (truncate k g).toPoly g.toPoly :=
+          toPoly_truncate_lowEq k g
+        have hkg : LowEq k (p.toPoly * (truncate k g).toPoly) 1 :=
+          (LowEq.mul_left p.toPoly hg).trans (h.of_le hkn)
+        exact hkg.of_le (Nat.min_le_left k (n * 2 ^ (fuel + 1)))
+      · simp [hkn]
+        let next := Nat.min k (2 * n)
+        let fg := M.mulLow next p g
+        let correction := Raw.C (2 : R) - fg
+        let g' := M.mulLow next g correction
+        have hnext : next ≤ 2 * n := Nat.min_le_right k (2 * n)
+        have hfg : LowEq next fg.toPoly (p.toPoly * g.toPoly) :=
+          toPoly_mulLow_lowEq M next p g
+        have hcorrection :
+            LowEq next correction.toPoly (Polynomial.C (2 : R) - fg.toPoly) := by
+          have hpoly : correction.toPoly = Polynomial.C (2 : R) - fg.toPoly := by
+            change (Raw.C (2 : R) - fg).toPoly = Polynomial.C (2 : R) - fg.toPoly
+            rw [Raw.toPoly_sub, Raw.toPoly_C]
+          intro i hi
+          rw [hpoly]
+        have hg' :
+            LowEq next g'.toPoly (g.toPoly * correction.toPoly) :=
+          toPoly_mulLow_lowEq M next g correction
+        have hstep : LowEq next (p.toPoly * g'.toPoly) 1 :=
+          LowEq.newton_step hnext hfg hcorrection hg' h
+        exact (ih next g' hstep).of_le
+          (min_mul_two_pow_le_min_min_mul k n fuel)
+
+private lemma inverseModX_lowEq (M : MulLowContext R) (k : Nat)
+    (p : Raw R) (h0 : p.toPoly.coeff 0 ≠ 0) :
+    LowEq k (p.toPoly * (inverseModX M k p).toPoly) 1 := by
+  unfold inverseModX
+  by_cases hk : k = 0
+  · subst k
+    intro i hi
+    omega
+  · simp [hk]
+    have hbase := inverseModX_base_lowEq (R := R) p h0
+    have hgo := inverseModX_go_lowEq M k p (k + 1) 1 (Raw.C (p.coeff 0)⁻¹) hbase
+    have hkpow : k ≤ 2 ^ (k + 1) :=
+      le_trans (Nat.le_of_lt (Nat.lt_two_pow_self (n := k)))
+        (Nat.pow_le_pow_right (by omega : 0 < 2) (Nat.le_succ k))
+    have hmin : Nat.min k (2 ^ (k + 1)) = k := Nat.min_eq_left hkpow
+    simpa [hmin] using hgo
+
+omit [BEq R] [LawfulBEq R] in
+private lemma toPoly_reverse_eq_reflect (n : Nat) (p : Raw R)
+    (hdeg : p.toPoly.natDegree < n) :
+    (reverse n p).toPoly = Polynomial.reflect (n - 1) p.toPoly := by
+  ext i
+  rw [toPoly_reverse_coeff, Polynomial.coeff_reflect]
+  by_cases hi : i < n
+  · have hle : i ≤ n - 1 := by omega
+    simp [hi, Polynomial.revAt, hle]
+  · have hle : ¬i ≤ n - 1 := by omega
+    simp [hi, Polynomial.revAt, hle]
+    exact (Polynomial.coeff_eq_zero_of_natDegree_lt
+      (lt_of_lt_of_le hdeg (Nat.le_of_not_lt hi))).symm
+
+omit [BEq R] [LawfulBEq R] in
+private lemma toPoly_reverse_natDegree_le (k : Nat) (p : Raw R) :
+    (reverse k p).toPoly.natDegree ≤ k - 1 := by
+  rw [Polynomial.natDegree_le_iff_coeff_eq_zero]
+  intro N hN
+  rw [toPoly_reverse_coeff]
+  have hnot : ¬N < k := by omega
+  simp [hnot]
+
+private lemma toPoly_mulLow_natDegree_le (M : MulLowContext R) (k : Nat)
+    (p q : Raw R) :
+    (M.mulLow k p q).toPoly.natDegree ≤ k - 1 := by
+  rw [Polynomial.natDegree_le_iff_coeff_eq_zero]
+  intro N hN
+  rw [toPoly_mulLow_coeff]
+  have hnot : ¬N < k := by omega
+  simp [hnot]
+
+private lemma raw_toPoly_natDegree_lt_size_of_trim_eq (p : Raw R)
+    (htrim : p.trim = p) (hpos : 0 < p.size) :
+    p.toPoly.natDegree < p.size := by
+  simpa [htrim] using Raw.toPoly_natDegree_lt_trim_size_of_pos (R := R) p (by
+    simpa [htrim] using hpos)
+
+omit [BEq R] [LawfulBEq R] in
+private lemma toImpl_size_le_of_degree_lt (f : R[X]) (n : Nat)
+    (hdeg : f.degree < (n : WithBot Nat)) : f.toImpl.size ≤ n := by
+  rcases Raw.toImpl_elim f with ⟨_hzero, himpl⟩ | ⟨hnz, himpl⟩
+  · simp [himpl]
+  · have hdegree : f.degree = f.natDegree := Polynomial.degree_eq_natDegree hnz
+    have hnat : f.natDegree < n := by
+      rw [hdegree] at hdeg
+      exact_mod_cast hdeg
+    simp [himpl]
+    omega
+
+omit [LawfulBEq R] in
+private lemma raw_coeff_last_eq_leadingCoeff_of_trim_eq (q : Raw R)
+    (htrim : q.trim = q) (hpos : 0 < q.size) :
+    q.coeff (q.size - 1) = q.leadingCoeff := by
+  rw [Raw.leadingCoeff, htrim]
+  simp [Raw.coeff, Array.getLastD, hpos]
+
+private lemma div_step_degree_lt (p q : Raw R)
+    (hptrim : p.trim = p) (hqtrim : q.trim = q)
+    (hqmonic : q.leadingCoeff = 1) (hsize : ¬p.size < q.size) (hqpos : 0 < q.size) :
+    ((p - Raw.C p.leadingCoeff * (q * Raw.X ^ (p.size - q.size))).trim).toPoly.degree <
+      ((p.size - 1 : Nat) : WithBot Nat) := by
+  rw [Polynomial.degree_lt_iff_coeff_zero]
+  intro m hm
+  rw [Raw.toPoly_trim, Raw.coeff_toPoly, Raw.sub_coeff, Raw.coeff_C_mul_X_pow]
+  have hppos : 0 < p.size := by omega
+  have hplast : p.coeff (p.size - 1) = p.leadingCoeff :=
+    raw_coeff_last_eq_leadingCoeff_of_trim_eq p hptrim hppos
+  have hqlast : q.coeff (q.size - 1) = 1 := by
+    rw [raw_coeff_last_eq_leadingCoeff_of_trim_eq q hqtrim hqpos, hqmonic]
+  by_cases hm_top : m = p.size - 1
+  · subst m
+    have hcond :
+        p.size - q.size ≤ p.size - 1 ∧
+          p.size - 1 - (p.size - q.size) < q.size := by
+      omega
+    rw [if_pos hcond]
+    have hidx : p.size - 1 - (p.size - q.size) = q.size - 1 := by omega
+    rw [hplast, hidx, hqlast]
+    simp
+  · have hmp : p.size ≤ m := by omega
+    have hpcoeff : p.coeff m = 0 := by simp [Raw.coeff, hmp]
+    have hcond :
+        ¬(p.size - q.size ≤ m ∧ m - (p.size - q.size) < q.size) := by
+      omega
+    rw [if_neg hcond, hpcoeff]
+    simp
+
+private lemma div_step_size_lt (p q : Raw R)
+    (hptrim : p.trim = p) (hqtrim : q.trim = q)
+    (hqmonic : q.leadingCoeff = 1) (hsize : ¬p.size < q.size) (hqpos : 0 < q.size) :
+    ((p - Raw.C p.leadingCoeff * (q * Raw.X ^ (p.size - q.size))).trim).size < p.size := by
+  let p' := (p - Raw.C p.leadingCoeff * (q * Raw.X ^ (p.size - q.size))).trim
+  have hdeg : p'.toPoly.degree < ((p.size - 1 : Nat) : WithBot Nat) :=
+    div_step_degree_lt p q hptrim hqtrim hqmonic hsize hqpos
+  have hle : p'.toPoly.toImpl.size ≤ p.size - 1 :=
+    toImpl_size_le_of_degree_lt p'.toPoly (p.size - 1) hdeg
+  have hround := Raw.toImpl_toPoly (R := R) p'
+  have htrim' : p'.trim = p' := by
+    exact Trim.trim_twice _
+  have hsize' : p'.size = p'.toPoly.toImpl.size := by
+    rw [hround, htrim']
+  have hppos : 0 < p.size := by omega
+  change p'.size < p.size
+  omega
+
+omit [BEq R] [LawfulBEq R] in
+private lemma raw_toPoly_degree_lt_of_size_lt (p q : Raw R)
+    (hsize : p.size < q.size)
+    (hqdegree : q.toPoly.degree = ((q.size - 1 : Nat) : WithBot Nat)) :
+    p.toPoly.degree < q.toPoly.degree := by
+  rw [hqdegree, Polynomial.degree_lt_iff_coeff_zero]
+  intro m hm
+  rw [Raw.coeff_toPoly]
+  have hp : p.size ≤ m := by omega
+  simp [Raw.coeff, hp]
+
+private theorem raw_divModByMonicAux_go_spec (q : Raw R)
+    (hqtrim : q.trim = q) (hqmonic : q.leadingCoeff = 1) (hqpos : 0 < q.size)
+    (hqdegree : q.toPoly.degree = ((q.size - 1 : Nat) : WithBot Nat)) :
+    ∀ fuel p,
+      p.trim = p →
+      p.size ≤ fuel →
+      let qr := Raw.divModByMonicAux.go fuel p q
+      qr.2.toPoly + q.toPoly * qr.1.toPoly = p.toPoly ∧
+        qr.2.toPoly.degree < q.toPoly.degree := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro p hptrim hfuel
+      have hpzero : p.size = 0 := by omega
+      unfold Raw.divModByMonicAux.go
+      constructor
+      · rw [Raw.toPoly_zero]
+        ring
+      · exact raw_toPoly_degree_lt_of_size_lt p q (by omega) hqdegree
+  | succ fuel ih =>
+      intro p hptrim hfuel
+      unfold Raw.divModByMonicAux.go
+      by_cases hsize : p.size < q.size
+      · simp only [hsize, ↓reduceIte]
+        constructor
+        · rw [Raw.toPoly_zero]
+          ring
+        · exact raw_toPoly_degree_lt_of_size_lt p q hsize hqdegree
+      · simp [hsize]
+        let step := (p - Raw.C p.leadingCoeff * (q * Raw.X ^ (p.size - q.size))).trim
+        have hstep_size : step.size < p.size := by
+          exact div_step_size_lt p q hptrim hqtrim hqmonic hsize hqpos
+        have hstep_trim : step.trim = step := by
+          exact Trim.trim_twice _
+        have hstep_fuel : step.size ≤ fuel := by omega
+        have ihstep := ih step hstep_trim hstep_fuel
+        rcases ihstep with ⟨hrel, hdeg⟩
+        constructor
+        · change
+            (Raw.divModByMonicAux.go fuel step q).2.toPoly +
+                q.toPoly *
+                  ((Raw.divModByMonicAux.go fuel step q).1 +
+                    Raw.C p.leadingCoeff * Raw.X ^ (p.size - q.size)).toPoly =
+              p.toPoly
+          rw [Raw.toPoly_add, _root_.mul_add, ← _root_.add_assoc, hrel]
+          dsimp only [step]
+          rw [Raw.toPoly_trim, Raw.toPoly_sub, Raw.toPoly_mul, Raw.toPoly_C,
+            Raw.toPoly_mul, Raw.toPoly_pow, Raw.toPoly_X]
+          rw [Raw.toPoly_mul, Raw.toPoly_C, Raw.toPoly_pow, Raw.toPoly_X]
+          ring
+        · exact hdeg
+
+private theorem raw_modByMonic_toPoly_eq_modByMonic (p q : CPolynomial R)
+    (hmonic : (q.leadingCoeff == 1) = true) :
+    ((p.val : Raw R).modByMonic q.val).toPoly = p.toPoly %ₘ q.toPoly := by
+  have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
+  have hqLC : q.leadingCoeff = 1 := by
+    simpa using (LawfulBEq.eq_of_beq hmonic)
+  have hqrawMonic : (q.val : Raw R).leadingCoeff = 1 := by
+    simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hqLC
+  have hqpos : 0 < (q.val : Raw R).size := by
+    by_contra hpos
+    have hsize : (q.val : Raw R).size = 0 := Nat.eq_zero_of_not_pos hpos
+    have hzero : q.leadingCoeff = 0 := by
+      simp [CPolynomial.leadingCoeff, Array.getLastD, hsize]
+    have : (1 : R) = 0 := by simpa [hqLC] using hzero.symm
+    exact one_ne_zero this
+  have hqdegree : q.toPoly.degree = (((q.val : Raw R).size - 1 : Nat) : WithBot Nat) := by
+    have hdeg := degree_toPoly q
+    cases hs : (q.val : Raw R).size with
+    | zero =>
+        omega
+    | succ n =>
+        simp [CPolynomial.degree, hs] at hdeg ⊢
+        exact hdeg.symm
+  have hspec := raw_divModByMonicAux_go_spec (R := R) q.val hqtrim hqrawMonic hqpos
+    hqdegree p.val.size p.val (Trim.trim_eq_of_isCanonical p.property) (Nat.le_refl p.val.size)
+  rcases hspec with ⟨hrel, hdeg⟩
+  have hqMonicPoly : q.toPoly.Monic := by
+    rw [Polynomial.Monic.def, ← leadingCoeff_toPoly]
+    exact hqLC
+  have hunique :=
+    Polynomial.div_modByMonic_unique
+      ((Raw.divModByMonicAux p.val q.val).1.toPoly)
+      ((Raw.divModByMonicAux p.val q.val).2.toPoly)
+      hqMonicPoly ⟨hrel, hdeg⟩
+  exact hunique.2.symm
+
+private theorem reversal_remainder_toPoly_eq_modByMonic
+    (M : Raw.MulLowContext R) (p q : CPolynomial R)
+    (hmonic : (q.leadingCoeff == 1) = true)
+    (hsize : ¬p.val.size < q.val.size) :
+    (let k := p.val.size - q.val.size + 1
+     let remainderLen := q.val.size - 1
+     let revP := reverse p.val.size p.val
+     let revQ := reverse q.val.size q.val
+     let invRevQ := inverseModX M k revQ
+     let quotientRev := M.mulLow k revP invRevQ
+     let quotient := reverse k quotientRev
+     let productLow := M.mulLow remainderLen q.val quotient
+     truncate remainderLen p.val - productLow).toPoly = p.toPoly %ₘ q.toPoly := by
+  let k := p.val.size - q.val.size + 1
+  let n := q.val.size - 1
+  let m := p.val.size - 1
+  let revP := reverse p.val.size p.val
+  let revQ := reverse q.val.size q.val
+  let invRevQ := inverseModX M k revQ
+  let quotientRev := M.mulLow k revP invRevQ
+  let quotient := reverse k quotientRev
+  let productLow := M.mulLow n q.val quotient
+  let rem := truncate n p.val - productLow
+  have hptrim : (p.val : Raw R).trim = p.val := Trim.trim_eq_of_isCanonical p.property
+  have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
+  have hqLC : q.leadingCoeff = 1 := by
+    simpa using (LawfulBEq.eq_of_beq hmonic)
+  have hqrawMonic : (q.val : Raw R).leadingCoeff = 1 := by
+    simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hqLC
+  have hqpos : 0 < (q.val : Raw R).size := by
+    by_contra hpos
+    have hsizeq : (q.val : Raw R).size = 0 := Nat.eq_zero_of_not_pos hpos
+    have hzero : q.leadingCoeff = 0 := by
+      simp [CPolynomial.leadingCoeff, Array.getLastD, hsizeq]
+    have : (1 : R) = 0 := by simpa [hqLC] using hzero.symm
+    exact one_ne_zero this
+  have hppos : 0 < (p.val : Raw R).size := by omega
+  have hkpos : 0 < k := by omega
+  have hqMonicPoly : q.toPoly.Monic := by
+    rw [Polynomial.Monic.def, ← leadingCoeff_toPoly]
+    exact hqLC
+  have hqdegree : q.toPoly.degree = ((n : Nat) : WithBot Nat) := by
+    have hdeg := degree_toPoly q
+    cases hs : (q.val : Raw R).size with
+    | zero =>
+        omega
+    | succ d =>
+        simp [CPolynomial.degree, n, hs] at hdeg ⊢
+        exact hdeg.symm
+  have hqnat : q.toPoly.natDegree ≤ n := by
+    rw [Polynomial.natDegree_le_iff_degree_le, hqdegree]
+  have hpdeg_lt : (p.val : Raw R).toPoly.natDegree < p.val.size :=
+    raw_toPoly_natDegree_lt_size_of_trim_eq p.val hptrim hppos
+  have hqdeg_lt : (q.val : Raw R).toPoly.natDegree < q.val.size :=
+    raw_toPoly_natDegree_lt_size_of_trim_eq q.val hqtrim hqpos
+  have hrevP : revP.toPoly = Polynomial.reflect m p.toPoly := by
+    simpa [revP, m, CPolynomial.toPoly] using
+      toPoly_reverse_eq_reflect (R := R) p.val.size p.val hpdeg_lt
+  have hrevQ : revQ.toPoly = Polynomial.reflect n q.toPoly := by
+    simpa [revQ, n, CPolynomial.toPoly] using
+      toPoly_reverse_eq_reflect (R := R) q.val.size q.val hqdeg_lt
+  have hrevQ0 : revQ.toPoly.coeff 0 = 1 := by
+    rw [hrevQ, Polynomial.coeff_reflect]
+    have hle : 0 ≤ n := Nat.zero_le n
+    simp [Polynomial.revAt, hle, n, raw_coeff_last_eq_leadingCoeff_of_trim_eq q.val hqtrim hqpos,
+      hqrawMonic, CPolynomial.toPoly, Raw.coeff_toPoly]
+  have hinv : LowEq k (revQ.toPoly * invRevQ.toPoly) 1 :=
+    inverseModX_lowEq M k revQ (by simp [hrevQ0])
+  have hquotRevLow :
+      LowEq k quotientRev.toPoly (revP.toPoly * invRevQ.toPoly) := by
+    simpa [quotientRev] using toPoly_mulLow_lowEq M k revP invRevQ
+  have hrevProd : LowEq k (revQ.toPoly * quotientRev.toPoly) revP.toPoly := by
+    have h₁ : LowEq k (revQ.toPoly * quotientRev.toPoly)
+        (revQ.toPoly * (revP.toPoly * invRevQ.toPoly)) :=
+      LowEq.mul_left revQ.toPoly hquotRevLow
+    have h₂ : revQ.toPoly * (revP.toPoly * invRevQ.toPoly) =
+        revP.toPoly * (revQ.toPoly * invRevQ.toPoly) := by ring
+    have h₃ : LowEq k (revP.toPoly * (revQ.toPoly * invRevQ.toPoly)) revP.toPoly := by
+      simpa using LowEq.mul_left revP.toPoly hinv
+    exact h₁.trans ((by simpa [h₂] using h₃) : LowEq k
+      (revQ.toPoly * (revP.toPoly * invRevQ.toPoly)) revP.toPoly)
+  have hquotRevNat : quotientRev.toPoly.natDegree ≤ k - 1 := by
+    simpa [quotientRev] using toPoly_mulLow_natDegree_le M k revP invRevQ
+  have hquotRevDegLt : quotientRev.toPoly.natDegree < k := by omega
+  have hquotReflect : quotient.toPoly = Polynomial.reflect (k - 1) quotientRev.toPoly := by
+    simpa [quotient] using toPoly_reverse_eq_reflect (R := R) k quotientRev hquotRevDegLt
+  have hquotRevReflect : quotientRev.toPoly = Polynomial.reflect (k - 1) quotient.toPoly := by
+    rw [hquotReflect, Polynomial.reflect_reflect]
+  have hquotNat : quotient.toPoly.natDegree ≤ k - 1 := by
+    simpa [quotient] using toPoly_reverse_natDegree_le (R := R) k quotientRev
+  have hm : m = n + (k - 1) := by omega
+  have hreflectMul :
+      Polynomial.reflect m (q.toPoly * quotient.toPoly) =
+        revQ.toPoly * quotientRev.toPoly := by
+    calc
+      Polynomial.reflect m (q.toPoly * quotient.toPoly)
+          = Polynomial.reflect (n + (k - 1)) (q.toPoly * quotient.toPoly) := by rw [hm]
+      _ = Polynomial.reflect n q.toPoly * Polynomial.reflect (k - 1) quotient.toPoly := by
+          rw [Polynomial.reflect_mul q.toPoly quotient.toPoly hqnat hquotNat]
+      _ = revQ.toPoly * quotientRev.toPoly := by rw [← hrevQ, ← hquotRevReflect]
+  have hreflectHigh : LowEq k
+      (Polynomial.reflect m (q.toPoly * quotient.toPoly))
+      (Polynomial.reflect m p.toPoly) := by
+    rw [hreflectMul, ← hrevP]
+    exact hrevProd
+  have hprodNat : (q.toPoly * quotient.toPoly).natDegree ≤ m := by
+    have hmul : (q.toPoly * quotient.toPoly).natDegree ≤
+        q.toPoly.natDegree + quotient.toPoly.natDegree :=
+      Polynomial.natDegree_mul_le
+    have hsum : q.toPoly.natDegree + quotient.toPoly.natDegree ≤ n + (k - 1) :=
+      Nat.add_le_add hqnat hquotNat
+    omega
+  have hpNat : p.toPoly.natDegree < p.val.size := hpdeg_lt
+  have hremDegree : rem.toPoly.degree < q.toPoly.degree := by
+    rw [hqdegree, Polynomial.degree_lt_iff_coeff_zero]
+    intro i hi
+    dsimp only [rem, productLow]
+    rw [Raw.toPoly_sub, Polynomial.coeff_sub, toPoly_truncate_coeff, toPoly_mulLow_coeff]
+    have hnotn : ¬i < n := by exact not_lt_of_ge hi
+    simp [hnotn]
+  have hrel : rem.toPoly + q.toPoly * quotient.toPoly = p.toPoly := by
+    ext i
+    by_cases hin : i < n
+    · rw [Polynomial.coeff_add, Raw.toPoly_sub, Polynomial.coeff_sub,
+        toPoly_truncate_coeff]
+      dsimp only [productLow]
+      rw [toPoly_mulLow_coeff]
+      simp [hin, sub_eq_add_neg]
+      rw [show (p.val : Raw R).toPoly = p.toPoly by rfl,
+        show (q.val : Raw R).toPoly = q.toPoly by rfl]
+      ring
+    · have hni : n ≤ i := Nat.le_of_not_lt hin
+      by_cases him : i ≤ m
+      · let j := m - i
+        have hjk : j < k := by omega
+        have hjm : j ≤ m := by omega
+        have hij : Polynomial.revAt m j = i := by
+          simp [Polynomial.revAt, hjm, j]
+          omega
+        have hcoeff := hreflectHigh j hjk
+        rw [Polynomial.coeff_reflect, Polynomial.coeff_reflect, hij] at hcoeff
+        rw [Polynomial.coeff_add, Raw.toPoly_sub, Polynomial.coeff_sub,
+          toPoly_truncate_coeff]
+        dsimp only [productLow]
+        rw [toPoly_mulLow_coeff]
+        have hnotn : ¬i < n := not_lt_of_ge hni
+        simp [hnotn, hcoeff]
+      · have hmi : m < i := lt_of_not_ge him
+        have hpzero : p.toPoly.coeff i = 0 := by
+          exact Polynomial.coeff_eq_zero_of_natDegree_lt (lt_of_lt_of_le hpNat (by omega))
+        have hprodzero : (q.toPoly * quotient.toPoly).coeff i = 0 := by
+          exact Polynomial.coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt hprodNat hmi)
+        rw [Polynomial.coeff_add, Raw.toPoly_sub, Polynomial.coeff_sub,
+          toPoly_truncate_coeff]
+        dsimp only [productLow]
+        rw [toPoly_mulLow_coeff]
+        have hnotn : ¬i < n := not_lt_of_ge hni
+        simp [hnotn, hpzero, hprodzero]
+  have hunique :=
+    Polynomial.div_modByMonic_unique quotient.toPoly rem.toPoly hqMonicPoly ⟨hrel, hremDegree⟩
+  dsimp only [rem, productLow, quotient, quotientRev, invRevQ, revQ, revP, n, k]
+  exact hunique.2.symm
+
+/-- The reversal monic remainder agrees with the canonical monic remainder. -/
+theorem modByMonicByReversal_eq_modByMonic
+    (M : Raw.MulLowContext R) (p q : CPolynomial R) :
+    modByMonicByReversal M p q = modByMonic p q := by
+  by_cases hmonic : q.leadingCoeff == 1
+  · by_cases hsize : p.val.size < q.val.size
+    · apply CPolynomial.ext
+      have hptrim : (p.val : Raw R).trim = p.val := Trim.trim_eq_of_isCanonical p.property
+      have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
+      have hrawMonic : ((q.val : Raw R).leadingCoeff == 1) = true := by
+        simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hmonic
+      have hguard :
+          ((p.val : Raw R).trim == p.val && (q.val : Raw R).trim == q.val &&
+              (q.val : Raw R).leadingCoeff == 1) = true := by
+        simp [hptrim, hqtrim, hrawMonic]
+      unfold modByMonicByReversal CPolynomial.modByMonic
+      change (Raw.modByMonicByReversal M (p.val : Raw R) q.val).trim =
+        ((p.val : Raw R).modByMonic q.val).trim
+      unfold Raw.modByMonicByReversal
+      rw [if_pos hguard, if_pos hsize]
+      cases hp : (p.val : Raw R).size with
+      | zero =>
+          unfold Raw.modByMonic Raw.divModByMonicAux
+          rw [hp]
+          simp [Raw.divModByMonicAux.go]
+      | succ n =>
+          unfold Raw.modByMonic Raw.divModByMonicAux
+          rw [hp]
+          simp [Raw.divModByMonicAux.go, hsize, hptrim]
+    · apply CPolynomial.ext
+      have hptrim : (p.val : Raw R).trim = p.val := Trim.trim_eq_of_isCanonical p.property
+      have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
+      have hrawMonic : ((q.val : Raw R).leadingCoeff == 1) = true := by
+        simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hmonic
+      have hguard :
+          ((p.val : Raw R).trim == p.val && (q.val : Raw R).trim == q.val &&
+              (q.val : Raw R).leadingCoeff == 1) = true := by
+        simp [hptrim, hqtrim, hrawMonic]
+      unfold modByMonicByReversal CPolynomial.modByMonic
+      change (Raw.modByMonicByReversal M (p.val : Raw R) q.val).trim =
+        ((p.val : Raw R).modByMonic q.val).trim
+      unfold Raw.modByMonicByReversal
+      rw [if_pos hguard, if_neg hsize]
+      let rem : Raw R :=
+        let k := p.val.size - q.val.size + 1
+        let remainderLen := q.val.size - 1
+        let revP := reverse p.val.size p.val
+        let revQ := reverse q.val.size q.val
+        let invRevQ := inverseModX M k revQ
+        let quotientRev := M.mulLow k revP invRevQ
+        let quotient := reverse k quotientRev
+        let productLow := M.mulLow remainderLen q.val quotient
+        truncate remainderLen p.val - productLow
+      change rem.trim = ((p.val : Raw R).modByMonic q.val).trim
+      rw [← Raw.toImpl_toPoly rem,
+        ← Raw.toImpl_toPoly ((p.val : Raw R).modByMonic q.val)]
+      congr 1
+      have hremMath : rem.toPoly = p.toPoly %ₘ q.toPoly := by
+        simpa [rem] using reversal_remainder_toPoly_eq_modByMonic M p q hmonic hsize
+      have hrawMath :
+          ((p.val : Raw R).modByMonic q.val).toPoly = p.toPoly %ₘ q.toPoly :=
+        raw_modByMonic_toPoly_eq_modByMonic p q hmonic
+      exact hremMath.trans hrawMath.symm
+  · apply CPolynomial.ext
+    have hptrim : (p.val : Raw R).trim = p.val := Trim.trim_eq_of_isCanonical p.property
+    have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
+    have hrawNotMonic : ¬(((q.val : Raw R).leadingCoeff == 1) = true) := by
+      intro hraw
+      apply hmonic
+      simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hraw
+    have hguard :
+        ¬(((p.val : Raw R).trim == p.val && (q.val : Raw R).trim == q.val &&
+            (q.val : Raw R).leadingCoeff == 1) = true) := by
+      intro hguard
+      have hraw : (((q.val : Raw R).leadingCoeff == 1) = true) := by
+        simpa [hptrim, hqtrim] using hguard
+      exact hrawNotMonic hraw
+    unfold modByMonicByReversal
+    change (Raw.modByMonicByReversal M (p.val : Raw R) q.val).trim =
+      (CPolynomial.modByMonic p q).val
+    unfold Raw.modByMonicByReversal
+    rw [if_neg hguard]
+    exact congrArg Subtype.val (modByMonicRemainderOnly_eq_modByMonic p q)
+
+end Division
+
+end CPolynomial
+end CompPoly

--- a/CompPoly/Univariate/DivisionCorrectness.lean
+++ b/CompPoly/Univariate/DivisionCorrectness.lean
@@ -26,7 +26,8 @@ section Division
 
 variable [Field R] [BEq R] [LawfulBEq R]
 
-private def LowEq (k : Nat) (p q : R[X]) : Prop :=
+/-- Two polynomials agree on all coefficients below `k`. -/
+private def lowEq (k : Nat) (p q : R[X]) : Prop :=
   ∀ i, i < k → p.coeff i = q.coeff i
 
 omit [BEq R] [LawfulBEq R] in
@@ -51,61 +52,61 @@ private lemma toPoly_mulLow_coeff (M : MulLowContext R) (k : Nat)
 
 omit [BEq R] [LawfulBEq R] in
 private lemma toPoly_truncate_lowEq (k : Nat) (p : Raw R) :
-    LowEq k (truncate k p).toPoly p.toPoly := by
+    lowEq k (truncate k p).toPoly p.toPoly := by
   intro i hi
   simp [toPoly_truncate_coeff, hi]
 
 private lemma toPoly_mulLow_lowEq (M : MulLowContext R) (k : Nat)
     (p q : Raw R) :
-    LowEq k (M.mulLow k p q).toPoly (p.toPoly * q.toPoly) := by
+    lowEq k (M.mulLow k p q).toPoly (p.toPoly * q.toPoly) := by
   intro i hi
   simp [toPoly_mulLow_coeff, hi]
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.refl (k : Nat) (p : R[X]) : LowEq k p p := by
+private lemma lowEq.refl (k : Nat) (p : R[X]) : lowEq k p p := by
   intro _ _
   rfl
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.symm {k : Nat} {p q : R[X]} (h : LowEq k p q) :
-    LowEq k q p := by
+private lemma lowEq.symm {k : Nat} {p q : R[X]} (h : lowEq k p q) :
+    lowEq k q p := by
   intro i hi
   exact (h i hi).symm
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.trans {k : Nat} {p q r : R[X]} (hpq : LowEq k p q)
-    (hqr : LowEq k q r) : LowEq k p r := by
+private lemma lowEq.trans {k : Nat} {p q r : R[X]} (hpq : lowEq k p q)
+    (hqr : lowEq k q r) : lowEq k p r := by
   intro i hi
   exact (hpq i hi).trans (hqr i hi)
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.of_le {k l : Nat} {p q : R[X]} (hle : k ≤ l)
-    (h : LowEq l p q) : LowEq k p q := by
+private lemma lowEq.of_le {k l : Nat} {p q : R[X]} (hle : k ≤ l)
+    (h : lowEq l p q) : lowEq k p q := by
   intro i hi
   exact h i (lt_of_lt_of_le hi hle)
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.add {k : Nat} {p₁ p₂ q₁ q₂ : R[X]}
-    (h₁ : LowEq k p₁ q₁) (h₂ : LowEq k p₂ q₂) :
-    LowEq k (p₁ + p₂) (q₁ + q₂) := by
+private lemma lowEq.add {k : Nat} {p₁ p₂ q₁ q₂ : R[X]}
+    (h₁ : lowEq k p₁ q₁) (h₂ : lowEq k p₂ q₂) :
+    lowEq k (p₁ + p₂) (q₁ + q₂) := by
   intro i hi
   simp [h₁ i hi, h₂ i hi]
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.neg {k : Nat} {p q : R[X]} (h : LowEq k p q) :
-    LowEq k (-p) (-q) := by
+private lemma lowEq.neg {k : Nat} {p q : R[X]} (h : lowEq k p q) :
+    lowEq k (-p) (-q) := by
   intro i hi
   simp [h i hi]
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.sub {k : Nat} {p₁ p₂ q₁ q₂ : R[X]}
-    (h₁ : LowEq k p₁ q₁) (h₂ : LowEq k p₂ q₂) :
-    LowEq k (p₁ - p₂) (q₁ - q₂) := by
+private lemma lowEq.sub {k : Nat} {p₁ p₂ q₁ q₂ : R[X]}
+    (h₁ : lowEq k p₁ q₁) (h₂ : lowEq k p₂ q₂) :
+    lowEq k (p₁ - p₂) (q₁ - q₂) := by
   exact h₁.add h₂.neg
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.mul_left {k : Nat} {p q : R[X]} (r : R[X])
-    (h : LowEq k p q) : LowEq k (r * p) (r * q) := by
+private lemma lowEq.mul_left {k : Nat} {p q : R[X]} (r : R[X])
+    (h : lowEq k p q) : lowEq k (r * p) (r * q) := by
   intro i hi
   rw [Polynomial.coeff_mul, Polynomial.coeff_mul]
   apply Finset.sum_congr rfl
@@ -116,12 +117,12 @@ private lemma LowEq.mul_left {k : Nat} {p q : R[X]} (r : R[X])
   rw [h b hb]
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.mul_right {k : Nat} {p q : R[X]} (r : R[X])
-    (h : LowEq k p q) : LowEq k (p * r) (q * r) := by
+private lemma lowEq.mul_right {k : Nat} {p q : R[X]} (r : R[X])
+    (h : lowEq k p q) : lowEq k (p * r) (q * r) := by
   intro i hi
   calc
     (p * r).coeff i = (r * p).coeff i := by rw [_root_.mul_comm p r]
-    _ = (r * q).coeff i := LowEq.mul_left (k := k) (p := p) (q := q) r h i hi
+    _ = (r * q).coeff i := lowEq.mul_left (k := k) (p := p) (q := q) r h i hi
     _ = (q * r).coeff i := by rw [_root_.mul_comm q r]
 
 omit [BEq R] [LawfulBEq R] in
@@ -129,14 +130,14 @@ private lemma polynomial_C_two : Polynomial.C (2 : R) = (2 : R[X]) := by
   exact Polynomial.C_eq_natCast 2
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.eq_one_of_sub {k : Nat} {p : R[X]}
-    (h : LowEq k (p - 1) 0) : LowEq k p 1 := by
+private lemma lowEq.eq_one_of_sub {k : Nat} {p : R[X]}
+    (h : lowEq k (p - 1) 0) : lowEq k p 1 := by
   intro i hi
   exact sub_eq_zero.mp (by simpa [Polynomial.coeff_sub] using h i hi)
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.mul_self_zero {n : Nat} {p : R[X]}
-    (h : LowEq n p 0) : LowEq (2 * n) (p * p) 0 := by
+private lemma lowEq.mul_self_zero {n : Nat} {p : R[X]}
+    (h : lowEq n p 0) : lowEq (2 * n) (p * p) 0 := by
   intro i hi
   rw [Polynomial.coeff_mul]
   apply Finset.sum_eq_zero
@@ -151,40 +152,40 @@ private lemma LowEq.mul_self_zero {n : Nat} {p : R[X]}
     simp
 
 omit [BEq R] [LawfulBEq R] in
-private lemma LowEq.newton_step {n next : Nat} {p g fg correction g' : R[X]}
+private lemma lowEq.newton_step {n next : Nat} {p g fg correction g' : R[X]}
     (hnext : next ≤ 2 * n)
-    (hfg : LowEq next fg (p * g))
-    (hcorrection : LowEq next correction (Polynomial.C (2 : R) - fg))
-    (hg' : LowEq next g' (g * correction))
-    (h : LowEq n (p * g) 1) :
-    LowEq next (p * g') 1 := by
-  have hpg : LowEq next (p * g') (p * (g * correction)) :=
-    LowEq.mul_left p hg'
-  have hcorrection' : LowEq next correction (Polynomial.C (2 : R) - p * g) := by
+    (hfg : lowEq next fg (p * g))
+    (hcorrection : lowEq next correction (Polynomial.C (2 : R) - fg))
+    (hg' : lowEq next g' (g * correction))
+    (h : lowEq n (p * g) 1) :
+    lowEq next (p * g') 1 := by
+  have hpg : lowEq next (p * g') (p * (g * correction)) :=
+    lowEq.mul_left p hg'
+  have hcorrection' : lowEq next correction (Polynomial.C (2 : R) - p * g) := by
     intro i hi
     have h1 := hcorrection i hi
     have h2 := hfg i hi
     simp [h1, h2]
   have hpgcorrection :
-      LowEq next (p * (g * correction)) ((p * g) * (Polynomial.C (2 : R) - p * g)) := by
+      lowEq next (p * (g * correction)) ((p * g) * (Polynomial.C (2 : R) - p * g)) := by
     intro i hi
     rw [← _root_.mul_assoc p g correction]
-    exact LowEq.mul_left (p * g) hcorrection' i hi
-  have hE : LowEq n (p * g - 1) 0 := by
+    exact lowEq.mul_left (p * g) hcorrection' i hi
+  have h_e : lowEq n (p * g - 1) 0 := by
     intro i hi
     have hcoeff := h i hi
     simp [Polynomial.coeff_sub, hcoeff]
-  have hE2 : LowEq next ((p * g - 1) * (p * g - 1)) 0 := by
-    exact (LowEq.mul_self_zero hE).of_le hnext
-  have hmain : LowEq next (((p * g) * (Polynomial.C (2 : R) - p * g)) - 1) 0 := by
+  have h_e2 : lowEq next ((p * g - 1) * (p * g - 1)) 0 := by
+    exact (lowEq.mul_self_zero h_e).of_le hnext
+  have hmain : lowEq next (((p * g) * (Polynomial.C (2 : R) - p * g)) - 1) 0 := by
     have hpoly :
         ((p * g) * (Polynomial.C (2 : R) - p * g)) - 1 =
           -((p * g - 1) * (p * g - 1)) := by
       rw [polynomial_C_two (R := R)]
       ring
     rw [hpoly]
-    simpa using hE2.neg
-  exact hpg.trans (hpgcorrection.trans (LowEq.eq_one_of_sub hmain))
+    simpa using h_e2.neg
+  exact hpg.trans (hpgcorrection.trans (lowEq.eq_one_of_sub hmain))
 
 private lemma min_mul_two_pow_le_min_min_mul (k n fuel : Nat) :
     Nat.min k (n * 2 ^ (fuel + 1)) ≤
@@ -205,7 +206,7 @@ private lemma min_mul_two_pow_le_min_min_mul (k n fuel : Nat) :
 omit [BEq R] [LawfulBEq R] in
 private lemma inverseModX_base_lowEq (p : Raw R)
     (h0 : p.toPoly.coeff 0 ≠ 0) :
-    LowEq 1 (p.toPoly * (Raw.C (p.coeff 0)⁻¹).toPoly) 1 := by
+    lowEq 1 (p.toPoly * (Raw.C (p.coeff 0)⁻¹).toPoly) 1 := by
   intro i hi
   have hi0 : i = 0 := by omega
   subst i
@@ -216,8 +217,8 @@ private lemma inverseModX_base_lowEq (p : Raw R)
 
 private lemma inverseModX_go_lowEq (M : MulLowContext R) (k : Nat) (p : Raw R) :
     ∀ fuel n g,
-      LowEq n (p.toPoly * g.toPoly) 1 →
-      LowEq (Nat.min k (n * 2 ^ fuel))
+      lowEq n (p.toPoly * g.toPoly) 1 →
+      lowEq (Nat.min k (n * 2 ^ fuel))
         (p.toPoly * (Raw.inverseModX.go M k p fuel n g).toPoly) 1 := by
   intro fuel
   induction fuel with
@@ -225,20 +226,20 @@ private lemma inverseModX_go_lowEq (M : MulLowContext R) (k : Nat) (p : Raw R) :
       intro n g h
       unfold Raw.inverseModX.go
       have hg :
-          LowEq (Nat.min k n) (truncate k g).toPoly g.toPoly :=
+          lowEq (Nat.min k n) (truncate k g).toPoly g.toPoly :=
         (toPoly_truncate_lowEq k g).of_le (Nat.min_le_left k n)
       simpa using
-        (LowEq.mul_left p.toPoly hg).trans (h.of_le (Nat.min_le_right k n))
+        (lowEq.mul_left p.toPoly hg).trans (h.of_le (Nat.min_le_right k n))
   | succ fuel ih =>
       intro n g h
       unfold Raw.inverseModX.go
       by_cases hkn : k ≤ n
       · simp [hkn]
         have hg :
-            LowEq k (truncate k g).toPoly g.toPoly :=
+            lowEq k (truncate k g).toPoly g.toPoly :=
           toPoly_truncate_lowEq k g
-        have hkg : LowEq k (p.toPoly * (truncate k g).toPoly) 1 :=
-          (LowEq.mul_left p.toPoly hg).trans (h.of_le hkn)
+        have hkg : lowEq k (p.toPoly * (truncate k g).toPoly) 1 :=
+          (lowEq.mul_left p.toPoly hg).trans (h.of_le hkn)
         exact hkg.of_le (Nat.min_le_left k (n * 2 ^ (fuel + 1)))
       · simp [hkn]
         let next := Nat.min k (2 * n)
@@ -246,26 +247,26 @@ private lemma inverseModX_go_lowEq (M : MulLowContext R) (k : Nat) (p : Raw R) :
         let correction := Raw.C (2 : R) - fg
         let g' := M.mulLow next g correction
         have hnext : next ≤ 2 * n := Nat.min_le_right k (2 * n)
-        have hfg : LowEq next fg.toPoly (p.toPoly * g.toPoly) :=
+        have hfg : lowEq next fg.toPoly (p.toPoly * g.toPoly) :=
           toPoly_mulLow_lowEq M next p g
         have hcorrection :
-            LowEq next correction.toPoly (Polynomial.C (2 : R) - fg.toPoly) := by
+            lowEq next correction.toPoly (Polynomial.C (2 : R) - fg.toPoly) := by
           have hpoly : correction.toPoly = Polynomial.C (2 : R) - fg.toPoly := by
             change (Raw.C (2 : R) - fg).toPoly = Polynomial.C (2 : R) - fg.toPoly
             rw [Raw.toPoly_sub, Raw.toPoly_C]
           intro i hi
           rw [hpoly]
         have hg' :
-            LowEq next g'.toPoly (g.toPoly * correction.toPoly) :=
+            lowEq next g'.toPoly (g.toPoly * correction.toPoly) :=
           toPoly_mulLow_lowEq M next g correction
-        have hstep : LowEq next (p.toPoly * g'.toPoly) 1 :=
-          LowEq.newton_step hnext hfg hcorrection hg' h
+        have hstep : lowEq next (p.toPoly * g'.toPoly) 1 :=
+          lowEq.newton_step hnext hfg hcorrection hg' h
         exact (ih next g' hstep).of_le
           (min_mul_two_pow_le_min_min_mul k n fuel)
 
 private lemma inverseModX_lowEq (M : MulLowContext R) (k : Nat)
     (p : Raw R) (h0 : p.toPoly.coeff 0 ≠ 0) :
-    LowEq k (p.toPoly * (inverseModX M k p).toPoly) 1 := by
+    lowEq k (p.toPoly * (inverseModX M k p).toPoly) 1 := by
   unfold inverseModX
   by_cases hk : k = 0
   · subst k
@@ -298,18 +299,18 @@ omit [BEq R] [LawfulBEq R] in
 private lemma toPoly_reverse_natDegree_le (k : Nat) (p : Raw R) :
     (reverse k p).toPoly.natDegree ≤ k - 1 := by
   rw [Polynomial.natDegree_le_iff_coeff_eq_zero]
-  intro N hN
+  intro i hi
   rw [toPoly_reverse_coeff]
-  have hnot : ¬N < k := by omega
+  have hnot : ¬i < k := by omega
   simp [hnot]
 
 private lemma toPoly_mulLow_natDegree_le (M : MulLowContext R) (k : Nat)
     (p q : Raw R) :
     (M.mulLow k p q).toPoly.natDegree ≤ k - 1 := by
   rw [Polynomial.natDegree_le_iff_coeff_eq_zero]
-  intro N hN
+  intro i hi
   rw [toPoly_mulLow_coeff]
-  have hnot : ¬N < k := by omega
+  have hnot : ¬i < k := by omega
   simp [hnot]
 
 private lemma raw_toPoly_natDegree_lt_size_of_trim_eq (p : Raw R)
@@ -453,16 +454,16 @@ private theorem raw_modByMonic_toPoly_eq_modByMonic (p q : CPolynomial R)
     (hmonic : (q.leadingCoeff == 1) = true) :
     ((p.val : Raw R).modByMonic q.val).toPoly = p.toPoly %ₘ q.toPoly := by
   have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
-  have hqLC : q.leadingCoeff = 1 := by
+  have hq_lc : q.leadingCoeff = 1 := by
     simpa using (LawfulBEq.eq_of_beq hmonic)
-  have hqrawMonic : (q.val : Raw R).leadingCoeff = 1 := by
-    simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hqLC
+  have hq_raw_monic : (q.val : Raw R).leadingCoeff = 1 := by
+    simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hq_lc
   have hqpos : 0 < (q.val : Raw R).size := by
     by_contra hpos
     have hsize : (q.val : Raw R).size = 0 := Nat.eq_zero_of_not_pos hpos
     have hzero : q.leadingCoeff = 0 := by
       simp [CPolynomial.leadingCoeff, Array.getLastD, hsize]
-    have : (1 : R) = 0 := by simpa [hqLC] using hzero.symm
+    have : (1 : R) = 0 := by simpa [hq_lc] using hzero.symm
     exact one_ne_zero this
   have hqdegree : q.toPoly.degree = (((q.val : Raw R).size - 1 : Nat) : WithBot Nat) := by
     have hdeg := degree_toPoly q
@@ -472,17 +473,17 @@ private theorem raw_modByMonic_toPoly_eq_modByMonic (p q : CPolynomial R)
     | succ n =>
         simp [CPolynomial.degree, hs] at hdeg ⊢
         exact hdeg.symm
-  have hspec := raw_divModByMonicAux_go_spec (R := R) q.val hqtrim hqrawMonic hqpos
+  have hspec := raw_divModByMonicAux_go_spec (R := R) q.val hqtrim hq_raw_monic hqpos
     hqdegree p.val.size p.val (Trim.trim_eq_of_isCanonical p.property) (Nat.le_refl p.val.size)
   rcases hspec with ⟨hrel, hdeg⟩
-  have hqMonicPoly : q.toPoly.Monic := by
+  have hq_monic_poly : q.toPoly.Monic := by
     rw [Polynomial.Monic.def, ← leadingCoeff_toPoly]
-    exact hqLC
+    exact hq_lc
   have hunique :=
     Polynomial.div_modByMonic_unique
       ((Raw.divModByMonicAux p.val q.val).1.toPoly)
       ((Raw.divModByMonicAux p.val q.val).2.toPoly)
-      hqMonicPoly ⟨hrel, hdeg⟩
+      hq_monic_poly ⟨hrel, hdeg⟩
   exact hunique.2.symm
 
 private theorem reversal_remainder_toPoly_eq_modByMonic
@@ -510,22 +511,22 @@ private theorem reversal_remainder_toPoly_eq_modByMonic
   let rem := truncate n p.val - productLow
   have hptrim : (p.val : Raw R).trim = p.val := Trim.trim_eq_of_isCanonical p.property
   have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
-  have hqLC : q.leadingCoeff = 1 := by
+  have hq_lc : q.leadingCoeff = 1 := by
     simpa using (LawfulBEq.eq_of_beq hmonic)
-  have hqrawMonic : (q.val : Raw R).leadingCoeff = 1 := by
-    simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hqLC
+  have hq_raw_monic : (q.val : Raw R).leadingCoeff = 1 := by
+    simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hq_lc
   have hqpos : 0 < (q.val : Raw R).size := by
     by_contra hpos
     have hsizeq : (q.val : Raw R).size = 0 := Nat.eq_zero_of_not_pos hpos
     have hzero : q.leadingCoeff = 0 := by
       simp [CPolynomial.leadingCoeff, Array.getLastD, hsizeq]
-    have : (1 : R) = 0 := by simpa [hqLC] using hzero.symm
+    have : (1 : R) = 0 := by simpa [hq_lc] using hzero.symm
     exact one_ne_zero this
   have hppos : 0 < (p.val : Raw R).size := by omega
   have hkpos : 0 < k := by omega
-  have hqMonicPoly : q.toPoly.Monic := by
+  have hq_monic_poly : q.toPoly.Monic := by
     rw [Polynomial.Monic.def, ← leadingCoeff_toPoly]
-    exact hqLC
+    exact hq_lc
   have hqdegree : q.toPoly.degree = ((n : Nat) : WithBot Nat) := by
     have hdeg := degree_toPoly q
     cases hs : (q.val : Raw R).size with
@@ -540,65 +541,66 @@ private theorem reversal_remainder_toPoly_eq_modByMonic
     raw_toPoly_natDegree_lt_size_of_trim_eq p.val hptrim hppos
   have hqdeg_lt : (q.val : Raw R).toPoly.natDegree < q.val.size :=
     raw_toPoly_natDegree_lt_size_of_trim_eq q.val hqtrim hqpos
-  have hrevP : revP.toPoly = Polynomial.reflect m p.toPoly := by
+  have h_revP : revP.toPoly = Polynomial.reflect m p.toPoly := by
     simpa [revP, m, CPolynomial.toPoly] using
       toPoly_reverse_eq_reflect (R := R) p.val.size p.val hpdeg_lt
-  have hrevQ : revQ.toPoly = Polynomial.reflect n q.toPoly := by
+  have h_revQ : revQ.toPoly = Polynomial.reflect n q.toPoly := by
     simpa [revQ, n, CPolynomial.toPoly] using
       toPoly_reverse_eq_reflect (R := R) q.val.size q.val hqdeg_lt
-  have hrevQ0 : revQ.toPoly.coeff 0 = 1 := by
-    rw [hrevQ, Polynomial.coeff_reflect]
+  have h_revQ0 : revQ.toPoly.coeff 0 = 1 := by
+    rw [h_revQ, Polynomial.coeff_reflect]
     have hle : 0 ≤ n := Nat.zero_le n
     simp [Polynomial.revAt, hle, n, raw_coeff_last_eq_leadingCoeff_of_trim_eq q.val hqtrim hqpos,
-      hqrawMonic, CPolynomial.toPoly, Raw.coeff_toPoly]
-  have hinv : LowEq k (revQ.toPoly * invRevQ.toPoly) 1 :=
-    inverseModX_lowEq M k revQ (by simp [hrevQ0])
-  have hquotRevLow :
-      LowEq k quotientRev.toPoly (revP.toPoly * invRevQ.toPoly) := by
+      hq_raw_monic, CPolynomial.toPoly, Raw.coeff_toPoly]
+  have hinv : lowEq k (revQ.toPoly * invRevQ.toPoly) 1 :=
+    inverseModX_lowEq M k revQ (by simp [h_revQ0])
+  have h_quotientRevLow :
+      lowEq k quotientRev.toPoly (revP.toPoly * invRevQ.toPoly) := by
     simpa [quotientRev] using toPoly_mulLow_lowEq M k revP invRevQ
-  have hrevProd : LowEq k (revQ.toPoly * quotientRev.toPoly) revP.toPoly := by
-    have h₁ : LowEq k (revQ.toPoly * quotientRev.toPoly)
+  have h_rev_prod : lowEq k (revQ.toPoly * quotientRev.toPoly) revP.toPoly := by
+    have h₁ : lowEq k (revQ.toPoly * quotientRev.toPoly)
         (revQ.toPoly * (revP.toPoly * invRevQ.toPoly)) :=
-      LowEq.mul_left revQ.toPoly hquotRevLow
+      lowEq.mul_left revQ.toPoly h_quotientRevLow
     have h₂ : revQ.toPoly * (revP.toPoly * invRevQ.toPoly) =
         revP.toPoly * (revQ.toPoly * invRevQ.toPoly) := by ring
-    have h₃ : LowEq k (revP.toPoly * (revQ.toPoly * invRevQ.toPoly)) revP.toPoly := by
-      simpa using LowEq.mul_left revP.toPoly hinv
-    exact h₁.trans ((by simpa [h₂] using h₃) : LowEq k
+    have h₃ : lowEq k (revP.toPoly * (revQ.toPoly * invRevQ.toPoly)) revP.toPoly := by
+      simpa using lowEq.mul_left revP.toPoly hinv
+    exact h₁.trans ((by simpa [h₂] using h₃) : lowEq k
       (revQ.toPoly * (revP.toPoly * invRevQ.toPoly)) revP.toPoly)
-  have hquotRevNat : quotientRev.toPoly.natDegree ≤ k - 1 := by
+  have h_quotientRevNat : quotientRev.toPoly.natDegree ≤ k - 1 := by
     simpa [quotientRev] using toPoly_mulLow_natDegree_le M k revP invRevQ
-  have hquotRevDegLt : quotientRev.toPoly.natDegree < k := by omega
-  have hquotReflect : quotient.toPoly = Polynomial.reflect (k - 1) quotientRev.toPoly := by
-    simpa [quotient] using toPoly_reverse_eq_reflect (R := R) k quotientRev hquotRevDegLt
-  have hquotRevReflect : quotientRev.toPoly = Polynomial.reflect (k - 1) quotient.toPoly := by
-    rw [hquotReflect, Polynomial.reflect_reflect]
-  have hquotNat : quotient.toPoly.natDegree ≤ k - 1 := by
+  have h_quotientRevDegreeLt : quotientRev.toPoly.natDegree < k := by omega
+  have h_quotientReflect : quotient.toPoly = Polynomial.reflect (k - 1) quotientRev.toPoly := by
+    simpa [quotient] using
+      toPoly_reverse_eq_reflect (R := R) k quotientRev h_quotientRevDegreeLt
+  have h_quotientRevReflect : quotientRev.toPoly = Polynomial.reflect (k - 1) quotient.toPoly := by
+    rw [h_quotientReflect, Polynomial.reflect_reflect]
+  have h_quotientNat : quotient.toPoly.natDegree ≤ k - 1 := by
     simpa [quotient] using toPoly_reverse_natDegree_le (R := R) k quotientRev
   have hm : m = n + (k - 1) := by omega
-  have hreflectMul :
+  have h_reflect_mul :
       Polynomial.reflect m (q.toPoly * quotient.toPoly) =
         revQ.toPoly * quotientRev.toPoly := by
     calc
       Polynomial.reflect m (q.toPoly * quotient.toPoly)
           = Polynomial.reflect (n + (k - 1)) (q.toPoly * quotient.toPoly) := by rw [hm]
       _ = Polynomial.reflect n q.toPoly * Polynomial.reflect (k - 1) quotient.toPoly := by
-          rw [Polynomial.reflect_mul q.toPoly quotient.toPoly hqnat hquotNat]
-      _ = revQ.toPoly * quotientRev.toPoly := by rw [← hrevQ, ← hquotRevReflect]
-  have hreflectHigh : LowEq k
+          rw [Polynomial.reflect_mul q.toPoly quotient.toPoly hqnat h_quotientNat]
+      _ = revQ.toPoly * quotientRev.toPoly := by rw [← h_revQ, ← h_quotientRevReflect]
+  have h_reflect_high : lowEq k
       (Polynomial.reflect m (q.toPoly * quotient.toPoly))
       (Polynomial.reflect m p.toPoly) := by
-    rw [hreflectMul, ← hrevP]
-    exact hrevProd
-  have hprodNat : (q.toPoly * quotient.toPoly).natDegree ≤ m := by
+    rw [h_reflect_mul, ← h_revP]
+    exact h_rev_prod
+  have h_prod_nat : (q.toPoly * quotient.toPoly).natDegree ≤ m := by
     have hmul : (q.toPoly * quotient.toPoly).natDegree ≤
         q.toPoly.natDegree + quotient.toPoly.natDegree :=
       Polynomial.natDegree_mul_le
     have hsum : q.toPoly.natDegree + quotient.toPoly.natDegree ≤ n + (k - 1) :=
-      Nat.add_le_add hqnat hquotNat
+      Nat.add_le_add hqnat h_quotientNat
     omega
-  have hpNat : p.toPoly.natDegree < p.val.size := hpdeg_lt
-  have hremDegree : rem.toPoly.degree < q.toPoly.degree := by
+  have hp_nat : p.toPoly.natDegree < p.val.size := hpdeg_lt
+  have h_remDegree : rem.toPoly.degree < q.toPoly.degree := by
     rw [hqdegree, Polynomial.degree_lt_iff_coeff_zero]
     intro i hi
     dsimp only [rem, productLow]
@@ -624,7 +626,7 @@ private theorem reversal_remainder_toPoly_eq_modByMonic
         have hij : Polynomial.revAt m j = i := by
           simp [Polynomial.revAt, hjm, j]
           omega
-        have hcoeff := hreflectHigh j hjk
+        have hcoeff := h_reflect_high j hjk
         rw [Polynomial.coeff_reflect, Polynomial.coeff_reflect, hij] at hcoeff
         rw [Polynomial.coeff_add, Raw.toPoly_sub, Polynomial.coeff_sub,
           toPoly_truncate_coeff]
@@ -634,9 +636,9 @@ private theorem reversal_remainder_toPoly_eq_modByMonic
         simp [hnotn, hcoeff]
       · have hmi : m < i := lt_of_not_ge him
         have hpzero : p.toPoly.coeff i = 0 := by
-          exact Polynomial.coeff_eq_zero_of_natDegree_lt (lt_of_lt_of_le hpNat (by omega))
+          exact Polynomial.coeff_eq_zero_of_natDegree_lt (lt_of_lt_of_le hp_nat (by omega))
         have hprodzero : (q.toPoly * quotient.toPoly).coeff i = 0 := by
-          exact Polynomial.coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt hprodNat hmi)
+          exact Polynomial.coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt h_prod_nat hmi)
         rw [Polynomial.coeff_add, Raw.toPoly_sub, Polynomial.coeff_sub,
           toPoly_truncate_coeff]
         dsimp only [productLow]
@@ -644,7 +646,7 @@ private theorem reversal_remainder_toPoly_eq_modByMonic
         have hnotn : ¬i < n := not_lt_of_ge hni
         simp [hnotn, hpzero, hprodzero]
   have hunique :=
-    Polynomial.div_modByMonic_unique quotient.toPoly rem.toPoly hqMonicPoly ⟨hrel, hremDegree⟩
+    Polynomial.div_modByMonic_unique quotient.toPoly rem.toPoly hq_monic_poly ⟨hrel, h_remDegree⟩
   dsimp only [rem, productLow, quotient, quotientRev, invRevQ, revQ, revP, n, k]
   exact hunique.2.symm
 
@@ -657,12 +659,12 @@ theorem modByMonicByReversal_eq_modByMonic
     · apply CPolynomial.ext
       have hptrim : (p.val : Raw R).trim = p.val := Trim.trim_eq_of_isCanonical p.property
       have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
-      have hrawMonic : ((q.val : Raw R).leadingCoeff == 1) = true := by
+      have h_raw_monic : ((q.val : Raw R).leadingCoeff == 1) = true := by
         simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hmonic
       have hguard :
           ((p.val : Raw R).trim == p.val && (q.val : Raw R).trim == q.val &&
               (q.val : Raw R).leadingCoeff == 1) = true := by
-        simp [hptrim, hqtrim, hrawMonic]
+        simp [hptrim, hqtrim, h_raw_monic]
       unfold modByMonicByReversal CPolynomial.modByMonic
       change (Raw.modByMonicByReversal M (p.val : Raw R) q.val).trim =
         ((p.val : Raw R).modByMonic q.val).trim
@@ -680,12 +682,12 @@ theorem modByMonicByReversal_eq_modByMonic
     · apply CPolynomial.ext
       have hptrim : (p.val : Raw R).trim = p.val := Trim.trim_eq_of_isCanonical p.property
       have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
-      have hrawMonic : ((q.val : Raw R).leadingCoeff == 1) = true := by
+      have h_raw_monic : ((q.val : Raw R).leadingCoeff == 1) = true := by
         simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hmonic
       have hguard :
           ((p.val : Raw R).trim == p.val && (q.val : Raw R).trim == q.val &&
               (q.val : Raw R).leadingCoeff == 1) = true := by
-        simp [hptrim, hqtrim, hrawMonic]
+        simp [hptrim, hqtrim, h_raw_monic]
       unfold modByMonicByReversal CPolynomial.modByMonic
       change (Raw.modByMonicByReversal M (p.val : Raw R) q.val).trim =
         ((p.val : Raw R).modByMonic q.val).trim
@@ -705,16 +707,16 @@ theorem modByMonicByReversal_eq_modByMonic
       rw [← Raw.toImpl_toPoly rem,
         ← Raw.toImpl_toPoly ((p.val : Raw R).modByMonic q.val)]
       congr 1
-      have hremMath : rem.toPoly = p.toPoly %ₘ q.toPoly := by
+      have h_remMath : rem.toPoly = p.toPoly %ₘ q.toPoly := by
         simpa [rem] using reversal_remainder_toPoly_eq_modByMonic M p q hmonic hsize
-      have hrawMath :
+      have h_raw_math :
           ((p.val : Raw R).modByMonic q.val).toPoly = p.toPoly %ₘ q.toPoly :=
         raw_modByMonic_toPoly_eq_modByMonic p q hmonic
-      exact hremMath.trans hrawMath.symm
+      exact h_remMath.trans h_raw_math.symm
   · apply CPolynomial.ext
     have hptrim : (p.val : Raw R).trim = p.val := Trim.trim_eq_of_isCanonical p.property
     have hqtrim : (q.val : Raw R).trim = q.val := Trim.trim_eq_of_isCanonical q.property
-    have hrawNotMonic : ¬(((q.val : Raw R).leadingCoeff == 1) = true) := by
+    have h_raw_not_monic : ¬(((q.val : Raw R).leadingCoeff == 1) = true) := by
       intro hraw
       apply hmonic
       simpa [Raw.leadingCoeff, CPolynomial.leadingCoeff, hqtrim] using hraw
@@ -724,7 +726,7 @@ theorem modByMonicByReversal_eq_modByMonic
       intro hguard
       have hraw : (((q.val : Raw R).leadingCoeff == 1) = true) := by
         simpa [hptrim, hqtrim] using hguard
-      exact hrawNotMonic hraw
+      exact h_raw_not_monic hraw
     unfold modByMonicByReversal
     change (Raw.modByMonicByReversal M (p.val : Raw R) q.val).trim =
       (CPolynomial.modByMonic p q).val

--- a/CompPoly/Univariate/NTT/FastMul.lean
+++ b/CompPoly/Univariate/NTT/FastMul.lean
@@ -464,5 +464,98 @@ end RawMul
 
 end FastMul
 end NTT
+
+namespace Raw.MulLowContext
+
+variable {R : Type*} [Field R] [BEq R] [LawfulBEq R]
+
+omit [BEq R] [LawfulBEq R] in
+private theorem truncate_coeff_of_lt (k : Nat) (p : CPolynomial.Raw R) {i : Nat}
+    (hi : i < k) : (CPolynomial.Raw.truncate k p).coeff i = p.coeff i := by
+  simp [CPolynomial.Raw.truncate, CPolynomial.Raw.coeff, Array.getElem?_extract, hi]
+  by_cases hp : i < p.size
+  · simp [hp]
+  · simp [hp]
+
+private theorem mul_truncate_inputs_coeff_of_lt (k : Nat) (p q : CPolynomial.Raw R)
+    {i : Nat} (hi : i < k) :
+    ((CPolynomial.Raw.truncate k p) * (CPolynomial.Raw.truncate k q)).coeff i =
+      (p * q).coeff i := by
+  rw [CPolynomial.Raw.mul_coeff, CPolynomial.Raw.mul_coeff]
+  apply Finset.sum_congr rfl
+  intro j hj
+  have hjlt : j < i + 1 := Finset.mem_range.mp hj
+  have hjle : j ≤ i := Nat.le_of_lt_succ hjlt
+  have hjk : j < k := Nat.lt_of_le_of_lt hjle hi
+  have hik : i - j < k := Nat.lt_of_le_of_lt (Nat.sub_le i j) hi
+  rw [truncate_coeff_of_lt k p hjk, truncate_coeff_of_lt k q hik]
+
+private def nttTruncateMulLow
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (NTT.FittingDomain R requiredLen))
+    (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
+  match bestDomainForLength?
+      (NTT.Domain.requiredLength (CPolynomial.Raw.truncate k p) (CPolynomial.Raw.truncate k q)) with
+  | some ⟨D, _⟩ =>
+      CPolynomial.Raw.truncate k
+        (NTT.FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
+          (CPolynomial.Raw.truncate k q))
+  | none =>
+      (direct (R := R)).mulLow k p q
+
+/--
+NTT-backed low-product backend.
+
+This truncates both inputs to the requested output precision, multiplies them
+with the smallest fitting NTT domain when one is available, and truncates the
+result back to the requested precision. If the domain table cannot cover the
+requested product length, it falls back to the direct low-convolution backend.
+-/
+def nttTruncate
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (NTT.FittingDomain R requiredLen)) :
+    CPolynomial.Raw.MulLowContext R where
+  mulLow := nttTruncateMulLow bestDomainForLength?
+  size_le := by
+    intro k p q
+    unfold nttTruncateMulLow
+    cases hdomain :
+        bestDomainForLength?
+          (NTT.Domain.requiredLength (CPolynomial.Raw.truncate k p)
+            (CPolynomial.Raw.truncate k q)) with
+    | none =>
+        simpa [hdomain] using (direct (R := R)).size_le k p q
+    | some fitted =>
+        rcases fitted with ⟨D, hfit⟩
+        simp [CPolynomial.Raw.truncate]
+  coeff_of_lt := by
+    intro k p q i hi
+    unfold nttTruncateMulLow
+    cases hdomain :
+        bestDomainForLength?
+          (NTT.Domain.requiredLength (CPolynomial.Raw.truncate k p)
+            (CPolynomial.Raw.truncate k q)) with
+    | none =>
+        simpa [hdomain] using (direct (R := R)).coeff_of_lt k p q i hi
+    | some fitted =>
+        rcases fitted with ⟨D, hfit⟩
+        rw [truncate_coeff_of_lt]
+        · have hfast :
+              (NTT.FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
+                (CPolynomial.Raw.truncate k q)).coeff i =
+              ((CPolynomial.Raw.truncate k p) * (CPolynomial.Raw.truncate k q)).coeff i := by
+            rw [← CPolynomial.Raw.Trim.coeff_eq_coeff
+              (NTT.FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
+                (CPolynomial.Raw.truncate k q)) i]
+            have htrim := NTT.FastMul.Raw.fastMulImpl_trim_eq_mul D
+              (CPolynomial.Raw.truncate k p) (CPolynomial.Raw.truncate k q)
+              (by
+                simpa [NTT.Domain.fits] using hfit)
+            rw [htrim]
+          exact hfast.trans (mul_truncate_inputs_coeff_of_lt k p q hi)
+        · exact hi
+
+end Raw.MulLowContext
+
 end CPolynomial
 end CompPoly

--- a/CompPoly/Univariate/NTT/FastMul.lean
+++ b/CompPoly/Univariate/NTT/FastMul.lean
@@ -460,102 +460,41 @@ theorem safeFastMul_eq_mul (D : Domain R) (p q : CPolynomial R)
     (hfit : Domain.fits D p.val q.val) : safeFastMul D p q hfit = p * q := by
   exact fastMulImpl_eq_mul D p q hfit
 
+/--
+NTT-backed multiplication with canonical multiplication as a fallback.
+
+The selector should return a domain fitting the required convolution length.
+When it does, this uses `fastMulImpl`; otherwise it falls back to canonical
+`CPolynomial` multiplication.
+-/
+@[inline] def withFallback
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (FittingDomain R requiredLen))
+    (p q : CPolynomial R) : CPolynomial R :=
+  let requiredLen := Domain.requiredLength p.val q.val
+  match bestDomainForLength? requiredLen with
+  | some ⟨D, _⟩ => fastMulImpl D p q
+  | none => p * q
+
+/-- `withFallback` agrees with canonical polynomial multiplication. -/
+theorem withFallback_eq_mul
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (FittingDomain R requiredLen))
+    (p q : CPolynomial R) :
+    withFallback bestDomainForLength? p q = p * q := by
+  let requiredLen := Domain.requiredLength p.val q.val
+  cases hdomain : bestDomainForLength? requiredLen with
+  | none =>
+      simp [withFallback, requiredLen, hdomain]
+  | some fitted =>
+      rcases fitted with ⟨D, hfit⟩
+      simp [withFallback, requiredLen, hdomain, fastMulImpl_eq_mul D p q (by
+        simpa [Domain.fits] using hfit)]
+
 end RawMul
 
 end FastMul
 end NTT
-
-namespace Raw.MulLowContext
-
-variable {R : Type*} [Field R] [BEq R] [LawfulBEq R]
-
-omit [BEq R] [LawfulBEq R] in
-private theorem truncate_coeff_of_lt (k : Nat) (p : CPolynomial.Raw R) {i : Nat}
-    (hi : i < k) : (CPolynomial.Raw.truncate k p).coeff i = p.coeff i := by
-  simp [CPolynomial.Raw.truncate, CPolynomial.Raw.coeff, Array.getElem?_extract, hi]
-  by_cases hp : i < p.size
-  · simp [hp]
-  · simp [hp]
-
-private theorem mul_truncate_inputs_coeff_of_lt (k : Nat) (p q : CPolynomial.Raw R)
-    {i : Nat} (hi : i < k) :
-    ((CPolynomial.Raw.truncate k p) * (CPolynomial.Raw.truncate k q)).coeff i =
-      (p * q).coeff i := by
-  rw [CPolynomial.Raw.mul_coeff, CPolynomial.Raw.mul_coeff]
-  apply Finset.sum_congr rfl
-  intro j hj
-  have hjlt : j < i + 1 := Finset.mem_range.mp hj
-  have hjle : j ≤ i := Nat.le_of_lt_succ hjlt
-  have hjk : j < k := Nat.lt_of_le_of_lt hjle hi
-  have hik : i - j < k := Nat.lt_of_le_of_lt (Nat.sub_le i j) hi
-  rw [truncate_coeff_of_lt k p hjk, truncate_coeff_of_lt k q hik]
-
-private def nttTruncateMulLow
-    (bestDomainForLength? : (requiredLen : Nat) →
-      Option (NTT.FittingDomain R requiredLen))
-    (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
-  match bestDomainForLength?
-      (NTT.Domain.requiredLength (CPolynomial.Raw.truncate k p) (CPolynomial.Raw.truncate k q)) with
-  | some ⟨D, _⟩ =>
-      CPolynomial.Raw.truncate k
-        (NTT.FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
-          (CPolynomial.Raw.truncate k q))
-  | none =>
-      (direct (R := R)).mulLow k p q
-
-/--
-NTT-backed low-product backend.
-
-This truncates both inputs to the requested output precision, multiplies them
-with the smallest fitting NTT domain when one is available, and truncates the
-result back to the requested precision. If the domain table cannot cover the
-requested product length, it falls back to the direct low-convolution backend.
--/
-def nttTruncate
-    (bestDomainForLength? : (requiredLen : Nat) →
-      Option (NTT.FittingDomain R requiredLen)) :
-    CPolynomial.Raw.MulLowContext R where
-  mulLow := nttTruncateMulLow bestDomainForLength?
-  size_le := by
-    intro k p q
-    unfold nttTruncateMulLow
-    cases hdomain :
-        bestDomainForLength?
-          (NTT.Domain.requiredLength (CPolynomial.Raw.truncate k p)
-            (CPolynomial.Raw.truncate k q)) with
-    | none =>
-        simpa [hdomain] using (direct (R := R)).size_le k p q
-    | some fitted =>
-        rcases fitted with ⟨D, hfit⟩
-        simp [CPolynomial.Raw.truncate]
-  coeff_of_lt := by
-    intro k p q i hi
-    unfold nttTruncateMulLow
-    cases hdomain :
-        bestDomainForLength?
-          (NTT.Domain.requiredLength (CPolynomial.Raw.truncate k p)
-            (CPolynomial.Raw.truncate k q)) with
-    | none =>
-        simpa [hdomain] using (direct (R := R)).coeff_of_lt k p q i hi
-    | some fitted =>
-        rcases fitted with ⟨D, hfit⟩
-        rw [truncate_coeff_of_lt]
-        · have hfast :
-              (NTT.FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
-                (CPolynomial.Raw.truncate k q)).coeff i =
-              ((CPolynomial.Raw.truncate k p) * (CPolynomial.Raw.truncate k q)).coeff i := by
-            rw [← CPolynomial.Raw.Trim.coeff_eq_coeff
-              (NTT.FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
-                (CPolynomial.Raw.truncate k q)) i]
-            have htrim := NTT.FastMul.Raw.fastMulImpl_trim_eq_mul D
-              (CPolynomial.Raw.truncate k p) (CPolynomial.Raw.truncate k q)
-              (by
-                simpa [NTT.Domain.fits] using hfit)
-            rw [htrim]
-          exact hfast.trans (mul_truncate_inputs_coeff_of_lt k p q hi)
-        · exact hi
-
-end Raw.MulLowContext
 
 end CPolynomial
 end CompPoly

--- a/CompPoly/Univariate/NTT/FastMulLow.lean
+++ b/CompPoly/Univariate/NTT/FastMulLow.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Salih Erdem Koçak, Doran Pamukçu
+-/
+import CompPoly.Univariate.NTT.FastMul
+
+/-!
+# Low Product via NTT
+
+This file exposes an NTT-backed `Raw.MulLowContext` for computing the low
+coefficients of a raw polynomial product.
+-/
+
+namespace CompPoly
+namespace CPolynomial
+namespace NTT
+namespace FastMulLow
+
+variable {R : Type*} [Field R] [BEq R] [LawfulBEq R]
+
+omit [BEq R] [LawfulBEq R] in
+private theorem truncate_coeff_of_lt (k : Nat) (p : CPolynomial.Raw R) {i : Nat}
+    (hi : i < k) : (CPolynomial.Raw.truncate k p).coeff i = p.coeff i := by
+  simp [CPolynomial.Raw.truncate, CPolynomial.Raw.coeff, Array.getElem?_extract, hi]
+  by_cases hp : i < p.size
+  · simp [hp]
+  · simp [hp]
+
+private theorem mul_truncate_inputs_coeff_of_lt (k : Nat) (p q : CPolynomial.Raw R)
+    {i : Nat} (hi : i < k) :
+    ((CPolynomial.Raw.truncate k p) * (CPolynomial.Raw.truncate k q)).coeff i =
+      (p * q).coeff i := by
+  rw [CPolynomial.Raw.mul_coeff, CPolynomial.Raw.mul_coeff]
+  apply Finset.sum_congr rfl
+  intro j hj
+  have hjlt : j < i + 1 := Finset.mem_range.mp hj
+  have hjle : j ≤ i := Nat.le_of_lt_succ hjlt
+  have hjk : j < k := Nat.lt_of_le_of_lt hjle hi
+  have hik : i - j < k := Nat.lt_of_le_of_lt (Nat.sub_le i j) hi
+  rw [truncate_coeff_of_lt k p hjk, truncate_coeff_of_lt k q hik]
+
+private def run
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (FittingDomain R requiredLen))
+    (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
+  match bestDomainForLength?
+      (Domain.requiredLength (CPolynomial.Raw.truncate k p) (CPolynomial.Raw.truncate k q)) with
+  | some ⟨D, _⟩ =>
+      CPolynomial.Raw.truncate k
+        (FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
+          (CPolynomial.Raw.truncate k q))
+  | none =>
+      (CPolynomial.Raw.MulLowContext.direct (R := R)).mulLow k p q
+
+/--
+NTT-backed low-product context with direct low-convolution as a fallback.
+
+This truncates both inputs to the requested output precision, multiplies them
+with the smallest fitting NTT domain when one is available, and truncates the
+result back to the requested precision. If the domain table cannot cover the
+requested product length, it falls back to the direct low-convolution backend.
+-/
+def withFallback
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (FittingDomain R requiredLen)) :
+    CPolynomial.Raw.MulLowContext R where
+  mulLow := run bestDomainForLength?
+  size_le := by
+    intro k p q
+    unfold run
+    cases hdomain :
+        bestDomainForLength?
+          (Domain.requiredLength (CPolynomial.Raw.truncate k p)
+            (CPolynomial.Raw.truncate k q)) with
+    | none =>
+        simpa [hdomain] using (CPolynomial.Raw.MulLowContext.direct (R := R)).size_le k p q
+    | some fitted =>
+        rcases fitted with ⟨D, hfit⟩
+        simp [CPolynomial.Raw.truncate]
+  coeff_of_lt := by
+    intro k p q i hi
+    unfold run
+    cases hdomain :
+        bestDomainForLength?
+          (Domain.requiredLength (CPolynomial.Raw.truncate k p)
+            (CPolynomial.Raw.truncate k q)) with
+    | none =>
+        simpa [hdomain] using
+          (CPolynomial.Raw.MulLowContext.direct (R := R)).coeff_of_lt k p q i hi
+    | some fitted =>
+        rcases fitted with ⟨D, hfit⟩
+        rw [truncate_coeff_of_lt]
+        · have hfast :
+              (FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
+                (CPolynomial.Raw.truncate k q)).coeff i =
+              ((CPolynomial.Raw.truncate k p) * (CPolynomial.Raw.truncate k q)).coeff i := by
+            rw [← CPolynomial.Raw.Trim.coeff_eq_coeff
+              (FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
+                (CPolynomial.Raw.truncate k q)) i]
+            have htrim := FastMul.Raw.fastMulImpl_trim_eq_mul D
+              (CPolynomial.Raw.truncate k p) (CPolynomial.Raw.truncate k q)
+              (by
+                simpa [Domain.fits] using hfit)
+            rw [htrim]
+          exact hfast.trans (mul_truncate_inputs_coeff_of_lt k p q hi)
+        · exact hi
+
+end FastMulLow
+end NTT
+end CPolynomial
+end CompPoly

--- a/CompPoly/Univariate/NTT/FastMulLow.lean
+++ b/CompPoly/Univariate/NTT/FastMulLow.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Salih Erdem Koçak, Doran Pamukçu
+Authors: Valerii Huhnin
 -/
 import CompPoly.Univariate.NTT.FastMul
 

--- a/CompPoly/Univariate/NTT/FastMulLow.lean
+++ b/CompPoly/Univariate/NTT/FastMulLow.lean
@@ -51,15 +51,15 @@ private def run
         (FastMul.Raw.fastMulImpl D (CPolynomial.Raw.truncate k p)
           (CPolynomial.Raw.truncate k q))
   | none =>
-      (CPolynomial.Raw.MulLowContext.direct (R := R)).mulLow k p q
+      (CPolynomial.Raw.MulLowContext.convolution (R := R)).mulLow k p q
 
 /--
-NTT-backed low-product context with direct low-convolution as a fallback.
+NTT-backed low-product context with low-convolution as a fallback.
 
 This truncates both inputs to the requested output precision, multiplies them
 with the selected fitting NTT domain when one is available, and truncates the
 result back to the requested precision. If the domain table cannot cover the
-requested product length, it falls back to the direct low-convolution backend.
+requested product length, it falls back to the low-convolution backend.
 -/
 def withFallback
     (bestDomainForLength? : (requiredLen : Nat) →
@@ -74,7 +74,8 @@ def withFallback
           (Domain.requiredLength (CPolynomial.Raw.truncate k p)
             (CPolynomial.Raw.truncate k q)) with
     | none =>
-        simpa [hdomain] using (CPolynomial.Raw.MulLowContext.direct (R := R)).size_le k p q
+        simpa [hdomain] using
+          (CPolynomial.Raw.MulLowContext.convolution (R := R)).size_le k p q
     | some fitted =>
         rcases fitted with ⟨D, hfit⟩
         simp [CPolynomial.Raw.truncate]
@@ -87,7 +88,7 @@ def withFallback
             (CPolynomial.Raw.truncate k q)) with
     | none =>
         simpa [hdomain] using
-          (CPolynomial.Raw.MulLowContext.direct (R := R)).coeff_of_lt k p q i hi
+          (CPolynomial.Raw.MulLowContext.convolution (R := R)).coeff_of_lt k p q i hi
     | some fitted =>
         rcases fitted with ⟨D, hfit⟩
         rw [truncate_coeff_of_lt]

--- a/CompPoly/Univariate/NTT/FastMulLow.lean
+++ b/CompPoly/Univariate/NTT/FastMulLow.lean
@@ -57,7 +57,7 @@ private def run
 NTT-backed low-product context with direct low-convolution as a fallback.
 
 This truncates both inputs to the requested output precision, multiplies them
-with the smallest fitting NTT domain when one is available, and truncates the
+with the selected fitting NTT domain when one is available, and truncates the
 result back to the requested precision. If the domain table cannot cover the
 requested product length, it falls back to the direct low-convolution backend.
 -/

--- a/CompPoly/Univariate/Raw/Division.lean
+++ b/CompPoly/Univariate/Raw/Division.lean
@@ -52,7 +52,7 @@ def modByMonic [Field R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
 @[inline, specialize]
 def subScaledShift [Field R] (p q : CPolynomial.Raw R) (scale : R) (shift : Nat) :
     CPolynomial.Raw R :=
-  let coeffs := Array.ofFn (n := p.size) fun j : Fin p.size =>
+  let coeffs := Array.ofFn (n := p.size) fun j : Fin p.size ↦
     let i := j.val - shift
     let subtractCoeff := if shift ≤ j.val ∧ i < q.size then scale * q.coeff i else 0
     p.coeff j.val - subtractCoeff

--- a/CompPoly/Univariate/Raw/Division.lean
+++ b/CompPoly/Univariate/Raw/Division.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles
+Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles, Valerii Huhnin
 -/
 import CompPoly.Univariate.Raw.Ops
 

--- a/CompPoly/Univariate/Raw/Division.lean
+++ b/CompPoly/Univariate/Raw/Division.lean
@@ -105,7 +105,7 @@ Remainder by a monic polynomial through reversal and truncated products.
 
 For canonical monic inputs this computes the quotient from the reversed divisor
 inverse modulo `X^k`, then subtracts only the low coefficients needed for the
-remainder. Inputs outside that executable contract fall back to the older
+remainder. Inputs outside that executable contract fall back to the
 remainder-only implementation.
 -/
 @[inline, specialize]

--- a/CompPoly/Univariate/Raw/Division.lean
+++ b/CompPoly/Univariate/Raw/Division.lean
@@ -79,6 +79,54 @@ where
         let p' := subScaledShift p q p.leadingCoeff k
         go n p' q
 
+/-- Inverse modulo `X^k`, using Newton iteration and the supplied low-product backend. -/
+@[inline, specialize]
+def inverseModX [Field R] [LawfulBEq R] (M : MulLowContext R) (k : Nat)
+    (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
+  if k = 0 then
+    #[]
+  else
+    go (k + 1) 1 (C (p.coeff 0)⁻¹)
+where
+  go : Nat → Nat → CPolynomial.Raw R → CPolynomial.Raw R
+  | 0, _, g => truncate k g
+  | fuel + 1, n, g =>
+      if k ≤ n then
+        truncate k g
+      else
+        let next := Nat.min k (2 * n)
+        let fg := M.mulLow next p g
+        let correction := C (2 : R) - fg
+        let g' := M.mulLow next g correction
+        go fuel next g'
+
+/--
+Remainder by a monic polynomial through reversal and truncated products.
+
+For canonical monic inputs this computes the quotient from the reversed divisor
+inverse modulo `X^k`, then subtracts only the low coefficients needed for the
+remainder. Inputs outside that executable contract fall back to the older
+remainder-only implementation.
+-/
+@[inline, specialize]
+def modByMonicByReversal [Field R] [LawfulBEq R] (M : MulLowContext R)
+    (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) : CPolynomial.Raw R :=
+  if p.trim == p && q.trim == q && q.leadingCoeff == 1 then
+    if p.size < q.size then
+      p
+    else
+      let k := p.size - q.size + 1
+      let remainderLen := q.size - 1
+      let revP := reverse p.size p
+      let revQ := reverse q.size q
+      let invRevQ := inverseModX M k revQ
+      let quotientRev := M.mulLow k revP invRevQ
+      let quotient := reverse k quotientRev
+      let productLow := M.mulLow remainderLen q quotient
+      truncate remainderLen p - productLow
+  else
+    modByMonicRemainderOnly p q
+
 /-- Division of two `CPolynomial.Raw`s. -/
 def div [Field R] (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
   (C (q.leadingCoeff)⁻¹ • p).divByMonic (C (q.leadingCoeff)⁻¹ * q)

--- a/CompPoly/Univariate/Raw/Division.lean
+++ b/CompPoly/Univariate/Raw/Division.lean
@@ -48,6 +48,37 @@ def modByMonic [Field R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
     CPolynomial.Raw R :=
   (divModByMonicAux p q).2
 
+/-- Subtract `scale * q * X^shift` from `p` without using general polynomial multiplication. -/
+@[inline, specialize]
+def subScaledShift [Field R] (p q : CPolynomial.Raw R) (scale : R) (shift : Nat) :
+    CPolynomial.Raw R :=
+  let coeffs := Array.ofFn (n := p.size) fun j : Fin p.size =>
+    let i := j.val - shift
+    let subtractCoeff := if shift ≤ j.val ∧ i < q.size then scale * q.coeff i else 0
+    p.coeff j.val - subtractCoeff
+  (CPolynomial.Raw.mk coeffs).trim
+
+/-- Remainder-only long division by a monic polynomial.
+
+Unlike `modByMonic`, this does not compute the quotient and avoids the general
+polynomial multiplications used by each cancellation step. It is intended as an
+executable implementation for the canonical `modByMonic` specification.
+-/
+@[inline, specialize]
+def modByMonicRemainderOnly [Field R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
+    CPolynomial.Raw R :=
+  go p.size p q
+where
+  go : Nat → CPolynomial.Raw R → CPolynomial.Raw R → CPolynomial.Raw R
+  | 0, p, _ => p
+  | n + 1, p, q =>
+      if p.size < q.size then
+        p
+      else
+        let k := p.size - q.size
+        let p' := subScaledShift p q p.leadingCoeff k
+        go n p' q
+
 /-- Division of two `CPolynomial.Raw`s. -/
 def div [Field R] (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
   (C (q.leadingCoeff)⁻¹ • p).divByMonic (C (q.leadingCoeff)⁻¹ * q)

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -134,9 +134,9 @@ def truncate [Zero R] (k : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
 def takeLow [Zero R] (k : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
   Array.ofFn fun i : Fin k => p.coeff i
 
-/-- Naive low product, computing only coefficients below `k`. -/
+/-- Direct low product, computing only coefficients below `k`. -/
 @[inline, specialize]
-def mulLowNaive [Semiring R] (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
+def mulLowDirect [Semiring R] (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
   Array.ofFn fun i : Fin k =>
     (Finset.range (i.val + 1)).sum fun j => p.coeff j * q.coeff (i.val - j)
 

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -132,18 +132,18 @@ def truncate [Zero R] (k : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
 /-- Return exactly the first `k` coefficients, padding missing coefficients with zero. -/
 @[inline, specialize]
 def takeLow [Zero R] (k : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
-  Array.ofFn fun i : Fin k => p.coeff i
+  Array.ofFn fun i : Fin k ↦ p.coeff i
 
 /-- Reverse the first `n` coefficients, padding missing coefficients with zero. -/
 @[inline, specialize]
 def reverse [Zero R] (n : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
-  Array.ofFn fun i : Fin n => p.coeff (n - 1 - i.val)
+  Array.ofFn fun i : Fin n ↦ p.coeff (n - 1 - i.val)
 
 /-- Low product computed by the coefficient convolution formula. -/
 @[inline, specialize]
 def mulLowConvolution [Semiring R] (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
-  Array.ofFn fun i : Fin k =>
-    (Finset.range (i.val + 1)).sum fun j => p.coeff j * q.coeff (i.val - j)
+  Array.ofFn fun i : Fin k ↦
+    (Finset.range (i.val + 1)).sum fun j ↦ p.coeff j * q.coeff (i.val - j)
 
 /-- Backend for computing the low `k` coefficients of a raw product. -/
 structure MulLowContext (R : Type*) [Semiring R] [BEq R] [LawfulBEq R] where

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -124,6 +124,31 @@ instance [Semiring R] [BEq R] : Mul (CPolynomial.Raw R) := ⟨mul⟩
 instance [Semiring R] [BEq R] : Pow (CPolynomial.Raw R) Nat := ⟨pow⟩
 instance [NatCast R] : NatCast (CPolynomial.Raw R) := ⟨fun n => C (n : R)⟩
 
+/-- Keep only the stored coefficients with index `< k`. -/
+@[inline, specialize]
+def truncate [Zero R] (k : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
+  p.extract 0 k
+
+/-- Return exactly the first `k` coefficients, padding missing coefficients with zero. -/
+@[inline, specialize]
+def takeLow [Zero R] (k : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
+  Array.ofFn fun i : Fin k => p.coeff i
+
+/-- Naive low product, computing only coefficients below `k`. -/
+@[inline, specialize]
+def mulLowNaive [Semiring R] (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
+  Array.ofFn fun i : Fin k =>
+    (Finset.range (i.val + 1)).sum fun j => p.coeff j * q.coeff (i.val - j)
+
+/-- Backend for computing the low `k` coefficients of a raw product. -/
+structure MulLowContext (R : Type*) [Semiring R] [BEq R] [LawfulBEq R] where
+  /-- Return the low `k` coefficients of `p * q`. -/
+  mulLow : Nat → CPolynomial.Raw R → CPolynomial.Raw R → CPolynomial.Raw R
+  /-- The backend does not return coefficients at degree `>= k`. -/
+  size_le : ∀ k p q, (mulLow k p q).size ≤ k
+  /-- Low coefficients agree with ordinary raw multiplication. -/
+  coeff_of_lt : ∀ k p q i, i < k → (mulLow k p q).coeff i = (p * q).coeff i
+
 /-- Upper bound on degree: `size - 1` if non-empty, `⊥` if empty. -/
 def degreeBound (p : CPolynomial.Raw R) : WithBot Nat :=
   match p.size with

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -139,9 +139,9 @@ def takeLow [Zero R] (k : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
 def reverse [Zero R] (n : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
   Array.ofFn fun i : Fin n => p.coeff (n - 1 - i.val)
 
-/-- Direct low product, computing only coefficients below `k`. -/
+/-- Low product computed by the coefficient convolution formula. -/
 @[inline, specialize]
-def mulLowDirect [Semiring R] (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
+def mulLowConvolution [Semiring R] (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=
   Array.ofFn fun i : Fin k =>
     (Finset.range (i.val + 1)).sum fun j => p.coeff j * q.coeff (i.val - j)
 

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -134,6 +134,11 @@ def truncate [Zero R] (k : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
 def takeLow [Zero R] (k : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
   Array.ofFn fun i : Fin k => p.coeff i
 
+/-- Reverse the first `n` coefficients, padding missing coefficients with zero. -/
+@[inline, specialize]
+def reverse [Zero R] (n : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
+  Array.ofFn fun i : Fin n => p.coeff (n - 1 - i.val)
+
 /-- Direct low product, computing only coefficients below `k`. -/
 @[inline, specialize]
 def mulLowDirect [Semiring R] (k : Nat) (p q : CPolynomial.Raw R) : CPolynomial.Raw R :=

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles,
-  Natalie Klaus, Dimitris Mitsios
+  Natalie Klaus, Dimitris Mitsios, Valerii Huhnin
 -/
 import CompPoly.Univariate.Raw.Division
 

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -714,6 +714,26 @@ lemma mul_coeff [LawfulBEq R] (p q : CPolynomial.Raw R) (k : ℕ) :
     (p * q).coeff k = (Finset.range (k + 1)).sum (fun i => p.coeff i * q.coeff (k - i)) := by
   rw [mul_coeff_range_size, sum_range_extend]
 
+namespace MulLowContext
+
+/-- Low-product backend using the direct coefficient formula. -/
+def naive [LawfulBEq R] : MulLowContext R where
+  mulLow := mulLowNaive
+  size_le := by
+    intro k p q
+    simp [mulLowNaive]
+  coeff_of_lt := by
+    intro k p q i hi
+    rw [mulLowNaive, CPolynomial.Raw.coeff]
+    have hsize : i < (Array.ofFn fun j : Fin k =>
+        (Finset.range (j.val + 1)).sum fun l => p.coeff l * q.coeff (j.val - l)).size := by
+      simpa using hi
+    rw [Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hsize]
+    simp only [Option.getD_some]
+    simpa using (mul_coeff p q i).symm
+
+end MulLowContext
+
 lemma mul_assoc_coeff_rhs [LawfulBEq R] (p q r : CPolynomial.Raw R) (n : ℕ) :
     (p * (q * r)).coeff n =
       (Finset.range (n + 1)).sum (fun i =>

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles,
   Natalie Klaus, Dimitris Mitsios
 -/
-import CompPoly.Univariate.Raw.Ops
+import CompPoly.Univariate.Raw.Division
 
 /-!
 # Raw Univariate Polynomial Proofs
@@ -996,6 +996,102 @@ lemma sub_coeff [LawfulBEq R] (p q : CPolynomial.Raw R) (i : ℕ) :
   exact sub_eq_add_neg (p.coeff i) (q.coeff i)
 
 end Ring
+
+section DivisionTheorems
+
+variable [Field R] [BEq R]
+
+lemma coeff_mul_X_pow [LawfulBEq R] (p : CPolynomial.Raw R) (n i : ℕ) :
+    (p * X ^ n).coeff i =
+      if n ≤ i ∧ i - n < p.size then p.coeff (i - n) else 0 := by
+  classical
+  rw [X_pow_eq_monomial_one, mul_coeff]
+  by_cases hn : n ≤ i
+  · have hmem : i - n ∈ Finset.range (i + 1) := by
+      simp only [Finset.mem_range]
+      omega
+    rw [Finset.sum_eq_single (i - n)]
+    · rw [coeff_monomial]
+      have hidx : n = i - (i - n) := by omega
+      by_cases hp : i - n < p.size
+      · rw [if_pos hidx, if_pos ⟨hn, hp⟩, mul_one]
+      · have hp' : p.size ≤ i - n := by omega
+        have hcoeff : p.coeff (i - n) = 0 := by
+          simp [coeff, Array.getElem?_eq_none hp']
+        rw [if_pos hidx, if_neg (by intro h; exact hp h.2), mul_one]
+        exact hcoeff
+    · intro b hbmem hb
+      rw [coeff_monomial]
+      have hidx : n ≠ i - b := by
+        intro h
+        have hb_le : b ≤ i := Nat.lt_succ_iff.mp (Finset.mem_range.mp hbmem)
+        have : b = i - n := by omega
+        exact hb this
+      simp [hidx]
+    · intro h
+      exact (h hmem).elim
+  · have hsum :
+        (∑ x ∈ Finset.range (i + 1), p.coeff x * (monomial n (1 : R)).coeff (i - x)) =
+          0 := by
+      apply Finset.sum_eq_zero
+      intro b _
+      rw [coeff_monomial]
+      have hidx : n ≠ i - b := by
+        intro h
+        have : n ≤ i := by omega
+        exact hn this
+      simp [hidx]
+    rw [hsum]
+    simp [hn]
+
+lemma coeff_C_mul_X_pow [LawfulBEq R] (scale : R) (p : CPolynomial.Raw R) (n i : ℕ) :
+    (C scale * (p * X ^ n)).coeff i =
+      if n ≤ i ∧ i - n < p.size then scale * p.coeff (i - n) else 0 := by
+  rw [C_mul_eq_smul_trim, Trim.coeff_eq_coeff, smul_coeff, coeff_mul_X_pow]
+  split_ifs <;> simp
+
+lemma subScaledShift_eq_sub_C_mul_X_pow [LawfulBEq R]
+    (p q : CPolynomial.Raw R) (scale : R) (shift : ℕ)
+    (hsize : shift + q.size ≤ p.size) :
+    subScaledShift p q scale shift = (p - C scale * (q * X ^ shift)).trim := by
+  apply Trim.eq_of_equiv
+  intro i
+  change (CPolynomial.Raw.mk (Array.ofFn fun j : Fin p.size =>
+      let i := j.val - shift
+      let subtractCoeff := if shift ≤ j.val ∧ i < q.size then scale * q.coeff i else 0
+      p.coeff j.val - subtractCoeff)).coeff i =
+    (p - C scale * (q * X ^ shift)).coeff i
+  rw [sub_coeff, coeff_C_mul_X_pow]
+  by_cases hi : i < p.size
+  · simp [coeff, hi]
+  · have hnot : ¬(shift ≤ i ∧ i - shift < q.size) := by omega
+    simp [coeff, hi, hnot]
+
+lemma modByMonicRemainderOnly_go_eq_divModByMonicAux_go_snd [LawfulBEq R] :
+    ∀ (n : ℕ) (p q : CPolynomial.Raw R),
+      modByMonicRemainderOnly.go n p q = (divModByMonicAux.go n p q).2 := by
+  intro n
+  induction n with
+  | zero =>
+      intro p q
+      rfl
+  | succ n ih =>
+      intro p q
+      unfold modByMonicRemainderOnly.go divModByMonicAux.go
+      by_cases hsize : p.size < q.size
+      · simp [hsize]
+      · simp [hsize]
+        have hle : p.size - q.size + q.size ≤ p.size := by omega
+        rw [subScaledShift_eq_sub_C_mul_X_pow p q p.leadingCoeff (p.size - q.size) hle]
+        exact ih _ _
+
+/-- The remainder-only raw monic remainder agrees with the canonical raw monic remainder. -/
+theorem modByMonicRemainderOnly_eq_modByMonic [LawfulBEq R]
+    (p q : CPolynomial.Raw R) :
+    modByMonicRemainderOnly p q = modByMonic p q := by
+  exact modByMonicRemainderOnly_go_eq_divModByMonicAux_go_snd p.size p q
+
+end DivisionTheorems
 
 end Operations
 

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -1111,6 +1111,12 @@ theorem modByMonicRemainderOnly_eq_modByMonic [LawfulBEq R]
     modByMonicRemainderOnly p q = modByMonic p q := by
   exact modByMonicRemainderOnly_go_eq_divModByMonicAux_go_snd p.size p q
 
+/-- The reversal raw monic remainder agrees with the canonical raw monic remainder. -/
+theorem modByMonicByReversal_eq_modByMonic [LawfulBEq R]
+    (M : MulLowContext R) (p q : CPolynomial.Raw R) :
+    modByMonicByReversal M p q = modByMonic p q := by
+  sorry
+
 end DivisionTheorems
 
 end Operations

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -725,8 +725,8 @@ def convolution [LawfulBEq R] : MulLowContext R where
   coeff_of_lt := by
     intro k p q i hi
     rw [mulLowConvolution, CPolynomial.Raw.coeff]
-    have hsize : i < (Array.ofFn fun j : Fin k =>
-        (Finset.range (j.val + 1)).sum fun l => p.coeff l * q.coeff (j.val - l)).size := by
+    have hsize : i < (Array.ofFn fun j : Fin k ↦
+        (Finset.range (j.val + 1)).sum fun l ↦ p.coeff l * q.coeff (j.val - l)).size := by
       simpa using hi
     rw [Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hsize]
     simp only [Option.getD_some]
@@ -766,12 +766,12 @@ lemma reverse_coeff (n : Nat) (p : CPolynomial.Raw R) (i : Nat) :
   unfold reverse coeff
   by_cases hi : i < n
   · simp only [Array.getD_eq_getD_getElem?]
-    have hsize : i < (Array.ofFn fun i : Fin n => p[n - 1 - ↑i]?.getD 0).size := by
+    have hsize : i < (Array.ofFn fun i : Fin n ↦ p[n - 1 - ↑i]?.getD 0).size := by
       simpa using hi
     rw [Array.getElem?_eq_getElem hsize]
     simp [hi]
   · simp only [Array.getD_eq_getD_getElem?]
-    have hsize : (Array.ofFn fun i : Fin n => p[n - 1 - ↑i]?.getD 0).size ≤ i := by
+    have hsize : (Array.ofFn fun i : Fin n ↦ p[n - 1 - ↑i]?.getD 0).size ≤ i := by
       simpa using Nat.le_of_not_lt hi
     rw [Array.getElem?_eq_none hsize]
     simp [hi]
@@ -1127,7 +1127,7 @@ lemma subScaledShift_eq_sub_C_mul_X_pow [LawfulBEq R]
     subScaledShift p q scale shift = (p - C scale * (q * X ^ shift)).trim := by
   apply Trim.eq_of_equiv
   intro i
-  change (CPolynomial.Raw.mk (Array.ofFn fun j : Fin p.size =>
+  change (CPolynomial.Raw.mk (Array.ofFn fun j : Fin p.size ↦
       let i := j.val - shift
       let subtractCoeff := if shift ≤ j.val ∧ i < q.size then scale * q.coeff i else 0
       p.coeff j.val - subtractCoeff)).coeff i =

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -716,15 +716,15 @@ lemma mul_coeff [LawfulBEq R] (p q : CPolynomial.Raw R) (k : ℕ) :
 
 namespace MulLowContext
 
-/-- Low-product backend using the direct coefficient formula. -/
-def direct [LawfulBEq R] : MulLowContext R where
-  mulLow := mulLowDirect
+/-- Low-product backend using the coefficient convolution formula. -/
+def convolution [LawfulBEq R] : MulLowContext R where
+  mulLow := mulLowConvolution
   size_le := by
     intro k p q
-    simp [mulLowDirect]
+    simp [mulLowConvolution]
   coeff_of_lt := by
     intro k p q i hi
-    rw [mulLowDirect, CPolynomial.Raw.coeff]
+    rw [mulLowConvolution, CPolynomial.Raw.coeff]
     have hsize : i < (Array.ofFn fun j : Fin k =>
         (Finset.range (j.val + 1)).sum fun l => p.coeff l * q.coeff (j.val - l)).size := by
       simpa using hi
@@ -744,6 +744,21 @@ lemma truncate_coeff (k : Nat) (p : CPolynomial.Raw R) (i : Nat) :
     · simp [hik, hip]
     · simp [hik, hip]
   · simp [hik]
+
+namespace MulLowContext
+
+/-- Low-product backend using ordinary multiplication followed by truncation. -/
+def naive [LawfulBEq R] : MulLowContext R where
+  mulLow k p q := truncate k (p * q)
+  size_le := by
+    intro k p q
+    simp [truncate]
+  coeff_of_lt := by
+    intro k p q i hi
+    rw [truncate_coeff]
+    simp [hi]
+
+end MulLowContext
 
 omit [BEq R] in
 lemma reverse_coeff (n : Nat) (p : CPolynomial.Raw R) (i : Nat) :

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -717,14 +717,14 @@ lemma mul_coeff [LawfulBEq R] (p q : CPolynomial.Raw R) (k : ℕ) :
 namespace MulLowContext
 
 /-- Low-product backend using the direct coefficient formula. -/
-def naive [LawfulBEq R] : MulLowContext R where
-  mulLow := mulLowNaive
+def direct [LawfulBEq R] : MulLowContext R where
+  mulLow := mulLowDirect
   size_le := by
     intro k p q
-    simp [mulLowNaive]
+    simp [mulLowDirect]
   coeff_of_lt := by
     intro k p q i hi
-    rw [mulLowNaive, CPolynomial.Raw.coeff]
+    rw [mulLowDirect, CPolynomial.Raw.coeff]
     have hsize : i < (Array.ofFn fun j : Fin k =>
         (Finset.range (j.val + 1)).sum fun l => p.coeff l * q.coeff (j.val - l)).size := by
       simpa using hi

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -734,6 +734,42 @@ def direct [LawfulBEq R] : MulLowContext R where
 
 end MulLowContext
 
+omit [BEq R] in
+lemma truncate_coeff (k : Nat) (p : CPolynomial.Raw R) (i : Nat) :
+    (truncate k p).coeff i = if i < k then p.coeff i else 0 := by
+  unfold truncate coeff
+  simp [Array.getElem?_extract]
+  by_cases hik : i < k
+  · by_cases hip : i < p.size
+    · simp [hik, hip]
+    · simp [hik, hip]
+  · simp [hik]
+
+omit [BEq R] in
+lemma reverse_coeff (n : Nat) (p : CPolynomial.Raw R) (i : Nat) :
+    (reverse n p).coeff i = if i < n then p.coeff (n - 1 - i) else 0 := by
+  unfold reverse coeff
+  by_cases hi : i < n
+  · simp only [Array.getD_eq_getD_getElem?]
+    have hsize : i < (Array.ofFn fun i : Fin n => p[n - 1 - ↑i]?.getD 0).size := by
+      simpa using hi
+    rw [Array.getElem?_eq_getElem hsize]
+    simp [hi]
+  · simp only [Array.getD_eq_getD_getElem?]
+    have hsize : (Array.ofFn fun i : Fin n => p[n - 1 - ↑i]?.getD 0).size ≤ i := by
+      simpa using Nat.le_of_not_lt hi
+    rw [Array.getElem?_eq_none hsize]
+    simp [hi]
+
+lemma mulLow_coeff [LawfulBEq R] (M : MulLowContext R) (k : Nat)
+    (p q : CPolynomial.Raw R) (i : Nat) :
+    (M.mulLow k p q).coeff i = if i < k then (p * q).coeff i else 0 := by
+  by_cases hi : i < k
+  · simp [hi, M.coeff_of_lt k p q i hi]
+  · have hsize : (M.mulLow k p q).size ≤ i := by
+      exact le_trans (M.size_le k p q) (Nat.le_of_not_lt hi)
+    simp [hi, coeff, Array.getElem?_eq_none hsize]
+
 lemma mul_assoc_coeff_rhs [LawfulBEq R] (p q r : CPolynomial.Raw R) (n : ℕ) :
     (p * (q * r)).coeff n =
       (Finset.range (n + 1)).sum (fun i =>
@@ -1110,12 +1146,6 @@ theorem modByMonicRemainderOnly_eq_modByMonic [LawfulBEq R]
     (p q : CPolynomial.Raw R) :
     modByMonicRemainderOnly p q = modByMonic p q := by
   exact modByMonicRemainderOnly_go_eq_divModByMonicAux_go_snd p.size p q
-
-/-- The reversal raw monic remainder agrees with the canonical raw monic remainder. -/
-theorem modByMonicByReversal_eq_modByMonic [LawfulBEq R]
-    (M : MulLowContext R) (p q : CPolynomial.Raw R) :
-    modByMonicByReversal M p q = modByMonic p q := by
-  sorry
 
 end DivisionTheorems
 

--- a/CompPoly/Univariate/ToPoly/Equiv.lean
+++ b/CompPoly/Univariate/ToPoly/Equiv.lean
@@ -24,17 +24,29 @@ variable {R : Type*} [Semiring R] [BEq R]
 section RingEquiv
 
 @[grind =]
-lemma toPoly_neg {R : Type*} [Ring R] [BEq R] [LawfulBEq R] (p : CPolynomial R) :
+lemma Raw.toPoly_neg {R : Type*} [Ring R] [BEq R] [LawfulBEq R] (p : CPolynomial.Raw R) :
     (-p).toPoly = -p.toPoly := by
   ext i
-  rw [Polynomial.coeff_neg, CPolynomial.toPoly, CPolynomial.toPoly]
-  rw [Raw.coeff_toPoly, Raw.coeff_toPoly]
-  simpa using (Raw.neg_coeff (p := p.val) (i := i))
+  rw [Polynomial.coeff_neg, Raw.coeff_toPoly, Raw.coeff_toPoly]
+  change p.neg.coeff i = -p.coeff i
+  exact Raw.neg_coeff p i
+
+@[grind =]
+lemma toPoly_neg {R : Type*} [Ring R] [BEq R] [LawfulBEq R] (p : CPolynomial R) :
+    (-p).toPoly = -p.toPoly := by
+  exact Raw.toPoly_neg p.val
 
 @[grind =]
 lemma toPoly_add [LawfulBEq R] (p q : CPolynomial R) :
     (p + q).toPoly = p.toPoly + q.toPoly := by
   apply Raw.toPoly_add
+
+@[grind =]
+lemma Raw.toPoly_sub {R : Type*} [Ring R] [BEq R] [LawfulBEq R]
+    (p q : CPolynomial.Raw R) :
+    (p - q).toPoly = p.toPoly - q.toPoly := by
+  change (p + -q).toPoly = p.toPoly + -q.toPoly
+  rw [Raw.toPoly_add, Raw.toPoly_neg]
 
 @[grind =]
 lemma toPoly_sub {R : Type*} [Ring R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) :
@@ -75,8 +87,7 @@ lemma toPoly_mul_coeffC [LawfulBEq R] (p q : CPolynomial R) (i : ℕ) :
 @[grind =]
 lemma toPoly_mul [LawfulBEq R] (p q : CPolynomial R) :
     (p * q).toPoly = p.toPoly * q.toPoly := by
-  ext i
-  exact toPoly_mul_coeffC p q i
+  exact Raw.toPoly_mul p.val q.val
 
 @[simp, grind =]
 lemma eval₂_C {R : Type*} [Semiring R] {S : Type*} [Semiring S]
@@ -102,6 +113,15 @@ lemma Raw.toPoly_one {R : Type*} [Semiring R] :
 lemma toPoly_one [LawfulBEq R] [Nontrivial R] :
     (1 : CPolynomial R).toPoly = 1 := by apply Raw.toPoly_one
 
+@[grind =]
+lemma Raw.toPoly_pow [LawfulBEq R] (p : CPolynomial.Raw R) :
+    ∀ n : ℕ, (p ^ n).toPoly = p.toPoly ^ n
+  | 0 => by
+      simp [Raw.pow_zero]
+  | n + 1 => by
+      rw [Raw.pow_succ, Raw.toPoly_mul, Raw.toPoly_pow p n]
+      simp [pow_succ']
+
 @[simp, grind =]
 lemma Raw.toPoly_zero {R : Type*} [Semiring R] : (0 : CPolynomial.Raw R).toPoly = 0 := by
   simp [Raw.toPoly, Raw.eval₂]
@@ -118,19 +138,9 @@ lemma Raw.toPoly_X {R : Type*} [Semiring R] :
 @[grind =]
 lemma toPoly_pow [Nontrivial R] [LawfulBEq R] (p : CPolynomial R) (n : ℕ) :
     (p ^ n).toPoly = p.toPoly ^ n := by
-  induction n with
-  | zero =>
-    simp only [_root_.pow_zero]
-    rw [toPoly_one]
-  | succ n ih =>
-    have hp : p ^ (n + 1) = p ^ n * p := by
-      apply ext
-      show (p ^ (n + 1)).val = (p ^ n * p).val
-      rw [val_pow, show (p ^ n * p).val = (p ^ n).val * p.val from rfl, val_pow]
-      exact pow_succ_right p.val n
-    have htp : p.toPoly ^ (n + 1) = p.toPoly ^ n * p.toPoly := by
-      simpa using (_root_.pow_succ (p.toPoly : R[X]) n)
-    rw [hp, toPoly_mul, ih, htp]
+  change (p ^ n).val.toPoly = p.val.toPoly ^ n
+  rw [val_pow]
+  exact Raw.toPoly_pow p.val n
 
 lemma toPoly_sum.{u} {R : Type*} [Semiring R] [BEq R] [LawfulBEq R] {ι : Type u}
     [DecidableEq ι]

--- a/CompPoly/Univariate/ToPoly/Equiv.lean
+++ b/CompPoly/Univariate/ToPoly/Equiv.lean
@@ -111,7 +111,8 @@ lemma Raw.toPoly_one {R : Type*} [Semiring R] :
   apply toPoly_C
 
 lemma toPoly_one [LawfulBEq R] [Nontrivial R] :
-    (1 : CPolynomial R).toPoly = 1 := by apply Raw.toPoly_one
+    (1 : CPolynomial R).toPoly = 1 := by
+  apply Raw.toPoly_one
 
 @[grind =]
 lemma Raw.toPoly_pow [LawfulBEq R] (p : CPolynomial.Raw R) :

--- a/CompPoly/Univariate/ToPoly/Impl.lean
+++ b/CompPoly/Univariate/ToPoly/Impl.lean
@@ -234,6 +234,71 @@ theorem degreeLT_toPoly {n : ℕ} [BEq R] [LawfulBEq R] {p : CPolynomial R} :
 
 end ImplementationCorrectness
 
+section EvaluationDivision
+
+variable {R : Type*}
+
+/-- Evaluation preserves multiplication. -/
+theorem eval_mul [CommSemiring R] [BEq R] [LawfulBEq R]
+    (p q : CPolynomial R) (x : R) :
+    (p * q).eval x = p.eval x * q.eval x := by
+  rw [eval_toPoly, toPoly_mul, Polynomial.eval_mul, ← eval_toPoly, ← eval_toPoly]
+
+namespace Raw
+
+theorem eval_sub_C_mul_X_pow_trim_eq_self_of_eval_eq_zero
+    [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial.Raw R) (scale : R)
+    (shift : ℕ) {x : R} (hq : q.eval x = 0) :
+    ((p - C scale * (q * X ^ shift)).trim).eval x = p.eval x := by
+  rw [eval_trim_eq_eval]
+  rw [← eval_toPoly_eq_eval x]
+  rw [toPoly_sub, toPoly_mul, toPoly_C, toPoly_mul, toPoly_pow, toPoly_X]
+  rw [Polynomial.eval_sub, Polynomial.eval_mul, Polynomial.eval_C, Polynomial.eval_mul,
+    Polynomial.eval_pow, Polynomial.eval_X]
+  simp [eval_toPoly_eq_eval, hq]
+
+theorem eval_divModByMonicAux_go_snd_eq_self_of_eval_eq_zero
+    [Field R] [BEq R] [LawfulBEq R] :
+    ∀ (fuel : ℕ) (p q : CPolynomial.Raw R) {x : R}, q.eval x = 0 →
+      (divModByMonicAux.go fuel p q).2.eval x = p.eval x := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro p q x hq
+      rfl
+  | succ fuel ih =>
+      intro p q x hq
+      unfold divModByMonicAux.go
+      by_cases hsize : p.size < q.size
+      · simp [hsize]
+      · simp [hsize]
+        trans ((p - C p.leadingCoeff * (q * X ^ (p.size - q.size))).trim).eval x
+        · exact ih _ _ hq
+        · exact eval_sub_C_mul_X_pow_trim_eq_self_of_eval_eq_zero p q p.leadingCoeff
+            (p.size - q.size) hq
+
+/-- Reducing by a polynomial that vanishes at `x` preserves evaluation at `x`. -/
+theorem eval_modByMonic_eq_self_of_eval_eq_zero
+    [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial.Raw R) {x : R}
+    (hq : q.eval x = 0) :
+    (modByMonic p q).eval x = p.eval x :=
+  eval_divModByMonicAux_go_snd_eq_self_of_eval_eq_zero p.size p q hq
+
+end Raw
+
+/-- Reducing by a polynomial that vanishes at `x` preserves evaluation at `x`. -/
+theorem eval_modByMonic_eq_self_of_eval_eq_zero
+    [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) {x : R}
+    (hq : q.eval x = 0) :
+    (CPolynomial.modByMonic p q).eval x = p.eval x := by
+  have hq_raw : q.val.eval x = 0 := by
+    simpa [CPolynomial.eval, Raw.eval, Raw.eval₂] using hq
+  change ((Raw.modByMonic p.val q.val).trim).eval x = p.val.eval x
+  rw [Raw.eval_trim_eq_eval]
+  exact Raw.eval_modByMonic_eq_self_of_eval_eq_zero p.val q.val hq_raw
+
+end EvaluationDivision
+
 end CPolynomial
 
 end CompPoly

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -721,12 +721,14 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let naiveMod : CPolynomial.ModContext BabyBear.Field := CPolynomial.ModContext.naive
   let remainderOnlyMod : CPolynomial.ModContext BabyBear.Field :=
     CPolynomial.ModContext.remainderOnly
-  let directLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
-    CPolynomial.Raw.MulLowContext.direct
+  let naiveLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
+    CPolynomial.Raw.MulLowContext.naive
+  let convolutionLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
+    CPolynomial.Raw.MulLowContext.convolution
   let nttWithFallbackLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
     CPolynomial.NTT.FastMulLow.withFallback babyBearBestDomainForLength?
-  let reversalDirectLowMod : CPolynomial.ModContext BabyBear.Field :=
-    CPolynomial.ModContext.reversal directLowMul
+  let reversalConvolutionLowMod : CPolynomial.ModContext BabyBear.Field :=
+    CPolynomial.ModContext.reversal convolutionLowMul
   let reversalNttLowMod : CPolynomial.ModContext BabyBear.Field :=
     CPolynomial.ModContext.reversal nttWithFallbackLowMul
   let nextGen := gen
@@ -775,15 +777,16 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
       koalaMulRhsPoly)
     (checksumCPolynomial checksumKoalaBear))
   records := records.push (← runTimed
-    "univariate-mul-low-naive" "CPolynomial.Raw" "truncate (mul)" "BabyBear.Field"
+    "univariate-mul-low-naive" "CPolynomial.Raw" "MulLowContext.naive" "BabyBear.Field"
     univariateMulLowShape mulWarmupIterations mulMeasuredIterations
-    (fun _ ↦
-      CPolynomial.Raw.truncate univariateMulLowOutputCoeffSlots (mulLowLhsRaw * mulLowRhsRaw))
+    (fun _ ↦ naiveLowMul.mulLow univariateMulLowOutputCoeffSlots mulLowLhsRaw mulLowRhsRaw)
     (checksumRawPolynomial checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-mul-low-direct" "CPolynomial.Raw" "MulLowContext.direct" "BabyBear.Field"
+    "univariate-mul-low-convolution" "CPolynomial.Raw" "MulLowContext.convolution"
+    "BabyBear.Field"
     univariateMulLowShape mulWarmupIterations mulMeasuredIterations
-    (fun _ ↦ directLowMul.mulLow univariateMulLowOutputCoeffSlots mulLowLhsRaw mulLowRhsRaw)
+    (fun _ ↦ convolutionLowMul.mulLow univariateMulLowOutputCoeffSlots mulLowLhsRaw
+      mulLowRhsRaw)
     (checksumRawPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-mul-low-ntt-with-fallback" "CPolynomial.Raw" "FastMulLow.withFallback"
@@ -804,10 +807,10 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.modByMonicRemainderOnly batchPoly modDivisor)
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-mod-by-monic-reversal-direct-low-mul" "CPolynomial"
-    "modByMonicByReversal, MulLowContext.direct" "BabyBear.Field"
+    "univariate-mod-by-monic-reversal-convolution-low-mul" "CPolynomial"
+    "modByMonicByReversal, MulLowContext.convolution" "BabyBear.Field"
     univariateModShape modWarmupIterations modMeasuredIterations
-    (fun _ ↦ reversalDirectLowMod.modByMonic batchPoly modDivisor)
+    (fun _ ↦ reversalConvolutionLowMod.modByMonic batchPoly modDivisor)
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-mod-by-monic-reversal-ntt-low-mul" "CPolynomial"
@@ -822,10 +825,10 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.modByMonicRemainderOnly mediumBatchPoly mediumModDivisor)
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-mod-by-monic-medium-reversal-direct-low-mul" "CPolynomial"
-    "modByMonicByReversal, MulLowContext.direct" "BabyBear.Field"
+    "univariate-mod-by-monic-medium-reversal-convolution-low-mul" "CPolynomial"
+    "modByMonicByReversal, MulLowContext.convolution" "BabyBear.Field"
     mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
-    (fun _ ↦ reversalDirectLowMod.modByMonic mediumBatchPoly mediumModDivisor)
+    (fun _ ↦ reversalConvolutionLowMod.modByMonic mediumBatchPoly mediumModDivisor)
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-mod-by-monic-medium-reversal-ntt-low-mul" "CPolynomial"
@@ -862,10 +865,11 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul remainderOnlyMod batchPoly batchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-batch-subproduct-naive-mul-reversal-direct-low-mod" "CPolynomial"
-    "evalBatchSubproduct naive mul/reversal-direct-low mod" "BabyBear.Field"
+    "univariate-batch-subproduct-naive-mul-reversal-convolution-low-mod" "CPolynomial"
+    "evalBatchSubproduct naive mul/reversal-convolution-low mod" "BabyBear.Field"
     univariateBatchShape batchWarmupIterations batchMeasuredIterations
-    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul reversalDirectLowMod batchPoly batchPoints)
+    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul reversalConvolutionLowMod batchPoly
+      batchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
     "univariate-batch-subproduct-ntt-mul-reversal-ntt-low-mod" "CPolynomial"

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -45,6 +45,12 @@ private def batchWarmupIterations : Nat := 1
 /-- Number of measured iterations for full-array batch-evaluation benchmarks. -/
 private def batchMeasuredIterations : Nat := 5
 
+/-- Number of warmup iterations for larger full-array batch-evaluation benchmarks. -/
+private def largeBatchWarmupIterations : Nat := 1
+
+/-- Number of measured iterations for larger full-array batch-evaluation benchmarks. -/
+private def largeBatchMeasuredIterations : Nat := 10
+
 /-- Number of warmup iterations for direct monic-remainder benchmarks. -/
 private def modWarmupIterations : Nat := 1
 
@@ -63,6 +69,12 @@ private def univariateBatchCoeffSlots : Nat := 128
 /-- Number of points used by univariate batch-evaluation benchmarks. -/
 private def univariateBatchPointCount : Nat := 16
 
+/-- Number of coefficient slots used by larger univariate batch-evaluation benchmarks. -/
+private def largeUnivariateBatchCoeffSlots : Nat := 8192
+
+/-- Number of points used by larger univariate batch-evaluation benchmarks. -/
+private def largeUnivariateBatchPointCount : Nat := 1024
+
 /-- Number of linear factors in the direct monic-remainder benchmark divisor. -/
 private def univariateModDivisorPointCount : Nat := 16
 
@@ -72,6 +84,10 @@ private def univariateMulCoeffSlots : Nat := 128
 /-- Input-shape label for univariate batch-evaluation benchmarks. -/
 private def univariateBatchShape : String :=
   s!"degree<{univariateBatchCoeffSlots}, dense, {univariateBatchPointCount} points"
+
+/-- Input-shape label for larger univariate batch-evaluation benchmarks. -/
+private def largeUnivariateBatchShape : String :=
+  s!"degree<{largeUnivariateBatchCoeffSlots}, dense, {largeUnivariateBatchPointCount} points"
 
 /-- Input-shape label for direct univariate monic-remainder benchmarks. -/
 private def univariateModShape : String :=
@@ -630,6 +646,8 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let (points, gen) := (babyBearPoints 32).run gen
   let (batchCoeffs, gen) := (babyBearArray univariateBatchCoeffSlots false).run gen
   let (batchPoints, gen) := (babyBearPoints univariateBatchPointCount).run gen
+  let (largeBatchCoeffs, gen) := (babyBearArray largeUnivariateBatchCoeffSlots false).run gen
+  let (largeBatchPoints, gen) := (babyBearPoints largeUnivariateBatchPointCount).run gen
   let densePoly := cpolyOfArray denseCoeffs
   let sparsePoly := cpolyOfArray sparseCoeffs
   let mulLhsPoly := cpolyOfArray mulLhsCoeffs
@@ -637,6 +655,7 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let koalaMulLhsPoly := cpolyOfArray koalaMulLhsCoeffs
   let koalaMulRhsPoly := cpolyOfArray koalaMulRhsCoeffs
   let batchPoly := cpolyOfArray batchCoeffs
+  let largeBatchPoly := cpolyOfArray largeBatchCoeffs
   let modDivisor := monicDivisorFromPoints batchPoints
   let naiveMul : CPolynomial.MulContext BabyBear.Field := CPolynomial.MulContext.naive
   let nttMul : CPolynomial.MulContext BabyBear.Field :=
@@ -725,6 +744,28 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     "evalBatchSubproduct ntt mul/fast mod" "BabyBear.Field"
     univariateBatchShape batchWarmupIterations batchMeasuredIterations
     (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul fastMod batchPoly batchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-large-naive-sum" "CPolynomial" "evalBatch" "BabyBear.Field"
+    largeUnivariateBatchShape largeBatchWarmupIterations largeBatchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatch largeBatchPoly largeBatchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-large-naive-horner" "CPolynomial" "evalBatchHorner" "BabyBear.Field"
+    largeUnivariateBatchShape largeBatchWarmupIterations largeBatchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchHorner largeBatchPoly largeBatchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-large-subproduct-naive-mul-fast-mod" "CPolynomial"
+    "evalBatchSubproduct naive mul/fast mod" "BabyBear.Field"
+    largeUnivariateBatchShape largeBatchWarmupIterations largeBatchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul fastMod largeBatchPoly largeBatchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-large-subproduct-ntt-mul-fast-mod" "CPolynomial"
+    "evalBatchSubproduct ntt mul/fast mod" "BabyBear.Field"
+    largeUnivariateBatchShape largeBatchWarmupIterations largeBatchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul fastMod largeBatchPoly largeBatchPoints)
     (checksumArray checksumBabyBear))
   let (goldilocksRecords, extraGen) ← runDenseUnivariateZMod
     Goldilocks.fieldSize "goldilocks" "Goldilocks.Field" nextGen

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -79,7 +79,13 @@ private def largeUnivariateBatchPointCount : Nat := 1024
 private def univariateModDivisorPointCount : Nat := 16
 
 /-- Number of coefficient slots used by direct univariate multiplication benchmarks. -/
-private def univariateMulCoeffSlots : Nat := 128
+private def univariateMulCoeffSlots : Nat := 512
+
+/-- Number of coefficient slots used by low-product benchmarks. -/
+private def univariateMulLowCoeffSlots : Nat := 512
+
+/-- Number of low coefficients kept by low-product benchmarks. -/
+private def univariateMulLowOutputCoeffSlots : Nat := 512
 
 /-- Input-shape label for univariate batch-evaluation benchmarks. -/
 private def univariateBatchShape : String :=
@@ -97,6 +103,10 @@ private def univariateModShape : String :=
 /-- Input-shape label for direct univariate multiplication benchmarks. -/
 private def univariateMulShape : String :=
   s!"degree<{univariateMulCoeffSlots} dense lhs/rhs"
+
+/-- Input-shape label for direct univariate low-product benchmarks. -/
+private def univariateMulLowShape : String :=
+  s!"degree<{univariateMulLowCoeffSlots} dense lhs/rhs, low<{univariateMulLowOutputCoeffSlots}"
 
 /-- Number of warmup iterations for the slower additive NTT benchmark. -/
 private def additiveNttWarmupIterations : Nat := 10
@@ -134,13 +144,19 @@ instance : Fact (Nat.Prime BabyBear.fieldSize) where
 instance : Fact (Nat.Prime Goldilocks.fieldSize) where
   out := Goldilocks.is_prime
 
-/-- NTT domain large enough for direct degree-128 BabyBear multiplication benchmarks. -/
+/-- NTT domain large enough for direct degree-512 BabyBear multiplication benchmarks. -/
 private def babyBearMulNttDomain : CPolynomial.NTT.Domain BabyBear.Field :=
-  CPolynomial.NTT.BabyBear.domainOfLogN 8 (by decide)
+  CPolynomial.NTT.BabyBear.domainOfLogN 10 (by decide)
 
-/-- NTT domain large enough for direct degree-128 KoalaBear multiplication benchmarks. -/
+/-- Best-fitting BabyBear NTT domain lookup for dynamic multiplication contexts. -/
+private def babyBearBestDomainForLength? (requiredLen : Nat) :
+    Option (CPolynomial.NTT.FittingDomain BabyBear.Field requiredLen) :=
+  CPolynomial.NTT.bestDomainForLength? BabyBear.twoAdicity
+    CPolynomial.NTT.BabyBear.domainOfLogN (by intro _ _; rfl) requiredLen
+
+/-- NTT domain large enough for direct degree-512 KoalaBear multiplication benchmarks. -/
 private def koalaBearMulNttDomain : CPolynomial.NTT.Domain KoalaBear.Field :=
-  CPolynomial.NTT.KoalaBear.domainOfLogN 8 (by decide)
+  CPolynomial.NTT.KoalaBear.domainOfLogN 10 (by decide)
 
 /-- Result row emitted by one timed benchmark case. -/
 structure BenchRecord where
@@ -366,6 +382,10 @@ private def checksumArray (checksum : α → Nat) (xs : Array α) : Nat :=
 /-- Checksum a canonical univariate polynomial by its coefficient array. -/
 private def checksumCPolynomial [Zero α] (checksum : α → Nat) (p : CPolynomial α) : Nat :=
   checksumArray checksum p.val
+
+/-- Checksum a raw univariate polynomial by its stored coefficient array. -/
+private def checksumRawPolynomial (checksum : α → Nat) (p : CPolynomial.Raw α) : Nat :=
+  checksumArray checksum p
 
 /-- Time one benchmark closure and package its metadata and checksum. -/
 private def runTimed (name representation method field inputShape : String)
@@ -641,6 +661,8 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let (sparseCoeffs, gen) := (babyBearArray 512 true).run gen
   let (mulLhsCoeffs, gen) := (babyBearArray univariateMulCoeffSlots false).run gen
   let (mulRhsCoeffs, gen) := (babyBearArray univariateMulCoeffSlots false).run gen
+  let (mulLowLhsCoeffs, gen) := (babyBearArray univariateMulLowCoeffSlots false).run gen
+  let (mulLowRhsCoeffs, gen) := (babyBearArray univariateMulLowCoeffSlots false).run gen
   let (koalaMulLhsCoeffs, gen) := (koalaBearArray univariateMulCoeffSlots false).run gen
   let (koalaMulRhsCoeffs, gen) := (koalaBearArray univariateMulCoeffSlots false).run gen
   let (points, gen) := (babyBearPoints 32).run gen
@@ -650,6 +672,8 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let (largeBatchPoints, gen) := (babyBearPoints largeUnivariateBatchPointCount).run gen
   let densePoly := cpolyOfArray denseCoeffs
   let sparsePoly := cpolyOfArray sparseCoeffs
+  let mulLowLhsRaw : CPolynomial.Raw BabyBear.Field := mulLowLhsCoeffs
+  let mulLowRhsRaw : CPolynomial.Raw BabyBear.Field := mulLowRhsCoeffs
   let mulLhsPoly := cpolyOfArray mulLhsCoeffs
   let mulRhsPoly := cpolyOfArray mulRhsCoeffs
   let koalaMulLhsPoly := cpolyOfArray koalaMulLhsCoeffs
@@ -659,10 +683,14 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let modDivisor := monicDivisorFromPoints batchPoints
   let naiveMul : CPolynomial.MulContext BabyBear.Field := CPolynomial.MulContext.naive
   let nttMul : CPolynomial.MulContext BabyBear.Field :=
-    CPolynomial.MulContext.ntt BabyBear.twoAdicity CPolynomial.NTT.BabyBear.domainOfLogN
+    CPolynomial.MulContext.ntt babyBearBestDomainForLength?
   let naiveMod : CPolynomial.ModContext BabyBear.Field := CPolynomial.ModContext.naive
   let remainderOnlyMod : CPolynomial.ModContext BabyBear.Field :=
     CPolynomial.ModContext.remainderOnly
+  let directLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
+    CPolynomial.Raw.MulLowContext.direct
+  let nttTruncateLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
+    CPolynomial.Raw.MulLowContext.nttTruncate babyBearBestDomainForLength?
   let nextGen := gen
   let mut records := #[]
   records := records.push (← runTimed
@@ -702,7 +730,7 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ mulLhsPoly * mulRhsPoly)
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-mul-ntt" "CPolynomial" "FastMul.fastMulImpl, domain n=256"
+    "univariate-mul-ntt" "CPolynomial" "FastMul.fastMulImpl, domain n=1024"
     "BabyBear.Field"
     univariateMulShape mulWarmupIterations mulMeasuredIterations
     (fun _ ↦ CPolynomial.NTT.FastMul.fastMulImpl babyBearMulNttDomain mulLhsPoly mulRhsPoly)
@@ -713,12 +741,30 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ koalaMulLhsPoly * koalaMulRhsPoly)
     (checksumCPolynomial checksumKoalaBear))
   records := records.push (← runTimed
-    "univariate-mul-ntt-koalabear" "CPolynomial" "FastMul.fastMulImpl, domain n=256"
+    "univariate-mul-ntt-koalabear" "CPolynomial" "FastMul.fastMulImpl, domain n=1024"
     "KoalaBear.Field"
     univariateMulShape mulWarmupIterations mulMeasuredIterations
     (fun _ ↦ CPolynomial.NTT.FastMul.fastMulImpl koalaBearMulNttDomain koalaMulLhsPoly
       koalaMulRhsPoly)
     (checksumCPolynomial checksumKoalaBear))
+  records := records.push (← runTimed
+    "univariate-mul-low-naive" "CPolynomial.Raw" "truncate (mul)" "BabyBear.Field"
+    univariateMulLowShape mulWarmupIterations mulMeasuredIterations
+    (fun _ ↦
+      CPolynomial.Raw.truncate univariateMulLowOutputCoeffSlots (mulLowLhsRaw * mulLowRhsRaw))
+    (checksumRawPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mul-low-direct" "CPolynomial.Raw" "MulLowContext.direct" "BabyBear.Field"
+    univariateMulLowShape mulWarmupIterations mulMeasuredIterations
+    (fun _ ↦ directLowMul.mulLow univariateMulLowOutputCoeffSlots mulLowLhsRaw mulLowRhsRaw)
+    (checksumRawPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mul-low-ntt-truncate" "CPolynomial.Raw" "MulLowContext.nttTruncate"
+    "BabyBear.Field"
+    univariateMulLowShape mulWarmupIterations mulMeasuredIterations
+    (fun _ ↦ nttTruncateLowMul.mulLow univariateMulLowOutputCoeffSlots mulLowLhsRaw
+      mulLowRhsRaw)
+    (checksumRawPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-batch-naive-sum" "CPolynomial" "evalBatch" "BabyBear.Field"
     univariateBatchShape batchWarmupIterations batchMeasuredIterations

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -18,6 +18,7 @@ import CompPoly.Univariate.BatchEval
 import CompPoly.Univariate.NTT.BabyBear
 import CompPoly.Univariate.NTT.KoalaBear
 import CompPoly.Univariate.NTT.FastMul
+import CompPoly.Univariate.NTT.FastMulLow
 
 /-!
 # Evaluation Benchmarks
@@ -722,12 +723,12 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     CPolynomial.ModContext.remainderOnly
   let directLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
     CPolynomial.Raw.MulLowContext.direct
-  let nttTruncateLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
-    CPolynomial.Raw.MulLowContext.nttTruncate babyBearBestDomainForLength?
+  let nttWithFallbackLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
+    CPolynomial.NTT.FastMulLow.withFallback babyBearBestDomainForLength?
   let reversalDirectLowMod : CPolynomial.ModContext BabyBear.Field :=
     CPolynomial.ModContext.reversal directLowMul
   let reversalNttLowMod : CPolynomial.ModContext BabyBear.Field :=
-    CPolynomial.ModContext.reversal nttTruncateLowMul
+    CPolynomial.ModContext.reversal nttWithFallbackLowMul
   let nextGen := gen
   let mut records := #[]
   records := records.push (← runTimed
@@ -769,7 +770,7 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-mod-by-monic-reversal-ntt-low-mul" "CPolynomial"
-    "modByMonicByReversal, MulLowContext.nttTruncate" "BabyBear.Field"
+    "modByMonicByReversal, FastMulLow.withFallback" "BabyBear.Field"
     univariateModShape modWarmupIterations modMeasuredIterations
     (fun _ ↦ reversalNttLowMod.modByMonic batchPoly modDivisor)
     (checksumCPolynomial checksumBabyBear))
@@ -787,7 +788,7 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-mod-by-monic-medium-reversal-ntt-low-mul" "CPolynomial"
-    "modByMonicByReversal, MulLowContext.nttTruncate" "BabyBear.Field"
+    "modByMonicByReversal, FastMulLow.withFallback" "BabyBear.Field"
     mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
     (fun _ ↦ reversalNttLowMod.modByMonic mediumBatchPoly mediumModDivisor)
     (checksumCPolynomial checksumBabyBear))
@@ -826,10 +827,10 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ directLowMul.mulLow univariateMulLowOutputCoeffSlots mulLowLhsRaw mulLowRhsRaw)
     (checksumRawPolynomial checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-mul-low-ntt-truncate" "CPolynomial.Raw" "MulLowContext.nttTruncate"
+    "univariate-mul-low-ntt-with-fallback" "CPolynomial.Raw" "FastMulLow.withFallback"
     "BabyBear.Field"
     univariateMulLowShape mulWarmupIterations mulMeasuredIterations
-    (fun _ ↦ nttTruncateLowMul.mulLow univariateMulLowOutputCoeffSlots mulLowLhsRaw
+    (fun _ ↦ nttWithFallbackLowMul.mulLow univariateMulLowOutputCoeffSlots mulLowLhsRaw
       mulLowRhsRaw)
     (checksumRawPolynomial checksumBabyBear))
   records := records.push (← runTimed

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -52,10 +52,10 @@ private def mediumBatchWarmupIterations : Nat := 1
 /-- Number of measured iterations for medium full-array batch-evaluation benchmarks. -/
 private def mediumBatchMeasuredIterations : Nat := 10
 
-/-- Number of warmup iterations for larger full-array batch-evaluation benchmarks. -/
+/-- Number of warmup iterations for large full-array batch-evaluation benchmarks. -/
 private def largeBatchWarmupIterations : Nat := 1
 
-/-- Number of measured iterations for larger full-array batch-evaluation benchmarks. -/
+/-- Number of measured iterations for large full-array batch-evaluation benchmarks. -/
 private def largeBatchMeasuredIterations : Nat := 10
 
 /-- Number of warmup iterations for direct monic-remainder benchmarks. -/
@@ -88,10 +88,10 @@ private def mediumUnivariateBatchCoeffSlots : Nat := 8192
 /-- Number of points used by medium univariate batch-evaluation benchmarks. -/
 private def mediumUnivariateBatchPointCount : Nat := 1024
 
-/-- Number of coefficient slots used by larger univariate batch-evaluation benchmarks. -/
+/-- Number of coefficient slots used by large univariate batch-evaluation benchmarks. -/
 private def largeUnivariateBatchCoeffSlots : Nat := 65536
 
-/-- Number of points used by larger univariate batch-evaluation benchmarks. -/
+/-- Number of points used by large univariate batch-evaluation benchmarks. -/
 private def largeUnivariateBatchPointCount : Nat := 8192
 
 /-- Number of linear factors in the direct monic-remainder benchmark divisor. -/
@@ -115,7 +115,7 @@ private def mediumUnivariateBatchShape : String :=
   s!"degree<{mediumUnivariateBatchCoeffSlots}, dense, " ++
     s!"{mediumUnivariateBatchPointCount} points"
 
-/-- Input-shape label for larger univariate batch-evaluation benchmarks. -/
+/-- Input-shape label for large univariate batch-evaluation benchmarks. -/
 private def largeUnivariateBatchShape : String :=
   s!"degree<{largeUnivariateBatchCoeffSlots}, dense, " ++
     s!"{largeUnivariateBatchPointCount} points"

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -45,6 +45,12 @@ private def batchWarmupIterations : Nat := 1
 /-- Number of measured iterations for full-array batch-evaluation benchmarks. -/
 private def batchMeasuredIterations : Nat := 5
 
+/-- Number of warmup iterations for medium full-array batch-evaluation benchmarks. -/
+private def mediumBatchWarmupIterations : Nat := 1
+
+/-- Number of measured iterations for medium full-array batch-evaluation benchmarks. -/
+private def mediumBatchMeasuredIterations : Nat := 10
+
 /-- Number of warmup iterations for larger full-array batch-evaluation benchmarks. -/
 private def largeBatchWarmupIterations : Nat := 1
 
@@ -56,6 +62,12 @@ private def modWarmupIterations : Nat := 1
 
 /-- Number of measured iterations for direct monic-remainder benchmarks. -/
 private def modMeasuredIterations : Nat := 20
+
+/-- Number of warmup iterations for medium direct monic-remainder benchmarks. -/
+private def mediumModWarmupIterations : Nat := 1
+
+/-- Number of measured iterations for medium direct monic-remainder benchmarks. -/
+private def mediumModMeasuredIterations : Nat := 5
 
 /-- Number of warmup iterations for direct univariate multiplication benchmarks. -/
 private def mulWarmupIterations : Nat := 1
@@ -69,11 +81,17 @@ private def univariateBatchCoeffSlots : Nat := 128
 /-- Number of points used by univariate batch-evaluation benchmarks. -/
 private def univariateBatchPointCount : Nat := 16
 
+/-- Number of coefficient slots used by medium univariate batch-evaluation benchmarks. -/
+private def mediumUnivariateBatchCoeffSlots : Nat := 8192
+
+/-- Number of points used by medium univariate batch-evaluation benchmarks. -/
+private def mediumUnivariateBatchPointCount : Nat := 1024
+
 /-- Number of coefficient slots used by larger univariate batch-evaluation benchmarks. -/
-private def largeUnivariateBatchCoeffSlots : Nat := 8192
+private def largeUnivariateBatchCoeffSlots : Nat := 65536
 
 /-- Number of points used by larger univariate batch-evaluation benchmarks. -/
-private def largeUnivariateBatchPointCount : Nat := 1024
+private def largeUnivariateBatchPointCount : Nat := 8192
 
 /-- Number of linear factors in the direct monic-remainder benchmark divisor. -/
 private def univariateModDivisorPointCount : Nat := 16
@@ -91,14 +109,25 @@ private def univariateMulLowOutputCoeffSlots : Nat := 512
 private def univariateBatchShape : String :=
   s!"degree<{univariateBatchCoeffSlots}, dense, {univariateBatchPointCount} points"
 
+/-- Input-shape label for medium univariate batch-evaluation benchmarks. -/
+private def mediumUnivariateBatchShape : String :=
+  s!"degree<{mediumUnivariateBatchCoeffSlots}, dense, " ++
+    s!"{mediumUnivariateBatchPointCount} points"
+
 /-- Input-shape label for larger univariate batch-evaluation benchmarks. -/
 private def largeUnivariateBatchShape : String :=
-  s!"degree<{largeUnivariateBatchCoeffSlots}, dense, {largeUnivariateBatchPointCount} points"
+  s!"degree<{largeUnivariateBatchCoeffSlots}, dense, " ++
+    s!"{largeUnivariateBatchPointCount} points"
 
 /-- Input-shape label for direct univariate monic-remainder benchmarks. -/
 private def univariateModShape : String :=
   s!"degree<{univariateBatchCoeffSlots} dividend, degree={univariateModDivisorPointCount} " ++
     "monic divisor"
+
+/-- Input-shape label for medium direct univariate monic-remainder benchmarks. -/
+private def mediumUnivariateModShape : String :=
+  s!"degree<{mediumUnivariateBatchCoeffSlots} dividend, " ++
+    s!"degree={mediumUnivariateBatchPointCount} monic divisor"
 
 /-- Input-shape label for direct univariate multiplication benchmarks. -/
 private def univariateMulShape : String :=
@@ -668,6 +697,8 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let (points, gen) := (babyBearPoints 32).run gen
   let (batchCoeffs, gen) := (babyBearArray univariateBatchCoeffSlots false).run gen
   let (batchPoints, gen) := (babyBearPoints univariateBatchPointCount).run gen
+  let (mediumBatchCoeffs, gen) := (babyBearArray mediumUnivariateBatchCoeffSlots false).run gen
+  let (mediumBatchPoints, gen) := (babyBearPoints mediumUnivariateBatchPointCount).run gen
   let (largeBatchCoeffs, gen) := (babyBearArray largeUnivariateBatchCoeffSlots false).run gen
   let (largeBatchPoints, gen) := (babyBearPoints largeUnivariateBatchPointCount).run gen
   let densePoly := cpolyOfArray denseCoeffs
@@ -679,8 +710,10 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let koalaMulLhsPoly := cpolyOfArray koalaMulLhsCoeffs
   let koalaMulRhsPoly := cpolyOfArray koalaMulRhsCoeffs
   let batchPoly := cpolyOfArray batchCoeffs
+  let mediumBatchPoly := cpolyOfArray mediumBatchCoeffs
   let largeBatchPoly := cpolyOfArray largeBatchCoeffs
   let modDivisor := monicDivisorFromPoints batchPoints
+  let mediumModDivisor := monicDivisorFromPoints mediumBatchPoints
   let naiveMul : CPolynomial.MulContext BabyBear.Field := CPolynomial.MulContext.naive
   let nttMul : CPolynomial.MulContext BabyBear.Field :=
     CPolynomial.MulContext.ntt babyBearBestDomainForLength?
@@ -691,6 +724,10 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     CPolynomial.Raw.MulLowContext.direct
   let nttTruncateLowMul : CPolynomial.Raw.MulLowContext BabyBear.Field :=
     CPolynomial.Raw.MulLowContext.nttTruncate babyBearBestDomainForLength?
+  let reversalDirectLowMod : CPolynomial.ModContext BabyBear.Field :=
+    CPolynomial.ModContext.reversal directLowMul
+  let reversalNttLowMod : CPolynomial.ModContext BabyBear.Field :=
+    CPolynomial.ModContext.reversal nttTruncateLowMul
   let nextGen := gen
   let mut records := #[]
   records := records.push (← runTimed
@@ -723,6 +760,36 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     "BabyBear.Field"
     univariateModShape modWarmupIterations modMeasuredIterations
     (fun _ ↦ CPolynomial.modByMonicRemainderOnly batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-reversal-direct-low-mul" "CPolynomial"
+    "modByMonicByReversal, MulLowContext.direct" "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ reversalDirectLowMod.modByMonic batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-reversal-ntt-low-mul" "CPolynomial"
+    "modByMonicByReversal, MulLowContext.nttTruncate" "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ reversalNttLowMod.modByMonic batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-medium-remainder-only" "CPolynomial"
+    "modByMonicRemainderOnly" "BabyBear.Field"
+    mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
+    (fun _ ↦ CPolynomial.modByMonicRemainderOnly mediumBatchPoly mediumModDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-medium-reversal-direct-low-mul" "CPolynomial"
+    "modByMonicByReversal, MulLowContext.direct" "BabyBear.Field"
+    mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
+    (fun _ ↦ reversalDirectLowMod.modByMonic mediumBatchPoly mediumModDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-medium-reversal-ntt-low-mul" "CPolynomial"
+    "modByMonicByReversal, MulLowContext.nttTruncate" "BabyBear.Field"
+    mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
+    (fun _ ↦ reversalNttLowMod.modByMonic mediumBatchPoly mediumModDivisor)
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-mul-naive" "CPolynomial" "mul" "BabyBear.Field"
@@ -794,9 +861,47 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul remainderOnlyMod batchPoly batchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-batch-large-naive-sum" "CPolynomial" "evalBatch" "BabyBear.Field"
-    largeUnivariateBatchShape largeBatchWarmupIterations largeBatchMeasuredIterations
-    (fun _ ↦ CPolynomial.evalBatch largeBatchPoly largeBatchPoints)
+    "univariate-batch-subproduct-naive-mul-reversal-direct-low-mod" "CPolynomial"
+    "evalBatchSubproduct naive mul/reversal-direct-low mod" "BabyBear.Field"
+    univariateBatchShape batchWarmupIterations batchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul reversalDirectLowMod batchPoly batchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-subproduct-ntt-mul-reversal-ntt-low-mod" "CPolynomial"
+    "evalBatchSubproduct ntt mul/reversal-ntt-low mod" "BabyBear.Field"
+    univariateBatchShape batchWarmupIterations batchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul reversalNttLowMod batchPoly batchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-medium-naive-sum" "CPolynomial" "evalBatch" "BabyBear.Field"
+    mediumUnivariateBatchShape mediumBatchWarmupIterations mediumBatchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatch mediumBatchPoly mediumBatchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-medium-naive-horner" "CPolynomial" "evalBatchHorner" "BabyBear.Field"
+    mediumUnivariateBatchShape mediumBatchWarmupIterations mediumBatchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchHorner mediumBatchPoly mediumBatchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-medium-subproduct-naive-mul-remainder-only-mod" "CPolynomial"
+    "evalBatchSubproduct naive mul/remainder-only mod" "BabyBear.Field"
+    mediumUnivariateBatchShape mediumBatchWarmupIterations mediumBatchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul remainderOnlyMod mediumBatchPoly
+      mediumBatchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-medium-subproduct-ntt-mul-remainder-only-mod" "CPolynomial"
+    "evalBatchSubproduct ntt mul/remainder-only mod" "BabyBear.Field"
+    mediumUnivariateBatchShape mediumBatchWarmupIterations mediumBatchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul remainderOnlyMod mediumBatchPoly
+      mediumBatchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-medium-subproduct-ntt-mul-reversal-ntt-low-mod" "CPolynomial"
+    "evalBatchSubproduct ntt mul/reversal-ntt-low mod" "BabyBear.Field"
+    mediumUnivariateBatchShape mediumBatchWarmupIterations mediumBatchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul reversalNttLowMod mediumBatchPoly
+      mediumBatchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
     "univariate-batch-large-naive-horner" "CPolynomial" "evalBatchHorner" "BabyBear.Field"
@@ -804,17 +909,10 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.evalBatchHorner largeBatchPoly largeBatchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-batch-large-subproduct-naive-mul-remainder-only-mod" "CPolynomial"
-    "evalBatchSubproduct naive mul/remainder-only mod" "BabyBear.Field"
+    "univariate-batch-large-subproduct-ntt-mul-reversal-ntt-low-mod" "CPolynomial"
+    "evalBatchSubproduct ntt mul/reversal-ntt-low mod" "BabyBear.Field"
     largeUnivariateBatchShape largeBatchWarmupIterations largeBatchMeasuredIterations
-    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul remainderOnlyMod largeBatchPoly
-      largeBatchPoints)
-    (checksumArray checksumBabyBear))
-  records := records.push (← runTimed
-    "univariate-batch-large-subproduct-ntt-mul-remainder-only-mod" "CPolynomial"
-    "evalBatchSubproduct ntt mul/remainder-only mod" "BabyBear.Field"
-    largeUnivariateBatchShape largeBatchWarmupIterations largeBatchMeasuredIterations
-    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul remainderOnlyMod largeBatchPoly
+    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul reversalNttLowMod largeBatchPoly
       largeBatchPoints)
     (checksumArray checksumBabyBear))
   let (goldilocksRecords, extraGen) ← runDenseUnivariateZMod

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -661,7 +661,8 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let nttMul : CPolynomial.MulContext BabyBear.Field :=
     CPolynomial.MulContext.ntt BabyBear.twoAdicity CPolynomial.NTT.BabyBear.domainOfLogN
   let naiveMod : CPolynomial.ModContext BabyBear.Field := CPolynomial.ModContext.naive
-  let fastMod : CPolynomial.ModContext BabyBear.Field := CPolynomial.ModContext.fast
+  let remainderOnlyMod : CPolynomial.ModContext BabyBear.Field :=
+    CPolynomial.ModContext.remainderOnly
   let nextGen := gen
   let mut records := #[]
   records := records.push (← runTimed
@@ -690,9 +691,10 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.modByMonic batchPoly modDivisor)
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-mod-by-monic-fast" "CPolynomial" "modByMonicFast" "BabyBear.Field"
+    "univariate-mod-by-monic-remainder-only" "CPolynomial" "modByMonicRemainderOnly"
+    "BabyBear.Field"
     univariateModShape modWarmupIterations modMeasuredIterations
-    (fun _ ↦ CPolynomial.modByMonicFast batchPoly modDivisor)
+    (fun _ ↦ CPolynomial.modByMonicRemainderOnly batchPoly modDivisor)
     (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-mul-naive" "CPolynomial" "mul" "BabyBear.Field"
@@ -734,16 +736,16 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul naiveMod batchPoly batchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-batch-subproduct-naive-mul-fast-mod" "CPolynomial"
-    "evalBatchSubproduct naive mul/fast mod" "BabyBear.Field"
+    "univariate-batch-subproduct-naive-mul-remainder-only-mod" "CPolynomial"
+    "evalBatchSubproduct naive mul/remainder-only mod" "BabyBear.Field"
     univariateBatchShape batchWarmupIterations batchMeasuredIterations
-    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul fastMod batchPoly batchPoints)
+    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul remainderOnlyMod batchPoly batchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-batch-subproduct-ntt-mul-fast-mod" "CPolynomial"
-    "evalBatchSubproduct ntt mul/fast mod" "BabyBear.Field"
+    "univariate-batch-subproduct-ntt-mul-remainder-only-mod" "CPolynomial"
+    "evalBatchSubproduct ntt mul/remainder-only mod" "BabyBear.Field"
     univariateBatchShape batchWarmupIterations batchMeasuredIterations
-    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul fastMod batchPoly batchPoints)
+    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul remainderOnlyMod batchPoly batchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
     "univariate-batch-large-naive-sum" "CPolynomial" "evalBatch" "BabyBear.Field"
@@ -756,16 +758,18 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.evalBatchHorner largeBatchPoly largeBatchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-batch-large-subproduct-naive-mul-fast-mod" "CPolynomial"
-    "evalBatchSubproduct naive mul/fast mod" "BabyBear.Field"
+    "univariate-batch-large-subproduct-naive-mul-remainder-only-mod" "CPolynomial"
+    "evalBatchSubproduct naive mul/remainder-only mod" "BabyBear.Field"
     largeUnivariateBatchShape largeBatchWarmupIterations largeBatchMeasuredIterations
-    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul fastMod largeBatchPoly largeBatchPoints)
+    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul remainderOnlyMod largeBatchPoly
+      largeBatchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-batch-large-subproduct-ntt-mul-fast-mod" "CPolynomial"
-    "evalBatchSubproduct ntt mul/fast mod" "BabyBear.Field"
+    "univariate-batch-large-subproduct-ntt-mul-remainder-only-mod" "CPolynomial"
+    "evalBatchSubproduct ntt mul/remainder-only mod" "BabyBear.Field"
     largeUnivariateBatchShape largeBatchWarmupIterations largeBatchMeasuredIterations
-    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul fastMod largeBatchPoly largeBatchPoints)
+    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul remainderOnlyMod largeBatchPoly
+      largeBatchPoints)
     (checksumArray checksumBabyBear))
   let (goldilocksRecords, extraGen) ← runDenseUnivariateZMod
     Goldilocks.fieldSize "goldilocks" "Goldilocks.Field" nextGen

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -14,6 +14,7 @@ import CompPoly.Fields.BN254
 import CompPoly.Fields.Goldilocks
 import CompPoly.Multilinear.Basic
 import CompPoly.Multivariate.CMvPolynomial
+import CompPoly.Univariate.BatchEval
 import CompPoly.Univariate.NTT.BabyBear
 import CompPoly.Univariate.NTT.KoalaBear
 import CompPoly.Univariate.NTT.FastMul
@@ -38,14 +39,30 @@ private def warmupIterations : Nat := 100
 /-- Number of measured iterations for ordinary evaluation benchmarks. -/
 private def measuredIterations : Nat := 5000
 
+/-- Number of warmup iterations for full-array batch-evaluation benchmarks. -/
+private def batchWarmupIterations : Nat := 1
+
+/-- Number of measured iterations for full-array batch-evaluation benchmarks. -/
+private def batchMeasuredIterations : Nat := 5
+
 /-- Number of warmup iterations for direct univariate multiplication benchmarks. -/
 private def mulWarmupIterations : Nat := 1
 
 /-- Number of measured iterations for direct univariate multiplication benchmarks. -/
 private def mulMeasuredIterations : Nat := 20
 
+/-- Number of coefficient slots used by univariate batch-evaluation benchmarks. -/
+private def univariateBatchCoeffSlots : Nat := 128
+
+/-- Number of points used by univariate batch-evaluation benchmarks. -/
+private def univariateBatchPointCount : Nat := 16
+
 /-- Number of coefficient slots used by direct univariate multiplication benchmarks. -/
 private def univariateMulCoeffSlots : Nat := 128
+
+/-- Input-shape label for univariate batch-evaluation benchmarks. -/
+private def univariateBatchShape : String :=
+  s!"degree<{univariateBatchCoeffSlots}, dense, {univariateBatchPointCount} points"
 
 /-- Input-shape label for direct univariate multiplication benchmarks. -/
 private def univariateMulShape : String :=
@@ -592,12 +609,17 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let (koalaMulLhsCoeffs, gen) := (koalaBearArray univariateMulCoeffSlots false).run gen
   let (koalaMulRhsCoeffs, gen) := (koalaBearArray univariateMulCoeffSlots false).run gen
   let (points, gen) := (babyBearPoints 32).run gen
+  let (batchCoeffs, gen) := (babyBearArray univariateBatchCoeffSlots false).run gen
+  let (batchPoints, gen) := (babyBearPoints univariateBatchPointCount).run gen
   let densePoly := cpolyOfArray denseCoeffs
   let sparsePoly := cpolyOfArray sparseCoeffs
   let mulLhsPoly := cpolyOfArray mulLhsCoeffs
   let mulRhsPoly := cpolyOfArray mulRhsCoeffs
   let koalaMulLhsPoly := cpolyOfArray koalaMulLhsCoeffs
   let koalaMulRhsPoly := cpolyOfArray koalaMulRhsCoeffs
+  let batchPoly := cpolyOfArray batchCoeffs
+  let naiveMul : CPolynomial.MulContext BabyBear.Field := CPolynomial.MulContext.naive
+  let naiveMod : CPolynomial.ModContext BabyBear.Field := CPolynomial.ModContext.naive
   let nextGen := gen
   let mut records := #[]
   records := records.push (← runTimed
@@ -643,6 +665,22 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.NTT.FastMul.fastMulImpl koalaBearMulNttDomain koalaMulLhsPoly
       koalaMulRhsPoly)
     (checksumCPolynomial checksumKoalaBear))
+  records := records.push (← runTimed
+    "univariate-batch-naive-sum" "CPolynomial" "evalBatch" "BabyBear.Field"
+    univariateBatchShape batchWarmupIterations batchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatch batchPoly batchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-naive-horner" "CPolynomial" "evalBatchHorner" "BabyBear.Field"
+    univariateBatchShape batchWarmupIterations batchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchHorner batchPoly batchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-subproduct-naive-mul-naive-mod" "CPolynomial"
+    "evalBatchSubproduct naive mul/mod" "BabyBear.Field"
+    univariateBatchShape batchWarmupIterations batchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul naiveMod batchPoly batchPoints)
+    (checksumArray checksumBabyBear))
   let (goldilocksRecords, extraGen) ← runDenseUnivariateZMod
     Goldilocks.fieldSize "goldilocks" "Goldilocks.Field" nextGen
   records := appendRecords records goldilocksRecords

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -639,6 +639,8 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let batchPoly := cpolyOfArray batchCoeffs
   let modDivisor := monicDivisorFromPoints batchPoints
   let naiveMul : CPolynomial.MulContext BabyBear.Field := CPolynomial.MulContext.naive
+  let nttMul : CPolynomial.MulContext BabyBear.Field :=
+    CPolynomial.MulContext.ntt BabyBear.twoAdicity CPolynomial.NTT.BabyBear.domainOfLogN
   let naiveMod : CPolynomial.ModContext BabyBear.Field := CPolynomial.ModContext.naive
   let fastMod : CPolynomial.ModContext BabyBear.Field := CPolynomial.ModContext.fast
   let nextGen := gen
@@ -663,6 +665,16 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     "degree<512, one nonzero per 4 coeffs, 32 points" warmupIterations measuredIterations
     (fun i ↦ CPolynomial.evalHorner (points.getD (i % points.size) 0) sparsePoly)
     checksumBabyBear)
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-naive" "CPolynomial" "modByMonic" "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ CPolynomial.modByMonic batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-fast" "CPolynomial" "modByMonicFast" "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ CPolynomial.modByMonicFast batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-mul-naive" "CPolynomial" "mul" "BabyBear.Field"
     univariateMulShape mulWarmupIterations mulMeasuredIterations
@@ -697,16 +709,6 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.evalBatchHorner batchPoly batchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
-    "univariate-mod-by-monic-naive" "CPolynomial" "modByMonic" "BabyBear.Field"
-    univariateModShape modWarmupIterations modMeasuredIterations
-    (fun _ ↦ CPolynomial.modByMonic batchPoly modDivisor)
-    (checksumCPolynomial checksumBabyBear))
-  records := records.push (← runTimed
-    "univariate-mod-by-monic-fast" "CPolynomial" "modByMonicFast" "BabyBear.Field"
-    univariateModShape modWarmupIterations modMeasuredIterations
-    (fun _ ↦ CPolynomial.modByMonicFast batchPoly modDivisor)
-    (checksumCPolynomial checksumBabyBear))
-  records := records.push (← runTimed
     "univariate-batch-subproduct-naive-mul-naive-mod" "CPolynomial"
     "evalBatchSubproduct naive mul/mod" "BabyBear.Field"
     univariateBatchShape batchWarmupIterations batchMeasuredIterations
@@ -717,6 +719,12 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     "evalBatchSubproduct naive mul/fast mod" "BabyBear.Field"
     univariateBatchShape batchWarmupIterations batchMeasuredIterations
     (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul fastMod batchPoly batchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-subproduct-ntt-mul-fast-mod" "CPolynomial"
+    "evalBatchSubproduct ntt mul/fast mod" "BabyBear.Field"
+    univariateBatchShape batchWarmupIterations batchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct nttMul fastMod batchPoly batchPoints)
     (checksumArray checksumBabyBear))
   let (goldilocksRecords, extraGen) ← runDenseUnivariateZMod
     Goldilocks.fieldSize "goldilocks" "Goldilocks.Field" nextGen

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -752,47 +752,6 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun i ↦ CPolynomial.evalHorner (points.getD (i % points.size) 0) sparsePoly)
     checksumBabyBear)
   records := records.push (← runTimed
-    "univariate-mod-by-monic-naive" "CPolynomial" "modByMonic" "BabyBear.Field"
-    univariateModShape modWarmupIterations modMeasuredIterations
-    (fun _ ↦ CPolynomial.modByMonic batchPoly modDivisor)
-    (checksumCPolynomial checksumBabyBear))
-  records := records.push (← runTimed
-    "univariate-mod-by-monic-remainder-only" "CPolynomial" "modByMonicRemainderOnly"
-    "BabyBear.Field"
-    univariateModShape modWarmupIterations modMeasuredIterations
-    (fun _ ↦ CPolynomial.modByMonicRemainderOnly batchPoly modDivisor)
-    (checksumCPolynomial checksumBabyBear))
-  records := records.push (← runTimed
-    "univariate-mod-by-monic-reversal-direct-low-mul" "CPolynomial"
-    "modByMonicByReversal, MulLowContext.direct" "BabyBear.Field"
-    univariateModShape modWarmupIterations modMeasuredIterations
-    (fun _ ↦ reversalDirectLowMod.modByMonic batchPoly modDivisor)
-    (checksumCPolynomial checksumBabyBear))
-  records := records.push (← runTimed
-    "univariate-mod-by-monic-reversal-ntt-low-mul" "CPolynomial"
-    "modByMonicByReversal, FastMulLow.withFallback" "BabyBear.Field"
-    univariateModShape modWarmupIterations modMeasuredIterations
-    (fun _ ↦ reversalNttLowMod.modByMonic batchPoly modDivisor)
-    (checksumCPolynomial checksumBabyBear))
-  records := records.push (← runTimed
-    "univariate-mod-by-monic-medium-remainder-only" "CPolynomial"
-    "modByMonicRemainderOnly" "BabyBear.Field"
-    mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
-    (fun _ ↦ CPolynomial.modByMonicRemainderOnly mediumBatchPoly mediumModDivisor)
-    (checksumCPolynomial checksumBabyBear))
-  records := records.push (← runTimed
-    "univariate-mod-by-monic-medium-reversal-direct-low-mul" "CPolynomial"
-    "modByMonicByReversal, MulLowContext.direct" "BabyBear.Field"
-    mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
-    (fun _ ↦ reversalDirectLowMod.modByMonic mediumBatchPoly mediumModDivisor)
-    (checksumCPolynomial checksumBabyBear))
-  records := records.push (← runTimed
-    "univariate-mod-by-monic-medium-reversal-ntt-low-mul" "CPolynomial"
-    "modByMonicByReversal, FastMulLow.withFallback" "BabyBear.Field"
-    mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
-    (fun _ ↦ reversalNttLowMod.modByMonic mediumBatchPoly mediumModDivisor)
-    (checksumCPolynomial checksumBabyBear))
-  records := records.push (← runTimed
     "univariate-mul-naive" "CPolynomial" "mul" "BabyBear.Field"
     univariateMulShape mulWarmupIterations mulMeasuredIterations
     (fun _ ↦ mulLhsPoly * mulRhsPoly)
@@ -833,6 +792,47 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ nttWithFallbackLowMul.mulLow univariateMulLowOutputCoeffSlots mulLowLhsRaw
       mulLowRhsRaw)
     (checksumRawPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-naive" "CPolynomial" "modByMonic" "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ CPolynomial.modByMonic batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-remainder-only" "CPolynomial" "modByMonicRemainderOnly"
+    "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ CPolynomial.modByMonicRemainderOnly batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-reversal-direct-low-mul" "CPolynomial"
+    "modByMonicByReversal, MulLowContext.direct" "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ reversalDirectLowMod.modByMonic batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-reversal-ntt-low-mul" "CPolynomial"
+    "modByMonicByReversal, FastMulLow.withFallback" "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ reversalNttLowMod.modByMonic batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-medium-remainder-only" "CPolynomial"
+    "modByMonicRemainderOnly" "BabyBear.Field"
+    mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
+    (fun _ ↦ CPolynomial.modByMonicRemainderOnly mediumBatchPoly mediumModDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-medium-reversal-direct-low-mul" "CPolynomial"
+    "modByMonicByReversal, MulLowContext.direct" "BabyBear.Field"
+    mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
+    (fun _ ↦ reversalDirectLowMod.modByMonic mediumBatchPoly mediumModDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-medium-reversal-ntt-low-mul" "CPolynomial"
+    "modByMonicByReversal, FastMulLow.withFallback" "BabyBear.Field"
+    mediumUnivariateModShape mediumModWarmupIterations mediumModMeasuredIterations
+    (fun _ ↦ reversalNttLowMod.modByMonic mediumBatchPoly mediumModDivisor)
+    (checksumCPolynomial checksumBabyBear))
   records := records.push (← runTimed
     "univariate-batch-naive-sum" "CPolynomial" "evalBatch" "BabyBear.Field"
     univariateBatchShape batchWarmupIterations batchMeasuredIterations

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -45,6 +45,12 @@ private def batchWarmupIterations : Nat := 1
 /-- Number of measured iterations for full-array batch-evaluation benchmarks. -/
 private def batchMeasuredIterations : Nat := 5
 
+/-- Number of warmup iterations for direct monic-remainder benchmarks. -/
+private def modWarmupIterations : Nat := 1
+
+/-- Number of measured iterations for direct monic-remainder benchmarks. -/
+private def modMeasuredIterations : Nat := 20
+
 /-- Number of warmup iterations for direct univariate multiplication benchmarks. -/
 private def mulWarmupIterations : Nat := 1
 
@@ -57,12 +63,20 @@ private def univariateBatchCoeffSlots : Nat := 128
 /-- Number of points used by univariate batch-evaluation benchmarks. -/
 private def univariateBatchPointCount : Nat := 16
 
+/-- Number of linear factors in the direct monic-remainder benchmark divisor. -/
+private def univariateModDivisorPointCount : Nat := 16
+
 /-- Number of coefficient slots used by direct univariate multiplication benchmarks. -/
 private def univariateMulCoeffSlots : Nat := 128
 
 /-- Input-shape label for univariate batch-evaluation benchmarks. -/
 private def univariateBatchShape : String :=
   s!"degree<{univariateBatchCoeffSlots}, dense, {univariateBatchPointCount} points"
+
+/-- Input-shape label for direct univariate monic-remainder benchmarks. -/
+private def univariateModShape : String :=
+  s!"degree<{univariateBatchCoeffSlots} dividend, degree={univariateModDivisorPointCount} " ++
+    "monic divisor"
 
 /-- Input-shape label for direct univariate multiplication benchmarks. -/
 private def univariateMulShape : String :=
@@ -300,6 +314,11 @@ private def cpolyOfArray {R : Type*} [Zero R] [BEq R] [LawfulBEq R]
   let p : CPolynomial.Raw R := coeffs
   ⟨p.trim, CPolynomial.Raw.Trim.isCanonical_trim p⟩
 
+/-- Build a monic divisor as a product of linear factors `X - C x`. -/
+private def monicDivisorFromPoints {R : Type*} [Field R] [BEq R] [LawfulBEq R]
+    (xs : Array R) : CPolynomial R :=
+  xs.foldl (fun acc x ↦ acc * CPolynomial.linearFactor x) (CPolynomial.C 1)
+
 /-- Mix one benchmark output value into a stable checksum accumulator. -/
 private def mixChecksum (acc value : Nat) : Nat :=
   (acc * 16777619 + value + 97) % 18446744073709551557
@@ -328,7 +347,7 @@ private def checksumConcreteBtf {k : Nat} (x : ConcreteBTField k) : Nat :=
 private def checksumArray (checksum : α → Nat) (xs : Array α) : Nat :=
   xs.foldl (fun acc x ↦ mixChecksum acc (checksum x)) 0
 
-/-- Checksum a canonical computable polynomial by its coefficient array. -/
+/-- Checksum a canonical univariate polynomial by its coefficient array. -/
 private def checksumCPolynomial [Zero α] (checksum : α → Nat) (p : CPolynomial α) : Nat :=
   checksumArray checksum p.val
 
@@ -618,8 +637,10 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
   let koalaMulLhsPoly := cpolyOfArray koalaMulLhsCoeffs
   let koalaMulRhsPoly := cpolyOfArray koalaMulRhsCoeffs
   let batchPoly := cpolyOfArray batchCoeffs
+  let modDivisor := monicDivisorFromPoints batchPoints
   let naiveMul : CPolynomial.MulContext BabyBear.Field := CPolynomial.MulContext.naive
   let naiveMod : CPolynomial.ModContext BabyBear.Field := CPolynomial.ModContext.naive
+  let fastMod : CPolynomial.ModContext BabyBear.Field := CPolynomial.ModContext.fast
   let nextGen := gen
   let mut records := #[]
   records := records.push (← runTimed
@@ -676,10 +697,26 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     (fun _ ↦ CPolynomial.evalBatchHorner batchPoly batchPoints)
     (checksumArray checksumBabyBear))
   records := records.push (← runTimed
+    "univariate-mod-by-monic-naive" "CPolynomial" "modByMonic" "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ CPolynomial.modByMonic batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mod-by-monic-fast" "CPolynomial" "modByMonicFast" "BabyBear.Field"
+    univariateModShape modWarmupIterations modMeasuredIterations
+    (fun _ ↦ CPolynomial.modByMonicFast batchPoly modDivisor)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
     "univariate-batch-subproduct-naive-mul-naive-mod" "CPolynomial"
     "evalBatchSubproduct naive mul/mod" "BabyBear.Field"
     univariateBatchShape batchWarmupIterations batchMeasuredIterations
     (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul naiveMod batchPoly batchPoints)
+    (checksumArray checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-batch-subproduct-naive-mul-fast-mod" "CPolynomial"
+    "evalBatchSubproduct naive mul/fast mod" "BabyBear.Field"
+    univariateBatchShape batchWarmupIterations batchMeasuredIterations
+    (fun _ ↦ CPolynomial.evalBatchSubproduct naiveMul fastMod batchPoly batchPoints)
     (checksumArray checksumBabyBear))
   let (goldilocksRecords, extraGen) ← runDenseUnivariateZMod
     Goldilocks.fieldSize "goldilocks" "Goldilocks.Field" nextGen


### PR DESCRIPTION
### Overview

This PR adds an implementation of subproduct-tree batch evaluation for univariate polynomials.

Pointwise Horner evaluation of a degree $n$ polynomial at $m$ points costs $O(nm)$. Subproduct-tree evaluation builds a product tree for the $m$ linear factors and then descends the tree by reducing the input polynomial modulo subtree products. With fast multiplication and fast monic modular reduction, the complexity is roughly $O((n + m) \log(n + m) \log m)$.

The algorithm is parameterized over multiplication (`MulContext`) and monic modular reduction (`ModContext`) of polynomials. When efficient implementations of these operations are provided, it demonstrates better performance compared to pointwise Horner on sufficiently large inputs.

### Results

Here are results from CI benchmark run:

| implementation | size | input | average time |
| --- | --- | --- | --- |
| pointwise Horner | small | degree<128, dense, 16 points | 0.11 ms |
| subproduct-tree (*) | small | degree<128, dense, 16 points | 10.52 ms |
| pointwise Horner | medium | degree<8192, dense, 1024 points | 0.40 s |
| subproduct-tree (*) | medium | degree<8192, dense, 1024 points | 1.30 s |
| pointwise Horner | large | degree<65536, dense, 8192 points | 25.60 s |
| subproduct-tree (*) | large | degree<65536, dense, 8192 points | 13.59 s |

(*) with NTT-based multiplication and reversal-based monic remainder.

Subproduct-tree wins against pointwise Horner on sufficiently large inputs, but on small inputs pointwise Horner is faster.

### Technical details

This PR provides two `MulContext` implementations:

- `naive`: canonical `CPolynomial` multiplication.
- `ntt`: NTT multiplication with canonical multiplication as a fallback. Fallback is needed to ensure it computes multiplication correctly, while keeping it a total function.

This PR provides three `ModContext` implementations:

- `naive`: canonical `CPolynomial.modByMonic`.
- `remainder-only`: improves over `naive` by avoiding quotient construction and the general polynomial multiplications used by each cancellation step. It keeps the long-division asymptotic shape, but has much better constants.
- `reversal`: computes the monic remainder through reversal and inverse modulo $X^k$. It computes the quotient from $\mathrm{reverse}(p) \cdot \mathrm{reverse}(q)^{-1} \bmod X^k$, reverses it back, and subtracts $q \cdot \mathrm{quotient}$ while keeping only the low coefficients needed for the remainder. With fast low-product multiplication, this gives the expected fast-polynomial remainder algorithm.

`reversal` implementation is itself parameterized over truncated multiplication (`MulLowContext`). Here truncated (also called low-product) multiplication means computing only the low $k$ coefficients of a product: $(p \cdot q) \bmod X^k$.

Current `MulLowContext` implementations:

- `naive`: canonical full multiplication followed by truncation.
- `convolution`: computes low coefficients using the convolution formula.
- `ntt-truncate`: NTT multiplication on truncated inputs, then output truncation, with `convolution` as a fallback.

### Future work

It might be possible to further optimize current NTT implementation. This will automatically improve subproduct-tree performance, as current best implementations of both `MulContext` and `ModContext` depend on it.

`ntt-truncate` implementation of truncated multiplication performs a full power-of-two NTT on the truncated inputs. There might be a more efficient implementation, possibly based on a Truncated Fourier Transform (TFT) algorithm.

With the addition of new benchmarks for added operations, the current benchmark suite has grown quite large. Currently it takes 15 minutes to run on CI. It might be worth to think about refactoring it.
