### PR TITLE
Z tech/keep add rm inst h add max nat

### DIFF
--- a/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
+++ b/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
@@ -34,13 +34,11 @@ lemma eval_C (c : R) : (CMvPolynomial.C c : CMvPolynomial n R).eval vals = c := 
 
 @[simp]
 lemma eval_add (p q : CMvPolynomial n R) :
-    (p + q).eval vals = p.eval vals + q.eval vals := by
-  simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_add p q
+    (p + q).eval vals = p.eval vals + q.eval vals := by simp [eval_equiv]
 
 @[simp]
 lemma eval_mul (p q : CMvPolynomial n R) :
-    (p * q).eval vals = p.eval vals * q.eval vals := by
-  simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_mul p q
+    (p * q).eval vals = p.eval vals * q.eval vals := by simp [eval_equiv]
 
 end
 

--- a/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
+++ b/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
@@ -21,15 +21,46 @@ variable {n : ℕ} {R : Type} [CommSemiring R] [BEq R] [LawfulBEq R]
 variable (vals : Fin n → R)
 
 @[simp]
+lemma eval_zero : (0 : CMvPolynomial n R).eval vals = 0 := by
+  simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_zero
+
+@[simp]
+lemma eval_one : (1 : CMvPolynomial n R).eval vals = 1 := by
+  simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_one
+
+@[simp]
+lemma eval_C (c : R) : (CMvPolynomial.C c : CMvPolynomial n R).eval vals = c := by
+  simp [eval_equiv, fromCMvPolynomial_C]
+
+@[simp]
 lemma eval_add (p q : CMvPolynomial n R) :
-    (p + q).eval vals = p.eval vals + q.eval vals := by simp [eval_equiv]
+    (p + q).eval vals = p.eval vals + q.eval vals := by
+  simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_add p q
 
 @[simp]
 lemma eval_mul (p q : CMvPolynomial n R) :
-    (p * q).eval vals = p.eval vals * q.eval vals := by simp [eval_equiv]
+    (p * q).eval vals = p.eval vals * q.eval vals := by
+  simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_mul p q
 
 end
 
-attribute [grind =] eval_add eval_mul
+section
+
+variable {n : ℕ} {R : Type} [CommRing R] [BEq R] [LawfulBEq R]
+variable (vals : Fin n → R)
+
+@[simp]
+lemma eval_neg (p : CMvPolynomial n R) :
+    (-p).eval vals = -(p.eval vals) := by
+  simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_neg p
+
+@[simp]
+lemma eval_sub (p q : CMvPolynomial n R) :
+    (p - q).eval vals = p.eval vals - q.eval vals := by
+  simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_sub p q
+
+end
+
+attribute [grind =] eval_zero eval_one eval_C eval_add eval_mul eval_neg eval_sub
 
 end CPoly

--- a/CompPoly/Multivariate/Lawful.lean
+++ b/CompPoly/Multivariate/Lawful.lean
@@ -221,9 +221,47 @@ section
 
 variable {n₁ n₂ : ℕ}
 
+/-- Align two polynomials by extending them to have the same number of variables. -/
+def align
+    (p₁ : Lawful n₁ R) (p₂ : Lawful n₂ R) :
+    Lawful (n₁ ⊔ n₂) R × Lawful (n₁ ⊔ n₂) R :=
+  letI sup := n₁ ⊔ n₂
+  (
+    cast (by congr 1; grind) (p₁.extend sup),
+    cast (by congr 1; grind) (p₂.extend sup)
+  )
+
+/-- Lift a binary polynomial operation to handle polynomials with different numbers of variables. -/
+def liftPoly
+    (f : Lawful (n₁ ⊔ n₂) R →
+  Lawful (n₁ ⊔ n₂) R →
+  Lawful (n₁ ⊔ n₂) R)
+  (p₁ : Lawful n₁ R) (p₂ : Lawful n₂ R) : Lawful (n₁ ⊔ n₂) R :=
+  Function.uncurry f (align p₁ p₂)
+
 def polyCoe (p : Lawful n R) : Lawful (n + 1) R := cast (by simp) (p.extend n.succ)
 
 instance : Coe (Lawful n R) (Lawful (n + 1) R) := ⟨polyCoe⟩
