### PR TITLE
chore(review): improve AI-reviewer (mark 3 rules as preferred, scope reviewer to diff)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -82,6 +82,38 @@
             ' <<< "$COMMENT_BODY"
           shell: bash
 
+        - name: Build review instructions
+          id: build_instructions
+          env:
+            USER_COMMENTS: ${{ steps.get_args.outputs.additional_comments }}
+          run: |
+            EOF=$(openssl rand -hex 8)
+            {
+              echo "final<<${EOF}"
+              cat <<'PRECEDENT'
+            Project precedent (CompPoly-specific conventions that override generic CONTRIBUTING.md rules — do NOT flag these as violations):
+
+            Variable naming overrides (algebraic context):
+              - Algebraic carrier types use R, M, G, F (rings, modules, groups, fields), not α, β.
+              - Polynomial-typed values use p, q (e.g. CPolynomial, CMvPolynomial, CMlPolynomial), not just predicates.
+              - Indices into vectors, lists, and Fin n use i, j, k regardless of underlying numeric type.
+              - In algebraic lemma names that mirror Mathlib (e.g. pow_add, npow_add), exponent variables may be a, b.
+
+            Style rules marked "preferred but not enforced" in CONTRIBUTING.md (the merged codebase uses both styles freely — do not flag):
+              - "Use the where syntax for instances" — both `instance ... := ⟨...⟩` and `instance ... where` are accepted.
+              - "Use manual dot notation for equality" — both `h.symm` and `Eq.symm h` are accepted.
+              - "Use <| / |> to reduce nesting" — both pipe-style and parens are accepted.
+
+            Review scope:
+              - Flag ONLY lines introduced by this PR (the diff). Do not comment on pre-existing code that this PR did not modify.
+            PRECEDENT
+              if [ -n "${USER_COMMENTS}" ]; then
+                printf '\n\nUser-supplied additional context:\n%s\n' "${USER_COMMENTS}"
+              fi
+              echo "${EOF}"
+            } >> $GITHUB_OUTPUT
+          shell: bash
+
         - uses: alexanderlhicks/lean-review-workflow@main
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -91,5 +123,5 @@
             pr_number: ${{ github.event.issue.number || github.event.pull_request.number }}
             external_refs: "${{ steps.get_args.outputs.external_refs }}"
             repo_context_refs: "${{ steps.get_args.outputs.repo_context_refs }}"
-            additional_comments: "${{ steps.get_args.outputs.additional_comments }}"
+            additional_comments: "${{ steps.build_instructions.outputs.final }}"
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -104,6 +104,9 @@
               - "Use manual dot notation for equality" — both `h.symm` and `Eq.symm h` are accepted.
               - "Use <| / |> to reduce nesting" — both pipe-style and parens are accepted.
 
+            File scope of style rules:
+              - The 100-character line-length rule applies ONLY to `.lean` source files. Do NOT flag long lines in `.md`, `.yml`, `.toml`, or any other non-Lean files. The enforced linter (`scripts/lint-style.py`) only processes `.lean` files.
+
             Review scope:
               - Flag ONLY lines introduced by this PR (the diff). Do not comment on pre-existing code that this PR did not modify.
             PRECEDENT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Our [linting script](`./scripts/lint-style.sh`) helps enforce some aspects of th
 * **Acronyms**: Treat as words (e.g., `HtmlParser` not `HTMLParser`).
 * **Prop-valued Classes**: Use `UpperCamelCase`. If the class is an adjective, use the `Is` prefix (e.g., `IsCompact`, `IsPrime`). If it is a noun, no prefix is needed (e.g., `Group`, `TopologicalSpace`).
 * **Spelling**: Use American English for declaration names (e.g., `analyze` not `analyse`, `color` not `colour`).
