### PR TITLE
feat(ntt): add `BabyBear` domain and benchmark NTT with Baby and Koala bears

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -83,6 +83,7 @@ import CompPoly.ToMathlib.Polynomial.BivariateWeightedDegree
 import CompPoly.Univariate.Basic
 import CompPoly.Univariate.Lagrange
 import CompPoly.Univariate.Linear
+import CompPoly.Univariate.NTT.BabyBear
 import CompPoly.Univariate.NTT.Domain
 import CompPoly.Univariate.NTT.FastMul
 import CompPoly.Univariate.NTT.Forward

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -87,6 +87,7 @@ import CompPoly.Univariate.NTT.Domain
 import CompPoly.Univariate.NTT.FastMul
 import CompPoly.Univariate.NTT.Forward
 import CompPoly.Univariate.NTT.Inverse
+import CompPoly.Univariate.NTT.KoalaBear
 import CompPoly.Univariate.NTT.Transform
 import CompPoly.Univariate.Quotient.Core
 import CompPoly.Univariate.Quotient.Equiv

--- a/CompPoly/Fields/BabyBear.lean
+++ b/CompPoly/Fields/BabyBear.lean
@@ -16,11 +16,14 @@ import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 
 namespace BabyBear
 
+/-- The BabyBear field modulus, `2^31 - 2^27 + 1`. -/
 @[reducible]
 def fieldSize : Nat := 2 ^ 31 - 2 ^ 27 + 1
 
+/-- The BabyBear prime field as a `ZMod`. -/
 abbrev Field := ZMod fieldSize
 
+/-- The BabyBear modulus is prime. -/
 theorem is_prime : Nat.Prime fieldSize := by
   unfold fieldSize
   pratt
@@ -33,9 +36,11 @@ theorem is_prime : Nat.Prime fieldSize := by
   - `twoAdicity = 27` with `fieldSize - 1 = 2^27 * 15`
 -/
 
+/-- Bit width of the BabyBear modulus. -/
 @[reducible]
 def pBits : Nat := 31
 
+/-- The largest supported power-of-two root-of-unity exponent for BabyBear. -/
 @[reducible]
 def twoAdicity : Nat := 27
 
@@ -55,6 +60,7 @@ instance : NonBinaryField Field where
   of `2^n`-th roots of unity for `0 ≤ n ≤ twoAdicity`.
 -/
 
+/-- The factorization `fieldSize - 1 = 2^twoAdicity * 15`. -/
 lemma fieldSize_sub_one_factorization : fieldSize - 1 = 2 ^ twoAdicity * 15 := by
   unfold fieldSize twoAdicity
   decide
@@ -65,6 +71,7 @@ lemma fieldSize_sub_one_factorization : fieldSize - 1 = 2 ^ twoAdicity * 15 := b
 
   The first entry n = 0 is 1.
 -/
+/-- Precomputed generators for the BabyBear two-adic subgroups. -/
 def twoAdicGenerators : List Field :=
   [
     (0x1 : Field),
@@ -97,14 +104,17 @@ def twoAdicGenerators : List Field :=
     (0x1A427A41 : Field)
   ]
 
+/-- The BabyBear two-adic generator table has one entry for each supported exponent. -/
 @[simp] lemma twoAdicGenerators_length : twoAdicGenerators.length = twoAdicity + 1 := by
   decide
 
+/-- Consecutive BabyBear two-adic generators square to the previous generator. -/
 @[simp] lemma twoAdicGenerators_succ_square_eq' (idx : Fin twoAdicity) :
     twoAdicGenerators[idx.val + 1] ^ 2 = twoAdicGenerators[idx] := by
   fin_cases idx
   <;> simp [twoAdicGenerators] <;> decide
 
+/-- Consecutive BabyBear two-adic generators square to the previous generator. -/
 @[simp] lemma twoAdicGenerators_succ_square_eq (idx : Nat) (h : idx < twoAdicity) :
     haveI : idx + 1 < twoAdicGenerators.length := by simp [twoAdicGenerators_length, h]
     twoAdicGenerators[idx + 1] ^ 2 = twoAdicGenerators[idx] :=
@@ -120,6 +130,7 @@ private def sqChain (g : Field) : Nat → Field
   | 0 => g
   | n + 1 => let h := sqChain g n; h * h
 
+/-- Repeated squaring agrees with exponentiation by a power of two. -/
 private theorem sqChain_eq_pow_two_pow (g : Field) (n : Nat) :
     sqChain g n = g ^ (2 ^ n) := by
   induction n with
@@ -137,12 +148,11 @@ private theorem sqChain_twoAdicGenerators_shift (k n : Nat) (hkn : k + n ≤ two
       calc
         sqChain twoAdicGenerators[(⟨k + (n + 1), by omega⟩ : Fin (twoAdicity + 1))]
             (n + 1)
-            =
+          = sqChain twoAdicGenerators[(⟨k + (n + 1), by omega⟩ :
+                Fin (twoAdicity + 1))] n *
               sqChain twoAdicGenerators[(⟨k + (n + 1), by omega⟩ :
-                  Fin (twoAdicity + 1))] n *
-                sqChain twoAdicGenerators[(⟨k + (n + 1), by omega⟩ :
-                  Fin (twoAdicity + 1))] n := by
-                  simp [sqChain]
+                Fin (twoAdicity + 1))] n := by
+              simp [sqChain]
         _ = twoAdicGenerators[(⟨k + 1, by omega⟩ : Fin (twoAdicity + 1))] *
               twoAdicGenerators[(⟨k + 1, by omega⟩ : Fin (twoAdicity + 1))] := by
               have hshift :