+
+section
+
+-- Mixed-arity fallbacks: keep these low-priority so same-arity `Add`/`Sub`/`Mul`
+-- instances win when both operands already live in `Lawful n R`.
+-- We intentionally do not add an `HPow` fallback here: exponentiation is unary, preserves
+-- arity, and is already handled above by the same-arity `NatPow (Lawful n R)` instance.
+instance (priority := low) [Add R] :
+    HAdd (Lawful n₁ R) (Lawful n₂ R) (Lawful (n₁ ⊔ n₂) R) :=
+  ⟨fun p₁ p₂ ↦ liftPoly (·+·) p₁ p₂⟩
+
+instance (priority := low) [Add R] [Neg R] :
+    HSub (Lawful n₁ R) (Lawful n₂ R) (Lawful (n₁ ⊔ n₂) R) :=
+  ⟨fun p₁ p₂ ↦ liftPoly (·-·) p₁ p₂⟩
+
+instance (priority := low) [Add R] [Mul R] :
+    HMul (Lawful n₁ R) (Lawful n₂ R) (Lawful (n₁ ⊔ n₂) R) :=
+  ⟨fun p₁ p₂ ↦ liftPoly (·*·) p₁ p₂⟩
+
+end
 
 end
 

--- a/CompPoly/Multivariate/Lawful.lean
+++ b/CompPoly/Multivariate/Lawful.lean
@@ -221,47 +221,9 @@ section
 
 variable {n₁ n₂ : ℕ}
 
-/-- Align two polynomials by extending them to have the same number of variables. -/
-def align
-    (p₁ : Lawful n₁ R) (p₂ : Lawful n₂ R) :
-    Lawful (n₁ ⊔ n₂) R × Lawful (n₁ ⊔ n₂) R :=
-  letI sup := n₁ ⊔ n₂
-  (
-    cast (by congr 1; grind) (p₁.extend sup),
-    cast (by congr 1; grind) (p₂.extend sup)
-  )
-
-/-- Lift a binary polynomial operation to handle polynomials with different numbers of variables. -/
-def liftPoly
-    (f : Lawful (n₁ ⊔ n₂) R →
-  Lawful (n₁ ⊔ n₂) R →
-  Lawful (n₁ ⊔ n₂) R)
-  (p₁ : Lawful n₁ R) (p₂ : Lawful n₂ R) : Lawful (n₁ ⊔ n₂) R :=
-  Function.uncurry f (align p₁ p₂)
-
 def polyCoe (p : Lawful n R) : Lawful (n + 1) R := cast (by simp) (p.extend n.succ)
 
 instance : Coe (Lawful n R) (Lawful (n + 1) R) := ⟨polyCoe⟩
-
-section
-
--- Mixed-arity fallbacks: keep these low-priority so same-arity `Add`/`Sub`/`Mul`
--- instances win when both operands already live in `Lawful n R`.
--- We intentionally do not add an `HPow` fallback here: exponentiation is unary, preserves
--- arity, and is already handled above by the same-arity `NatPow (Lawful n R)` instance.
-instance (priority := low) [Add R] :
-    HAdd (Lawful n₁ R) (Lawful n₂ R) (Lawful (n₁ ⊔ n₂) R) :=
-  ⟨fun p₁ p₂ ↦ liftPoly (·+·) p₁ p₂⟩
-
-instance (priority := low) [Add R] [Neg R] :
-    HSub (Lawful n₁ R) (Lawful n₂ R) (Lawful (n₁ ⊔ n₂) R) :=
-  ⟨fun p₁ p₂ ↦ liftPoly (·-·) p₁ p₂⟩
-
-instance (priority := low) [Add R] [Mul R] :
-    HMul (Lawful n₁ R) (Lawful n₂ R) (Lawful (n₁ ⊔ n₂) R) :=
-  ⟨fun p₁ p₂ ↦ liftPoly (·*·) p₁ p₂⟩
-
-end
 
 end
 