-* **Dot Notation**: Use namespaces to group related definitions (e.g., `List.map`). This enables dot notation (e.g., `l.map f`) when the type is known. Use manual dot notation for logical connectives and equality (e.g., `And.intro`, `Eq.refl`, `Iff.mp`).
+* **Dot Notation**: Use namespaces to group related definitions (e.g., `List.map`). This enables dot notation (e.g., `l.map f`) when the type is known. Use manual dot notation for logical connectives and equality (e.g., `And.intro`, `Eq.refl`, `Iff.mp`). *Preferred but not enforced — the merged codebase uses both `h.symm` and `Eq.symm h` forms freely; flag only when truly ambiguous.*
 * **Axiomatic Names**: Use standard names for properties: `refl`, `symm`, `trans`, `comm`, `assoc`, `inj` (injective), `congr`.
 * **Identifiers**: 
     * Use namespaces for logical properties (e.g., `And.comm`, `Or.intro`).
@@ -164,12 +164,12 @@ When translating theorem statements into names, we use standard mappings for sym
 * **Operators**: Put spaces on both sides of `:`, `:=`, and infix operators. Place them before a line break rather than at the start of the next line.
 * **Hypotheses**: Prefer placing hypotheses to the left of the colon (e.g., `(h : P) : Q`) rather than using arrows (`: P → Q`) when the proof introduces them.
 * **Functions**: Prefer `fun x ↦ ...` over `λ x, ...`.
-* **Instances**: Use the `where` syntax for defining instances and structures.
+* **Instances**: Use the `where` syntax for defining instances and structures. *Preferred but not enforced — the merged codebase uses both `instance ... := ⟨...⟩` and `instance ... where` forms freely.*
 * **Binders**: Use a space after binders (e.g., `∀ x,` not `∀x,`).
 * **Tactic Mode**: Place `by` at the end of the line preceding the tactic block. Indent the tactic block.
 * **Calculations**: In `calc` blocks, align relations.
 * **Empty Lines**: Avoid empty lines *inside* definitions or proofs.
-* **Delimiters**: Avoid parentheses where possible. Use `<|` (pipe left) and `|>` (pipe right) to reduce nesting. Avoid using `;` to separate tactics unless writing short, single-line tactic sequences.
+* **Delimiters**: Avoid parentheses where possible. Use `<|` (pipe left) and `|>` (pipe right) to reduce nesting. Avoid using `;` to separate tactics unless writing short, single-line tactic sequences. *The `<|` / `|>` preference is preferred but not enforced — the merged codebase uses both styles freely. The `;` guidance still applies.*
 * **Error Messages**: In custom error or trace messages, surround interpolated data with backticks (inline) or place it on a new indented line.
 
 ### Normal Forms

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ When translating theorem statements into names, we use standard mappings for sym
 
 ### Syntax and Formatting
 
-* **Line Length**: Keep lines under 100 characters.
+* **Line Length**: Keep `.lean` source lines under 100 characters. (Markdown and CI / workflow files are not subject to this rule — the enforced linter at `scripts/lint-style.py` only processes `.lean` files.)
 * **Indentation**: Use 2 spaces for indentation.
 * **Headers**: Use standard file headers including copyright, license (Apache 2.0), and authors.
   ```lean


### PR DESCRIPTION
Improves the automated reviewer (`alexanderlhicks/lean-review-workflow`)

1. improve CONTRIBUTING.md rules to be in sync with project's own merged code
2. scope review to diff (so it wouldn't scan entire file)
3. add project-specific naming conventions for algebraic code (`R` for ring carrier types, `p` for polynomial values).

## Changes

`CONTRIBUTING.md` (6 lines)

Annotated three style rules as **preferred but not enforced**, with a brief note explaining that the merged codebase uses both styles freely. 

`.github/workflows/review.yml` (34 lines)

Added a new `Build review instructions` step that constructs an `additional_comments` payload combining:

- A **project precedent** block listing CompPoly-specific algebraic conventions (`R, M, G, F` for carriers; `p, q` for polynomials; `i, j, k` for indices; `a, b` for exponents in lemma names mirroring Mathlib). These override the generic Mathlib conventions the reviewer would otherwise apply.
- An explicit instruction to **flag only lines introduced by the PR**, not pre-existing code that the diff doesn't touch.
- Any user-supplied content from a `/review …` comment (preserves the existing comment-trigger workflow).