@@ -151,7 +161,7 @@ private theorem sqChain_twoAdicGenerators_shift (k n : Nat) (hkn : k + n ≤ two
                     twoAdicGenerators[(⟨k + 1, by omega⟩ : Fin (twoAdicity + 1))] := by
                 simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using
                   (ih (k := k + 1) (by omega))
-              exact congrArg (fun x => x * x) hshift
+              exact congrArg (fun x ↦ x * x) hshift
         _ = twoAdicGenerators[(⟨k + 1, by omega⟩ : Fin (twoAdicity + 1))] ^ 2 := by
               simp [pow_two]
         _ = twoAdicGenerators[(⟨k, by omega⟩ : Fin (twoAdicity + 1))] := by

--- a/CompPoly/Fields/BabyBear.lean
+++ b/CompPoly/Fields/BabyBear.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 ArkLib Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Valerii Huhnin
 -/
 
 import CompPoly.Fields.Basic

--- a/CompPoly/Fields/BabyBear.lean
+++ b/CompPoly/Fields/BabyBear.lean
@@ -4,7 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 
+import CompPoly.Fields.Basic
 import CompPoly.Fields.PrattCertificate
+import Mathlib.Algebra.Order.Ring.Star
+import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 /-!
   # BabyBear Field `2^{31} - 2^{27} + 1`
 
@@ -21,5 +24,218 @@ abbrev Field := ZMod fieldSize
 theorem is_prime : Nat.Prime fieldSize := by
   unfold fieldSize
   pratt
+
+/-!
+  ## Constants
+
+  These are convenience constants for the BabyBear field:
+  - `pBits = 31`
+  - `twoAdicity = 27` with `fieldSize - 1 = 2^27 * 15`
+-/
+
+@[reducible]
+def pBits : Nat := 31
+
+@[reducible]
+def twoAdicity : Nat := 27
+
+instance : Fact (Nat.Prime fieldSize) := ⟨is_prime⟩
+
+instance : _root_.Field Field := ZMod.instField fieldSize
+
+instance : NonBinaryField Field where
+  char_neq_2 := by
+    simpa [Field, fieldSize] using
+      (by decide : (2 : ZMod (2 ^ 31 - 2 ^ 27 + 1)) ≠ 0)
+
+/-!
+  ## Two-adicity and roots of unity table
+
+  We record the factorization of `fieldSize - 1` and provide a precomputed table
+  of `2^n`-th roots of unity for `0 ≤ n ≤ twoAdicity`.
+-/
+
+lemma fieldSize_sub_one_factorization : fieldSize - 1 = 2 ^ twoAdicity * 15 := by
+  unfold fieldSize twoAdicity
+  decide
+
+/-!
+  A table of `2^n`-th roots of unity. The element at index `n` generates the
+  multiplicative subgroup of order `2^n`.
+
+  The first entry n = 0 is 1.
+-/
+def twoAdicGenerators : List Field :=
+  [
+    (0x1 : Field),
+    (0x78000000 : Field),
+    (0x67055C21 : Field),
+    (0x5EE99486 : Field),
+    (0xBB4C4E4 : Field),
+    (0x2D4CC4DA : Field),
+    (0x669D6090 : Field),
+    (0x17B56C64 : Field),
+    (0x67456167 : Field),
+    (0x688442F9 : Field),
+    (0x145E952D : Field),
+    (0x4FE61226 : Field),
+    (0x4C734715 : Field),
+    (0x11C33E2A : Field),
+    (0x62C3D2B1 : Field),
+    (0x77CAD399 : Field),
+    (0x54C131F4 : Field),
+    (0x4CABD6A6 : Field),
+    (0x5CF5713F : Field),
+    (0x3E9430E8 : Field),
+    (0xBA067A3 : Field),
+    (0x18ADC27D : Field),
+    (0x21FD55BC : Field),
+    (0x4B859B3D : Field),
+    (0x3BD57996 : Field),
+    (0x4483D85A : Field),
+    (0x3A26EEF8 : Field),
+    (0x1A427A41 : Field)
+  ]
+
+@[simp] lemma twoAdicGenerators_length : twoAdicGenerators.length = twoAdicity + 1 := by
+  decide
+
+@[simp] lemma twoAdicGenerators_succ_square_eq' (idx : Fin twoAdicity) :
+    twoAdicGenerators[idx.val + 1] ^ 2 = twoAdicGenerators[idx] := by
+  fin_cases idx
+  <;> simp [twoAdicGenerators] <;> decide
+
+@[simp] lemma twoAdicGenerators_succ_square_eq (idx : Nat) (h : idx < twoAdicity) :
+    haveI : idx + 1 < twoAdicGenerators.length := by simp [twoAdicGenerators_length, h]
+    twoAdicGenerators[idx + 1] ^ 2 = twoAdicGenerators[idx] :=
+  twoAdicGenerators_succ_square_eq' ⟨idx, h⟩
+
+/-- `twoAdicity` is maximal: `2^(twoAdicity+1)` does not divide `fieldSize - 1`. -/
+lemma twoAdicity_maximal : ¬ (2 ^ (twoAdicity + 1)) ∣ (fieldSize - 1) := by
+  decide
+
+/-- Repeated squaring: `sqChain g n = g ^ (2^n)`.
+    Does `n` multiplications instead of `2^n`, making it kernel-friendly. -/
+private def sqChain (g : Field) : Nat → Field
+  | 0 => g
+  | n + 1 => let h := sqChain g n; h * h
+
+private theorem sqChain_eq_pow_two_pow (g : Field) (n : Nat) :
+    sqChain g n = g ^ (2 ^ n) := by
+  induction n with
+  | zero => simp [sqChain]
+  | succ n ih => simp [sqChain, ih, pow_succ, pow_mul]
+
+/-- Repeated squaring walks backward through the precomputed two-adic generator table. -/
+private theorem sqChain_twoAdicGenerators_shift (k n : Nat) (hkn : k + n ≤ twoAdicity) :
+    sqChain twoAdicGenerators[(⟨k + n, by omega⟩ : Fin (twoAdicity + 1))] n =
+      twoAdicGenerators[(⟨k, by omega⟩ : Fin (twoAdicity + 1))] := by
+  induction n generalizing k with
+  | zero =>
+      simp [sqChain]
+  | succ n ih =>
+      calc
+        sqChain twoAdicGenerators[(⟨k + (n + 1), by omega⟩ : Fin (twoAdicity + 1))]
+            (n + 1)
+            =
+              sqChain twoAdicGenerators[(⟨k + (n + 1), by omega⟩ :
+                  Fin (twoAdicity + 1))] n *
+                sqChain twoAdicGenerators[(⟨k + (n + 1), by omega⟩ :
+                  Fin (twoAdicity + 1))] n := by
+                  simp [sqChain]
+        _ = twoAdicGenerators[(⟨k + 1, by omega⟩ : Fin (twoAdicity + 1))] *
+              twoAdicGenerators[(⟨k + 1, by omega⟩ : Fin (twoAdicity + 1))] := by
+              have hshift :
+                  sqChain twoAdicGenerators[(⟨k + (n + 1), by omega⟩ :
+                      Fin (twoAdicity + 1))] n =
+                    twoAdicGenerators[(⟨k + 1, by omega⟩ : Fin (twoAdicity + 1))] := by
+                simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using
+                  (ih (k := k + 1) (by omega))
+              exact congrArg (fun x => x * x) hshift
+        _ = twoAdicGenerators[(⟨k + 1, by omega⟩ : Fin (twoAdicity + 1))] ^ 2 := by
+              simp [pow_two]
+        _ = twoAdicGenerators[(⟨k, by omega⟩ : Fin (twoAdicity + 1))] := by
+              simpa [Nat.succ_eq_add_one, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+                using (twoAdicGenerators_succ_square_eq k (by omega))
+
+/-- Every nonzero index in the precomputed table is genuinely nontrivial. -/
+private lemma twoAdicGenerators_ne_one_of_pos (n : Fin (twoAdicity + 1)) (hn : 0 < n) :
+    twoAdicGenerators[n] ≠ (1 : Field) := by
+  fin_cases n <;> simp_all [twoAdicGenerators] <;> decide
+
+/-- The power `(twoAdicGenerators[bits])^(2^bits) = 1`. -/
+lemma twoAdicGenerators_pow_twoPow_eq_one (bits : Fin (twoAdicity + 1)) :
+    twoAdicGenerators[bits] ^ (2 ^ (bits : Nat)) = 1 := by
+  rw [← sqChain_eq_pow_two_pow]
+  rcases bits with ⟨n, hn⟩
+  have hshift :
+      sqChain twoAdicGenerators[(⟨n, hn⟩ : Fin (twoAdicity + 1))] n =
+        twoAdicGenerators[(⟨0, by omega⟩ : Fin (twoAdicity + 1))] := by
+    simpa using sqChain_twoAdicGenerators_shift 0 n (by omega)
+  simpa [twoAdicGenerators] using hshift
+
+/-- Helper: Fin-indexed version for computational verification of non-triviality. -/
+private lemma twoAdicGenerators_pow_ne_one_aux (n : Fin 28) (m : Fin 28)
+    (hm : m.val < n.val) :
+    twoAdicGenerators[n] ^ (2 ^ m.val) ≠ (1 : Field) := by
+  rw [← sqChain_eq_pow_two_pow]
+  let nMinus : Fin (twoAdicity + 1) :=
+    ⟨n.val - m.val, lt_of_le_of_lt (Nat.sub_le _ _) n.isLt⟩
+  have hshift :
+      sqChain twoAdicGenerators[n] m.val = twoAdicGenerators[nMinus] := by
+    have hn_le : n.val ≤ twoAdicity := by
+      simpa [twoAdicity] using Nat.le_of_lt_succ n.isLt
+    have hbound : (n.val - m.val) + m.val ≤ twoAdicity := by
+      simpa [Nat.sub_add_cancel (Nat.le_of_lt hm)] using hn_le
+    simpa [Nat.sub_add_cancel (Nat.le_of_lt hm)] using
+      (sqChain_twoAdicGenerators_shift (n.val - m.val) m.val hbound)
+  rw [hshift]
+  exact twoAdicGenerators_ne_one_of_pos nMinus (by
+    change 0 < n.val - m.val
+    exact Nat.sub_pos_of_lt hm)
+
+/-- If `m < bits`, then `(twoAdicGenerators[bits])^(2^m) ≠ 1`. -/
+lemma twoAdicGenerators_pow_twoPow_ne_one_of_lt
+    {bits : Fin (twoAdicity + 1)} {m : Nat} (hm : m < bits) :
+    (twoAdicGenerators[bits]) ^ (2 ^ m) ≠ (1 : Field) := by
+  have hm_lt : m < 28 := Nat.lt_trans hm bits.isLt
+  exact twoAdicGenerators_pow_ne_one_aux bits ⟨m, hm_lt⟩ hm
+
+/-- The precomputed element at index `bits` is a primitive `2^bits`-th root of unity. -/
+lemma isPrimitiveRoot_twoAdicGenerator (n : Fin (twoAdicity + 1)) :
+    IsPrimitiveRoot (twoAdicGenerators[n]) (2 ^ (n : Nat)) := by
+  rw [IsPrimitiveRoot.iff_def]
+  rcases n with ⟨_ | k, hb⟩
+  · simp [twoAdicGenerators]
+  · constructor
+    · exact twoAdicGenerators_pow_twoPow_eq_one ⟨k + 1, hb⟩
+    · intro m hm
+      by_contra h
+      have hord := orderOf_eq_prime_pow
+        (twoAdicGenerators_pow_twoPow_ne_one_of_lt (bits := ⟨k + 1, hb⟩) (m := k)
+          (by simp))
+        (twoAdicGenerators_pow_twoPow_eq_one ⟨k + 1, hb⟩)
+      have hdvd := orderOf_dvd_of_pow_eq_one hm
+      rw [hord] at hdvd
+      exact h hdvd
+
+/-- As a unit, the precomputed element is a member of `rootsOfUnity (2^bits)`. -/
+lemma twoAdicGenerator_unit_mem_rootsOfUnity
+    (bits : Fin (twoAdicity + 1)) (h : twoAdicGenerators[bits] ≠ 0) :
+    Units.mk0 (twoAdicGenerators[bits]) h ∈ rootsOfUnity (2 ^ (bits : Nat)) Field := by
+  rw [mem_rootsOfUnity]
+  rw [Units.ext_iff]
+  simp only [Units.val_pow_eq_pow_val, Units.val_mk0, Units.val_one]
+  exact twoAdicGenerators_pow_twoPow_eq_one bits
+
+/-- The order of `twoAdicGenerators[bits]` equals `2^bits`. -/
+lemma twoAdicGenerators_order (bits : Fin (twoAdicity + 1)) :
+    orderOf (twoAdicGenerators[bits]) = 2 ^ (bits : Nat) := by
+  rcases bits with ⟨_ | n, hb⟩
+  · simp [twoAdicGenerators, orderOf_one]
+  · exact orderOf_eq_prime_pow
+      (twoAdicGenerators_pow_twoPow_ne_one_of_lt (bits := ⟨n + 1, hb⟩) (m := n)
+        (by simp))
+      (twoAdicGenerators_pow_twoPow_eq_one ⟨n + 1, hb⟩)
 
 end BabyBear

--- a/CompPoly/Univariate/NTT/BabyBear.lean
+++ b/CompPoly/Univariate/NTT/BabyBear.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Valerii Huhnin
+-/
+import CompPoly.Fields.BabyBear
+import CompPoly.Univariate.NTT.Domain
+
+/-!
+# BabyBear NTT Domains
+
+Concrete radix-2 NTT domains over the BabyBear field.
+-/
+
+namespace CompPoly
+namespace CPolynomial
+namespace NTT
+namespace BabyBear
+
+/-- Build a finite index into the BabyBear two-adic generator table. -/
+def bitsOfLogN (logN : Nat) (hlogN : logN ≤ _root_.BabyBear.twoAdicity) :
+    Fin (_root_.BabyBear.twoAdicity + 1) :=
+  ⟨logN, Nat.lt_succ_of_le hlogN⟩
+
+/-- The BabyBear NTT domain size is nonzero in the field for supported two-adic sizes. -/
+theorem twoPowNatCast_ne_zero
+    (logN : Nat) (hlogN : logN ≤ _root_.BabyBear.twoAdicity) :
+    (((2 ^ logN : Nat) : _root_.BabyBear.Field) ≠ 0) := by
+  intro hzero
+  have hpow_pos : 0 < 2 ^ logN := by
+    positivity
+  have hpow_le : 2 ^ logN ≤ 2 ^ _root_.BabyBear.twoAdicity := by
+    exact Nat.pow_le_pow_right (by decide : 1 ≤ 2) hlogN
+  have hpow_lt : 2 ^ logN < _root_.BabyBear.fieldSize := by
+    have htop : 2 ^ _root_.BabyBear.twoAdicity < _root_.BabyBear.fieldSize := by
+      simp [_root_.BabyBear.twoAdicity, _root_.BabyBear.fieldSize]
+    exact lt_of_le_of_lt hpow_le htop
+  have hdiv : _root_.BabyBear.fieldSize ∣ 2 ^ logN := by
+    exact (ZMod.natCast_eq_zero_iff (2 ^ logN) _root_.BabyBear.fieldSize).mp hzero
+  exact (not_le_of_gt hpow_lt) (Nat.le_of_dvd hpow_pos hdiv)
+
+/-- BabyBear radix-2 NTT domain for a supported two-adic size. -/
+def domainOfLogN (logN : Nat) (hlogN : logN ≤ _root_.BabyBear.twoAdicity) :
+    Domain _root_.BabyBear.Field where
+  logN := logN
+  omega := _root_.BabyBear.twoAdicGenerators[bitsOfLogN logN hlogN]
+  primitive := by
+    simpa [bitsOfLogN] using
+      _root_.BabyBear.isPrimitiveRoot_twoAdicGenerator (bitsOfLogN logN hlogN)
+  natCast_ne_zero := twoPowNatCast_ne_zero logN hlogN
+
+end BabyBear
+end NTT
+end CPolynomial
+end CompPoly

--- a/CompPoly/Univariate/NTT/BabyBear.lean
+++ b/CompPoly/Univariate/NTT/BabyBear.lean
@@ -18,35 +18,35 @@ namespace NTT
 namespace BabyBear
 
 /-- Build a finite index into the BabyBear two-adic generator table. -/
-def bitsOfLogN (logN : Nat) (hlogN : logN ≤ _root_.BabyBear.twoAdicity) :
-    Fin (_root_.BabyBear.twoAdicity + 1) :=
+def bitsOfLogN (logN : Nat) (hlogN : logN ≤ BabyBear.twoAdicity) :
+    Fin (BabyBear.twoAdicity + 1) :=
   ⟨logN, Nat.lt_succ_of_le hlogN⟩
 
 /-- The BabyBear NTT domain size is nonzero in the field for supported two-adic sizes. -/
 theorem twoPowNatCast_ne_zero
-    (logN : Nat) (hlogN : logN ≤ _root_.BabyBear.twoAdicity) :
-    (((2 ^ logN : Nat) : _root_.BabyBear.Field) ≠ 0) := by
+    (logN : Nat) (hlogN : logN ≤ BabyBear.twoAdicity) :
+    (((2 ^ logN : Nat) : BabyBear.Field) ≠ 0) := by
   intro hzero
   have hpow_pos : 0 < 2 ^ logN := by
     positivity
-  have hpow_le : 2 ^ logN ≤ 2 ^ _root_.BabyBear.twoAdicity := by
+  have hpow_le : 2 ^ logN ≤ 2 ^ BabyBear.twoAdicity := by
     exact Nat.pow_le_pow_right (by decide : 1 ≤ 2) hlogN
-  have hpow_lt : 2 ^ logN < _root_.BabyBear.fieldSize := by
-    have htop : 2 ^ _root_.BabyBear.twoAdicity < _root_.BabyBear.fieldSize := by
-      simp [_root_.BabyBear.twoAdicity, _root_.BabyBear.fieldSize]
+  have hpow_lt : 2 ^ logN < BabyBear.fieldSize := by
+    have htop : 2 ^ BabyBear.twoAdicity < BabyBear.fieldSize := by
+      simp [BabyBear.twoAdicity, BabyBear.fieldSize]
     exact lt_of_le_of_lt hpow_le htop
-  have hdiv : _root_.BabyBear.fieldSize ∣ 2 ^ logN := by
-    exact (ZMod.natCast_eq_zero_iff (2 ^ logN) _root_.BabyBear.fieldSize).mp hzero
+  have hdiv : BabyBear.fieldSize ∣ 2 ^ logN := by
+    exact (ZMod.natCast_eq_zero_iff (2 ^ logN) BabyBear.fieldSize).mp hzero
   exact (not_le_of_gt hpow_lt) (Nat.le_of_dvd hpow_pos hdiv)
 
 /-- BabyBear radix-2 NTT domain for a supported two-adic size. -/
-def domainOfLogN (logN : Nat) (hlogN : logN ≤ _root_.BabyBear.twoAdicity) :
-    Domain _root_.BabyBear.Field where
+def domainOfLogN (logN : Nat) (hlogN : logN ≤ BabyBear.twoAdicity) :
+    Domain BabyBear.Field where
   logN := logN
-  omega := _root_.BabyBear.twoAdicGenerators[bitsOfLogN logN hlogN]
+  omega := BabyBear.twoAdicGenerators[bitsOfLogN logN hlogN]
   primitive := by
     simpa [bitsOfLogN] using
-      _root_.BabyBear.isPrimitiveRoot_twoAdicGenerator (bitsOfLogN logN hlogN)
+      BabyBear.isPrimitiveRoot_twoAdicGenerator (bitsOfLogN logN hlogN)
   natCast_ne_zero := twoPowNatCast_ne_zero logN hlogN
 
 end BabyBear

--- a/CompPoly/Univariate/NTT/Domain.lean
+++ b/CompPoly/Univariate/NTT/Domain.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Salih Erdem Koçak, Doran Pamukçu
+Authors: Salih Erdem Koçak, Doran Pamukçu, Valerii Huhnin
 -/
 import CompPoly.Univariate.Raw
 import Mathlib.Data.Nat.Log

--- a/CompPoly/Univariate/NTT/Domain.lean
+++ b/CompPoly/Univariate/NTT/Domain.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Salih Erdem Koçak, Doran Pamukçu
 -/
 import CompPoly.Univariate.Raw
+import Mathlib.Data.Nat.Log
 import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 
 /-!
@@ -95,6 +96,33 @@ def truncate (m : Nat) (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
 
 end RawHelpers
 end Domain
+
+/-- The smallest radix-2 exponent that can cover a requested convolution length. -/
+def bestLogN (requiredLen : Nat) : Nat :=
+  Nat.clog 2 requiredLen
+
+/-- An NTT domain bundled with proof that it covers the requested convolution length. -/
+abbrev FittingDomain (R : Type*) [Field R] (requiredLen : Nat) :=
+  { D : Domain R // requiredLen ≤ D.n }
+
+/--
+Generic adapter from field-specific radix-2 domain tables to a best-fitting domain lookup.
+
+The adapter chooses `logN = Nat.clog 2 requiredLen`, then returns `none` if that exponent
+is outside the supported table.
+-/
+def bestDomainForLength? [Field R]
+    (maxLogN : Nat) (domainOfLogN : (logN : Nat) → logN ≤ maxLogN → Domain R)
+    (domainOfLogN_logN : ∀ logN hlogN, (domainOfLogN logN hlogN).logN = logN)
+    (requiredLen : Nat) : Option (FittingDomain R requiredLen) :=
+  let logN := bestLogN requiredLen
+  if hlogN : logN ≤ maxLogN then
+    some ⟨domainOfLogN logN hlogN, by
+      have hfit : requiredLen ≤ 2 ^ logN := by
+        simpa [logN, bestLogN] using Nat.le_pow_clog (by decide : 1 < 2) requiredLen
+      simpa [Domain.n, domainOfLogN_logN logN hlogN] using hfit⟩
+  else
+    none
 
 end NTT
 end CPolynomial

--- a/CompPoly/Univariate/NTT/KoalaBear.lean
+++ b/CompPoly/Univariate/NTT/KoalaBear.lean
@@ -18,35 +18,35 @@ namespace NTT
 namespace KoalaBear
 
 /-- Build a finite index into the KoalaBear two-adic generator table. -/
-def bitsOfLogN (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
-    Fin (_root_.KoalaBear.twoAdicity + 1) :=
+def bitsOfLogN (logN : Nat) (hlogN : logN ≤ KoalaBear.twoAdicity) :
+    Fin (KoalaBear.twoAdicity + 1) :=
   ⟨logN, Nat.lt_succ_of_le hlogN⟩
 
 /-- The KoalaBear NTT domain size is nonzero in the field for supported two-adic sizes. -/
 theorem twoPowNatCast_ne_zero
-    (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
-    (((2 ^ logN : Nat) : _root_.KoalaBear.Field) ≠ 0) := by
+    (logN : Nat) (hlogN : logN ≤ KoalaBear.twoAdicity) :
+    (((2 ^ logN : Nat) : KoalaBear.Field) ≠ 0) := by
   intro hzero
   have hpow_pos : 0 < 2 ^ logN := by
     positivity
-  have hpow_le : 2 ^ logN ≤ 2 ^ _root_.KoalaBear.twoAdicity := by
+  have hpow_le : 2 ^ logN ≤ 2 ^ KoalaBear.twoAdicity := by
     exact Nat.pow_le_pow_right (by decide : 1 ≤ 2) hlogN
-  have hpow_lt : 2 ^ logN < _root_.KoalaBear.fieldSize := by
-    have htop : 2 ^ _root_.KoalaBear.twoAdicity < _root_.KoalaBear.fieldSize := by
-      simp [_root_.KoalaBear.twoAdicity, _root_.KoalaBear.fieldSize]
+  have hpow_lt : 2 ^ logN < KoalaBear.fieldSize := by
+    have htop : 2 ^ KoalaBear.twoAdicity < KoalaBear.fieldSize := by
+      simp [KoalaBear.twoAdicity, KoalaBear.fieldSize]
     exact lt_of_le_of_lt hpow_le htop
-  have hdiv : _root_.KoalaBear.fieldSize ∣ 2 ^ logN := by
-    exact (ZMod.natCast_eq_zero_iff (2 ^ logN) _root_.KoalaBear.fieldSize).mp hzero
+  have hdiv : KoalaBear.fieldSize ∣ 2 ^ logN := by
+    exact (ZMod.natCast_eq_zero_iff (2 ^ logN) KoalaBear.fieldSize).mp hzero
   exact (not_le_of_gt hpow_lt) (Nat.le_of_dvd hpow_pos hdiv)
 
 /-- KoalaBear radix-2 NTT domain for a supported two-adic size. -/
-def domainOfLogN (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
-    Domain _root_.KoalaBear.Field where
+def domainOfLogN (logN : Nat) (hlogN : logN ≤ KoalaBear.twoAdicity) :
+    Domain KoalaBear.Field where
   logN := logN
-  omega := _root_.KoalaBear.twoAdicGenerators[bitsOfLogN logN hlogN]
+  omega := KoalaBear.twoAdicGenerators[bitsOfLogN logN hlogN]
   primitive := by
     simpa [bitsOfLogN] using
-      _root_.KoalaBear.isPrimitiveRoot_twoAdicGenerator (bitsOfLogN logN hlogN)
+      KoalaBear.isPrimitiveRoot_twoAdicGenerator (bitsOfLogN logN hlogN)
   natCast_ne_zero := twoPowNatCast_ne_zero logN hlogN
 
 end KoalaBear

--- a/CompPoly/Univariate/NTT/KoalaBear.lean
+++ b/CompPoly/Univariate/NTT/KoalaBear.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Valerii Huhnin
+-/
+import CompPoly.Fields.KoalaBear
+import CompPoly.Univariate.NTT.Domain
+
+/-!
+# KoalaBear NTT Domains
+
+Concrete radix-2 NTT domains over the KoalaBear field.
+-/
+
+namespace CompPoly
+namespace CPolynomial
+namespace NTT
+namespace KoalaBear
+
+/-- Build a finite index into the KoalaBear two-adic generator table. -/
+def bitsOfLogN (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
+    Fin (_root_.KoalaBear.twoAdicity + 1) :=
+  ⟨logN, Nat.lt_succ_of_le hlogN⟩
+
+/-- The KoalaBear NTT domain size is nonzero in the field for supported two-adic sizes. -/
+theorem twoPowNatCast_ne_zero
+    (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
+    (((2 ^ logN : Nat) : _root_.KoalaBear.Field) ≠ 0) := by
+  intro hzero
+  have hpow_pos : 0 < 2 ^ logN := by
+    positivity
+  have hpow_le : 2 ^ logN ≤ 2 ^ _root_.KoalaBear.twoAdicity := by
+    exact Nat.pow_le_pow_right (by decide : 1 ≤ 2) hlogN
+  have hpow_lt : 2 ^ logN < _root_.KoalaBear.fieldSize := by
+    have htop : 2 ^ _root_.KoalaBear.twoAdicity < _root_.KoalaBear.fieldSize := by
+      simp [_root_.KoalaBear.twoAdicity, _root_.KoalaBear.fieldSize]
+    exact lt_of_le_of_lt hpow_le htop
+  have hdiv : _root_.KoalaBear.fieldSize ∣ 2 ^ logN := by
+    exact (ZMod.natCast_eq_zero_iff (2 ^ logN) _root_.KoalaBear.fieldSize).mp hzero
+  exact (not_le_of_gt hpow_lt) (Nat.le_of_dvd hpow_pos hdiv)
+
+/-- KoalaBear radix-2 NTT domain for a supported two-adic size. -/
+def domainOfLogN (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
+    Domain _root_.KoalaBear.Field where
+  logN := logN
+  omega := _root_.KoalaBear.twoAdicGenerators[bitsOfLogN logN hlogN]
+  primitive := by
+    simpa [bitsOfLogN] using
+      _root_.KoalaBear.isPrimitiveRoot_twoAdicGenerator (bitsOfLogN logN hlogN)
+  natCast_ne_zero := twoPowNatCast_ne_zero logN hlogN
+
+end KoalaBear
+end NTT
+end CPolynomial
+end CompPoly

--- a/bench/CompPolyBench.lean
+++ b/bench/CompPolyBench.lean
@@ -14,6 +14,9 @@ import CompPoly.Fields.BN254
 import CompPoly.Fields.Goldilocks
 import CompPoly.Multilinear.Basic
 import CompPoly.Multivariate.CMvPolynomial
+import CompPoly.Univariate.NTT.BabyBear
+import CompPoly.Univariate.NTT.KoalaBear
+import CompPoly.Univariate.NTT.FastMul
 
 /-!
 # Evaluation Benchmarks
@@ -34,6 +37,19 @@ private def warmupIterations : Nat := 100
 
 /-- Number of measured iterations for ordinary evaluation benchmarks. -/
 private def measuredIterations : Nat := 5000
+
+/-- Number of warmup iterations for direct univariate multiplication benchmarks. -/
+private def mulWarmupIterations : Nat := 1
+
+/-- Number of measured iterations for direct univariate multiplication benchmarks. -/
+private def mulMeasuredIterations : Nat := 20
+
+/-- Number of coefficient slots used by direct univariate multiplication benchmarks. -/
+private def univariateMulCoeffSlots : Nat := 128
+
+/-- Input-shape label for direct univariate multiplication benchmarks. -/
+private def univariateMulShape : String :=
+  s!"degree<{univariateMulCoeffSlots} dense lhs/rhs"
 
 /-- Number of warmup iterations for the slower additive NTT benchmark. -/
 private def additiveNttWarmupIterations : Nat := 10
@@ -70,6 +86,14 @@ instance : Fact (Nat.Prime BabyBear.fieldSize) where
 /-- Primality witness used for generic `ZMod` benchmarks over `Goldilocks`. -/
 instance : Fact (Nat.Prime Goldilocks.fieldSize) where
   out := Goldilocks.is_prime
+
+/-- NTT domain large enough for direct degree-128 BabyBear multiplication benchmarks. -/
+private def babyBearMulNttDomain : CPolynomial.NTT.Domain BabyBear.Field :=
+  CPolynomial.NTT.BabyBear.domainOfLogN 8 (by decide)
+
+/-- NTT domain large enough for direct degree-128 KoalaBear multiplication benchmarks. -/
+private def koalaBearMulNttDomain : CPolynomial.NTT.Domain KoalaBear.Field :=
+  CPolynomial.NTT.KoalaBear.domainOfLogN 8 (by decide)
 
 /-- Result row emitted by one timed benchmark case. -/
 structure BenchRecord where
@@ -248,6 +272,11 @@ private def babyBearVector (size : Nat) (sparse : Bool) : StateM StdGen (Array B
 private def babyBearPoints (size : Nat) : StateM StdGen (Array BabyBear.Field) :=
   babyBearArray size false
 
+/-- Generate KoalaBear coefficients with the same shape controls as `zmodArray`. -/
+private def koalaBearArray (size : Nat) (sparse : Bool) :
+    StateM StdGen (Array KoalaBear.Field) := do
+  zmodArray KoalaBear.fieldSize size sparse
+
 /-- Build a canonical computable polynomial from generated coefficients. -/
 private def cpolyOfArray {R : Type*} [Zero R] [BEq R] [LawfulBEq R]
     (coeffs : Array R) : CPolynomial R :=
@@ -262,6 +291,10 @@ private def mixChecksum (acc value : Nat) : Nat :=
 private def checksumBabyBear (x : BabyBear.Field) : Nat :=
   ZMod.val x
 
+/-- Convert a KoalaBear field element to a checksum word. -/
+private def checksumKoalaBear (x : KoalaBear.Field) : Nat :=
+  ZMod.val x
+
 /-- Convert a `ZMod` element to a checksum word. -/
 private def checksumZMod {modulus : Nat} (x : ZMod modulus) : Nat :=
   ZMod.val x
@@ -273,6 +306,14 @@ private def checksumBtf3 (x : AdditiveNTT.BTF₃) : Nat :=
 /-- Convert a concrete binary-tower field element to a checksum word. -/
 private def checksumConcreteBtf {k : Nat} (x : ConcreteBTField k) : Nat :=
   BitVec.toNat x
+
+/-- Checksum an array-like benchmark result. -/
+private def checksumArray (checksum : α → Nat) (xs : Array α) : Nat :=
+  xs.foldl (fun acc x ↦ mixChecksum acc (checksum x)) 0
+
+/-- Checksum a canonical computable polynomial by its coefficient array. -/
+private def checksumCPolynomial [Zero α] (checksum : α → Nat) (p : CPolynomial α) : Nat :=
+  checksumArray checksum p.val
 
 /-- Time one benchmark closure and package its metadata and checksum. -/
 private def runTimed (name representation method field inputShape : String)
@@ -546,9 +587,17 @@ private def runMultivariateZMod (modulus : Nat) [Fact (Nat.Prime modulus)]
 private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := do
   let (denseCoeffs, gen) := (babyBearArray 512 false).run gen
   let (sparseCoeffs, gen) := (babyBearArray 512 true).run gen
+  let (mulLhsCoeffs, gen) := (babyBearArray univariateMulCoeffSlots false).run gen
+  let (mulRhsCoeffs, gen) := (babyBearArray univariateMulCoeffSlots false).run gen
+  let (koalaMulLhsCoeffs, gen) := (koalaBearArray univariateMulCoeffSlots false).run gen
+  let (koalaMulRhsCoeffs, gen) := (koalaBearArray univariateMulCoeffSlots false).run gen
   let (points, gen) := (babyBearPoints 32).run gen
   let densePoly := cpolyOfArray denseCoeffs
   let sparsePoly := cpolyOfArray sparseCoeffs
+  let mulLhsPoly := cpolyOfArray mulLhsCoeffs
+  let mulRhsPoly := cpolyOfArray mulRhsCoeffs
+  let koalaMulLhsPoly := cpolyOfArray koalaMulLhsCoeffs
+  let koalaMulRhsPoly := cpolyOfArray koalaMulRhsCoeffs
   let nextGen := gen
   let mut records := #[]
   records := records.push (← runTimed
@@ -571,6 +620,29 @@ private def runUnivariate (gen : StdGen) : IO (Array BenchRecord × StdGen) := d
     "degree<512, one nonzero per 4 coeffs, 32 points" warmupIterations measuredIterations
     (fun i ↦ CPolynomial.evalHorner (points.getD (i % points.size) 0) sparsePoly)
     checksumBabyBear)
+  records := records.push (← runTimed
+    "univariate-mul-naive" "CPolynomial" "mul" "BabyBear.Field"
+    univariateMulShape mulWarmupIterations mulMeasuredIterations
+    (fun _ ↦ mulLhsPoly * mulRhsPoly)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mul-ntt" "CPolynomial" "FastMul.fastMulImpl, domain n=256"
+    "BabyBear.Field"
+    univariateMulShape mulWarmupIterations mulMeasuredIterations
+    (fun _ ↦ CPolynomial.NTT.FastMul.fastMulImpl babyBearMulNttDomain mulLhsPoly mulRhsPoly)
+    (checksumCPolynomial checksumBabyBear))
+  records := records.push (← runTimed
+    "univariate-mul-naive-koalabear" "CPolynomial" "mul" "KoalaBear.Field"
+    univariateMulShape mulWarmupIterations mulMeasuredIterations
+    (fun _ ↦ koalaMulLhsPoly * koalaMulRhsPoly)
+    (checksumCPolynomial checksumKoalaBear))
+  records := records.push (← runTimed
+    "univariate-mul-ntt-koalabear" "CPolynomial" "FastMul.fastMulImpl, domain n=256"
+    "KoalaBear.Field"
+    univariateMulShape mulWarmupIterations mulMeasuredIterations
+    (fun _ ↦ CPolynomial.NTT.FastMul.fastMulImpl koalaBearMulNttDomain koalaMulLhsPoly
+      koalaMulRhsPoly)
+    (checksumCPolynomial checksumKoalaBear))
   let (goldilocksRecords, extraGen) ← runDenseUnivariateZMod
     Goldilocks.fieldSize "goldilocks" "Goldilocks.Field" nextGen
   records := appendRecords records goldilocksRecords

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,8 +1,9 @@
 # Evaluation Benchmarks
 
-This directory contains the compiled evaluation benchmark executable for
+This directory contains the compiled benchmark executable for
 CompPoly. The benchmark is intentionally small enough for CI, but broad enough
-to cover the main polynomial evaluation surfaces and the existing additive NTT
+to cover the main polynomial evaluation surfaces, direct univariate
+multiplication, root-of-unity NTT multiplication, and the existing additive NTT
 implementation.
 
 ## Running
@@ -29,9 +30,10 @@ Generated benchmark artifacts are ignored by `bench/.gitignore`.
 
 ## What Is Measured
 
-The benchmark covers the main polynomial evaluation paths and the existing
-additive NTT implementation. Exact cases, input shapes, deterministic input
-generation, and reported fields are defined in `bench/CompPolyBench.lean`.
+The benchmark covers the main polynomial evaluation paths, direct versus
+NTT-backed univariate multiplication, and the existing additive NTT
+implementation. Exact cases, input shapes, deterministic input generation, and
+reported fields are defined in `bench/CompPolyBench.lean`.
 
 ## Determinism
 

--- a/tests/CompPolyTests/Univariate/NTT/Benchmark.lean
+++ b/tests/CompPolyTests/Univariate/NTT/Benchmark.lean
@@ -24,15 +24,10 @@ def benchSizes : Array Nat :=
   #[4, 8, 12, 16, 24, 32, 48, 64, 96, 128,
     192, 256, 384, 512, 768, 1024, 1536, 2048, 2560, 3000]
 
-def bestLogN (requiredLen : Nat) : Nat :=
-  Nat.clog 2 requiredLen
-
-def bestDomainForLength? (requiredLen : Nat) : Option (Domain _root_.KoalaBear.Field) :=
-  let logN := bestLogN requiredLen
-  if hlogN : logN ≤ _root_.KoalaBear.twoAdicity then
-    some (KoalaBear.domainOfLogN logN hlogN)
-  else
-    none
+def bestDomainForLength? (requiredLen : Nat) :
+    Option (FittingDomain _root_.KoalaBear.Field requiredLen) :=
+  CPolynomial.NTT.bestDomainForLength? _root_.KoalaBear.twoAdicity KoalaBear.domainOfLogN
+    (by intro _ _; rfl) requiredLen
 
 def mkPoly (n seed : Nat) : CPolynomial.Raw _root_.KoalaBear.Field :=
   Array.ofFn (fun i : Fin n => (((i.1 + 1) * seed + i.1 * i.1 + 17) :
@@ -80,7 +75,7 @@ def timeRepeated {α : Type} (reps : Nat) (f : Unit → α) : IO (Nat × α) := 
     let p := mkPoly n (41 + 13 * i)
     let q := mkPoly n (73 + 17 * i)
     let reqLen := Domain.requiredLength p q
-    let some benchDomain := bestDomainForLength? reqLen
+    let some ⟨benchDomain, _⟩ := bestDomainForLength? reqLen
       | throw <| IO.userError
           s!"no KoalaBear domain supports required length {reqLen} for size {n}"
     let (nttMs, nttRes) ← timeRepeated reps (fun _ => FastMul.Raw.fastMulImpl benchDomain p q)

--- a/tests/CompPolyTests/Univariate/NTT/Benchmark.lean
+++ b/tests/CompPolyTests/Univariate/NTT/Benchmark.lean
@@ -24,30 +24,38 @@ def benchSizes : Array Nat :=
   #[4, 8, 12, 16, 24, 32, 48, 64, 96, 128,
     192, 256, 384, 512, 768, 1024, 1536, 2048, 2560, 3000]
 
+/-- Best-fitting KoalaBear NTT domain for a required convolution length. -/
 def bestDomainForLength? (requiredLen : Nat) :
     Option (FittingDomain _root_.KoalaBear.Field requiredLen) :=
   CPolynomial.NTT.bestDomainForLength? _root_.KoalaBear.twoAdicity KoalaBear.domainOfLogN
     (by intro _ _; rfl) requiredLen
 
+/-- Deterministic KoalaBear polynomial used by the manual benchmark. -/
 def mkPoly (n seed : Nat) : CPolynomial.Raw _root_.KoalaBear.Field :=
-  Array.ofFn (fun i : Fin n => (((i.1 + 1) * seed + i.1 * i.1 + 17) :
+  Array.ofFn (fun i : Fin n ↦ (((i.1 + 1) * seed + i.1 * i.1 + 17) :
     _root_.KoalaBear.Field))
 
+/-- Operand size used by the one-off correctness check values. -/
 def checkSize : Nat := 512
 
+/-- First polynomial for the one-off correctness check. -/
 def p : CPolynomial.Raw _root_.KoalaBear.Field := mkPoly checkSize 60
 
+/-- Second polynomial for the one-off correctness check. -/
 def q : CPolynomial.Raw _root_.KoalaBear.Field := mkPoly checkSize 29
 
+/-- Render an average millisecond count. -/
 def avgMsString (totalMs reps : Nat) : String :=
   s!"{(Float.ofNat totalMs) / (Float.ofNat reps)}"
 
+/-- Render the raw-over-NTT speedup ratio. -/
 def speedupString (nttMs rawMs : Nat) : String :=
   if nttMs = 0 then
     "inf"
   else
     s!"{(Float.ofNat rawMs) / (Float.ofNat nttMs)}"
 
+/-- Number of repetitions to use for a benchmark size. -/
 def repeatsFor (n : Nat) : Nat :=
   if n ≤ 32 then 50
   else if n ≤ 128 then 20
@@ -55,6 +63,7 @@ def repeatsFor (n : Nat) : Nat :=
   else if n ≤ 1536 then 2
   else 1
 
+/-- Time repeated calls to a thunk and return the final result. -/
 def timeRepeated {α : Type} (reps : Nat) (f : Unit → α) : IO (Nat × α) := do
   let actualReps := max reps 1
   let start ← IO.monoMsNow
@@ -78,8 +87,8 @@ def timeRepeated {α : Type} (reps : Nat) (f : Unit → α) : IO (Nat × α) := 
     let some ⟨benchDomain, _⟩ := bestDomainForLength? reqLen
       | throw <| IO.userError
           s!"no KoalaBear domain supports required length {reqLen} for size {n}"
-    let (nttMs, nttRes) ← timeRepeated reps (fun _ => FastMul.Raw.fastMulImpl benchDomain p q)
-    let (rawMs, rawRes) ← timeRepeated reps (fun _ => p * q)
+    let (nttMs, nttRes) ← timeRepeated reps (fun _ ↦ FastMul.Raw.fastMulImpl benchDomain p q)
+    let (rawMs, rawRes) ← timeRepeated reps (fun _ ↦ p * q)
     unless nttRes = rawRes do
       throw <| IO.userError s!"benchmark mismatch at size {n}"
     let winner := if nttMs ≤ rawMs then "NTT" else "raw"

--- a/tests/CompPolyTests/Univariate/NTT/Benchmark.lean
+++ b/tests/CompPolyTests/Univariate/NTT/Benchmark.lean
@@ -5,7 +5,7 @@ Authors: Salih Erdem Koçak, Doran Pamukçu
 -/
 
 import CompPoly.Univariate.NTT.FastMul
-import CompPoly.Fields.KoalaBear
+import CompPoly.Univariate.NTT.KoalaBear
 
 /-!
   # Univariate Multiplication Benchmark
@@ -27,41 +27,22 @@ def benchSizes : Array Nat :=
 def bestLogN (requiredLen : Nat) : Nat :=
   Nat.clog 2 requiredLen
 
-def bestDomainForLength? (requiredLen : Nat) : Option (Domain KoalaBear.Field) :=
+def bestDomainForLength? (requiredLen : Nat) : Option (Domain _root_.KoalaBear.Field) :=
   let logN := bestLogN requiredLen
-  if hlogN : logN ≤ KoalaBear.twoAdicity then
-    let bits : Fin (KoalaBear.twoAdicity + 1) := ⟨logN, Nat.lt_succ_of_le hlogN⟩
-    some {
-      logN := logN
-      omega := KoalaBear.twoAdicGenerators[bits]
-      primitive := by
-        simpa using KoalaBear.isPrimitiveRoot_twoAdicGenerator bits
-      natCast_ne_zero := by
-        change (((2 ^ logN : Nat) : KoalaBear.Field) ≠ 0)
-        intro hzero
-        have hpow_pos : 0 < 2 ^ logN := by
-          positivity
-        have hpow_le : 2 ^ logN ≤ 2 ^ KoalaBear.twoAdicity := by
-          exact Nat.pow_le_pow_right (by decide : 1 ≤ 2) hlogN
-        have hpow_lt : 2 ^ logN < KoalaBear.fieldSize := by
-          have htop : 2 ^ KoalaBear.twoAdicity < KoalaBear.fieldSize := by
-            simp [KoalaBear.twoAdicity, KoalaBear.fieldSize]
-          exact lt_of_le_of_lt hpow_le htop
-        have hdiv : KoalaBear.fieldSize ∣ 2 ^ logN := by
-          exact (ZMod.natCast_eq_zero_iff (2 ^ logN) KoalaBear.fieldSize).mp hzero
-        exact (not_le_of_gt hpow_lt) (Nat.le_of_dvd hpow_pos hdiv)
-    }
+  if hlogN : logN ≤ _root_.KoalaBear.twoAdicity then
+    some (KoalaBear.domainOfLogN logN hlogN)
   else
     none
 
-def mkPoly (n seed : Nat) : CPolynomial.Raw KoalaBear.Field :=
-  Array.ofFn (fun i : Fin n => (((i.1 + 1) * seed + i.1 * i.1 + 17) : KoalaBear.Field))
+def mkPoly (n seed : Nat) : CPolynomial.Raw _root_.KoalaBear.Field :=
+  Array.ofFn (fun i : Fin n => (((i.1 + 1) * seed + i.1 * i.1 + 17) :
+    _root_.KoalaBear.Field))
 
 def checkSize : Nat := 512
 
-def p : CPolynomial.Raw KoalaBear.Field := mkPoly checkSize 60
+def p : CPolynomial.Raw _root_.KoalaBear.Field := mkPoly checkSize 60
 
-def q : CPolynomial.Raw KoalaBear.Field := mkPoly checkSize 29
+def q : CPolynomial.Raw _root_.KoalaBear.Field := mkPoly checkSize 29
 
 def avgMsString (totalMs reps : Nat) : String :=
   s!"{(Float.ofNat totalMs) / (Float.ofNat reps)}"

--- a/tests/CompPolyTests/Univariate/NTT/Common.lean
+++ b/tests/CompPolyTests/Univariate/NTT/Common.lean
@@ -3,8 +3,7 @@ Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Salih Erdem Koçak, Doran Pamukçu
 -/
-import CompPoly.Univariate.NTT.Domain
-import CompPoly.Fields.KoalaBear
+import CompPoly.Univariate.NTT.KoalaBear
 
 /-!
   # Univariate NTT Test Helpers
@@ -17,42 +16,21 @@ namespace CPolynomial
 namespace NTT
 namespace TestCommon
 
-def testBitsOfLogN (logN : Nat) (hlogN : logN ≤ KoalaBear.twoAdicity) :
-    Fin (KoalaBear.twoAdicity + 1) :=
-  ⟨logN, Nat.lt_succ_of_le hlogN⟩
+def testBitsOfLogN (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
+    Fin (_root_.KoalaBear.twoAdicity + 1) :=
+  CPolynomial.NTT.KoalaBear.bitsOfLogN logN hlogN
 
-private theorem koalaBear_twoPow_natCast_ne_zero
-    (logN : Nat) (hlogN : logN ≤ KoalaBear.twoAdicity) :
-    (((2 ^ logN : Nat) : KoalaBear.Field) ≠ 0) := by
-  intro hzero
-  have hpow_pos : 0 < 2 ^ logN := by
-    positivity
-  have hpow_le : 2 ^ logN ≤ 2 ^ KoalaBear.twoAdicity := by
-    exact Nat.pow_le_pow_right (by decide : 1 ≤ 2) hlogN
-  have hpow_lt : 2 ^ logN < KoalaBear.fieldSize := by
-    have htop : 2 ^ KoalaBear.twoAdicity < KoalaBear.fieldSize := by
-      simp [KoalaBear.twoAdicity, KoalaBear.fieldSize]
-    exact lt_of_le_of_lt hpow_le htop
-  have hdiv : KoalaBear.fieldSize ∣ 2 ^ logN := by
-    exact (ZMod.natCast_eq_zero_iff (2 ^ logN) KoalaBear.fieldSize).mp hzero
-  exact (not_le_of_gt hpow_lt) (Nat.le_of_dvd hpow_pos hdiv)
+def testDomainOfLogN (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
+    Domain _root_.KoalaBear.Field :=
+  CPolynomial.NTT.KoalaBear.domainOfLogN logN hlogN
 
-def testDomainOfLogN (logN : Nat) (hlogN : logN ≤ KoalaBear.twoAdicity) :
-    Domain KoalaBear.Field where
-  logN := logN
-  omega := KoalaBear.twoAdicGenerators[testBitsOfLogN logN hlogN]
-  primitive := by
-    simpa [testBitsOfLogN] using
-      KoalaBear.isPrimitiveRoot_twoAdicGenerator (testBitsOfLogN logN hlogN)
-  natCast_ne_zero := koalaBear_twoPow_natCast_ne_zero logN hlogN
-
-def testDomain8 : Domain KoalaBear.Field :=
+def testDomain8 : Domain _root_.KoalaBear.Field :=
   testDomainOfLogN 3 (by decide)
 
-def testDomain32 : Domain KoalaBear.Field :=
+def testDomain32 : Domain _root_.KoalaBear.Field :=
   testDomainOfLogN 5 (by decide)
 
-def testDomain64 : Domain KoalaBear.Field :=
+def testDomain64 : Domain _root_.KoalaBear.Field :=
   testDomainOfLogN 6 (by decide)
 
 end TestCommon

--- a/tests/CompPolyTests/Univariate/NTT/Common.lean
+++ b/tests/CompPolyTests/Univariate/NTT/Common.lean
@@ -16,20 +16,25 @@ namespace CPolynomial
 namespace NTT
 namespace TestCommon
 
+/-- Build a finite test index into the KoalaBear two-adic generator table. -/
 def testBitsOfLogN (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
     Fin (_root_.KoalaBear.twoAdicity + 1) :=
   CPolynomial.NTT.KoalaBear.bitsOfLogN logN hlogN
 
+/-- KoalaBear NTT domain constructor used by the test suite. -/
 def testDomainOfLogN (logN : Nat) (hlogN : logN ≤ _root_.KoalaBear.twoAdicity) :
     Domain _root_.KoalaBear.Field :=
   CPolynomial.NTT.KoalaBear.domainOfLogN logN hlogN
 
+/-- KoalaBear NTT test domain of size `8`. -/
 def testDomain8 : Domain _root_.KoalaBear.Field :=
   testDomainOfLogN 3 (by decide)
 
+/-- KoalaBear NTT test domain of size `32`. -/
 def testDomain32 : Domain _root_.KoalaBear.Field :=
   testDomainOfLogN 5 (by decide)
 
+/-- KoalaBear NTT test domain of size `64`. -/
 def testDomain64 : Domain _root_.KoalaBear.Field :=
   testDomainOfLogN 6 (by decide)
 


### PR DESCRIPTION
This PR adds:
- benchmark to compare naive multiplication vs NTT-based multiplication to `bench/CompPolyBench.lean`
- `KoalaBear` NTT infrastructure is moved to a dedicated file `CompPoly/Univariate/NTT/KoalaBear.lean` and shared across NTT-specific tests/benchmarks file `tests/CompPolyTests/Univariate/NTT/Benchmark.lean` and `bench/CompPolyBench.lean`
- `BabyBear` NTT infrastructure is added to benchmark NTT with `BabyBear` (default `CompPolyBench` prime)