### PR DESCRIPTION
## The problem

`eval_add` and `eval_mul` are simp lemmas, but `eval_zero`, `eval_one`,
`eval_C`, `eval_neg`, `eval_sub` are missing. Any proof that touches a
constant, a zero/one polynomial, or a subtraction has to manually unfold
via `eval₂Hom_apply` + `RingHom.map_*`.

Real downstream call sites in [`sumcheck-lean4`](https://github.com/z-tech/sumcheck-lean4):

[`Sumcheck/IP/SharpSAT/Arithmetize.lean#L71-L78`](https://github.com/z-tech/sumcheck-lean4/blob/z-tech/linear-codes/Sumcheck/IP/SharpSAT/Arithmetize.lean#L71-L78):

```lean
lemma eval_arithClause {n : ℕ} (c : Clause3 n) (x : Fin n → Bool) :
    (arithClause (𝔽 := 𝔽) c).eval (fun i => boolToField (x i)) =
      boolToField (c.eval x) := by
  unfold arithClause Clause3.eval
  rw [show (c.ℓ₁.eval x || c.ℓ₂.eval x || c.ℓ₃.eval x)
        = (c.ℓ₁.eval x || (c.ℓ₂.eval x || c.ℓ₃.eval x)) from by
    cases c.ℓ₁.eval x <;> cases c.ℓ₂.eval x <;> cases c.ℓ₃.eval x <;> rfl]
  simp [eval_sub, eval_mul, eval_one, eval_arithLit, boolToField_or, mul_assoc]
  --    ^^^^^^^^             ^^^^^^^^  Unknown identifier
```

[`Sumcheck/Properties/Lemmas/Eval.lean#L196-L200`](https://github.com/z-tech/sumcheck-lean4/blob/z-tech/linear-codes/Sumcheck/Properties/Lemmas/Eval.lean#L196-L200) (and similar at [L352](https://github.com/z-tech/sumcheck-lean4/blob/z-tech/linear-codes/Sumcheck/Properties/Lemmas/Eval.lean#L352), [L451](https://github.com/z-tech/sumcheck-lean4/blob/z-tech/linear-codes/Sumcheck/Properties/Lemmas/Eval.lean#L451), and three more places in `HonestProver.lean` / `HonestRoundProofs.lean`):

```lean
| 0 => by
    dsimp [powUnivariate, c1]
    rw [pow_zero]
    show CMvPolynomial.eval (fun _ : Fin 1 => b) (CMvPolynomial.C 1) = 1
    exact CPoly.eval_C _ _
    --    ^^^^^^^^^^^^  Unknown identifier
```

Each workaround inlines the missing lemma's proof:

```lean
simpa [eval₂Hom_apply] using (eval₂Hom (RingHom.id R) vals).map_one
```

— boilerplate that `simp`/`grind` can't pick up because there's nothing
attribute-tagged.

## The fix

Add the five lemmas in `CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean`,
mark `@[simp]`, extend the existing `attribute [grind =]` line:

- `eval_zero`, `eval_one`, `eval_C` over `[CommSemiring R]`
- `eval_neg`, `eval_sub` over `[CommRing R]` (matching the existing
  semiring/ring split for `eval_add` / `eval_mul`)

Each proof is one line via `eval₂Hom_apply` + `RingHom.map_{zero,one,neg,sub}`
(and `eval_equiv` + `fromCMvPolynomial_C` for `eval_C`).

Purely additive: one file, +30/-1 lines, no existing lemma touched.