### PR TITLE
feat(bivariate): RingEquiv between CBivariate R and CMvPolynomial 2 R

### DIFF
--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+
+import CompPoly.Bivariate.Basic
+import CompPoly.Multivariate.CMvPolynomial
+
+open CompPoly CPoly
+
+variable R
+
+#check CPolynomial
+#print CPolynomial
+
+/- theorem CBivariate_eq_CMvPolynomial {R : Type*}  [CommSemiring R] [BEq R] [LawfulBEq R] : CBivariate R ≃+* CMvPolynomial 2 R := by sorry -/
+noncomputable def bivariateEquiv {R : Type*} [Semiring R] : CBivariate R ≃+* CMvPolynomial 2 R := sorry

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -9,6 +9,7 @@ import CompPoly.Bivariate.ToPoly
 import CompPoly.Multivariate.CMvPolynomial
 import CompPoly.Multivariate.MvPolyEquiv.Instances
 import CompPoly.Multivariate.FinSuccEquiv
+import CompPoly.Multivariate.Rename
 
 open CompPoly CPoly CBivariate
 
@@ -18,29 +19,72 @@ variable [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
 namespace CMvPolynomial
 
 @[simp]
-lemma isEmptyRingEquiv_symm_apply (r : R) :
-  CMvPolynomial.isEmptyRingEquiv.symm r = CMvPolynomial.C r := by
-    unfold CMvPolynomial.isEmptyRingEquiv
-    exact CPoly.polyRingEquiv.symm_apply_eq.mpr (CMvPolynomial.fromCMvPolynomial_C r).symm
+lemma isEmptyRingEquiv_symm_apply
+    {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R] (r : R) :
+    CMvPolynomial.isEmptyRingEquiv.symm r = CMvPolynomial.C r := by
+  unfold CMvPolynomial.isEmptyRingEquiv
+  rw [RingEquiv.symm_trans_apply, polyRingEquiv.symm_apply_eq]
+  exact (CMvPolynomial.fromCMvPolynomial_C r).symm
 
-/- theorem CBivariate_eq_CMvPolynomial {R : Type*}  [CommSemiring R] [BEq R] [LawfulBEq R] : CBivariate R ≃+* CMvPolynomial 2 R := by sorry -/
-noncomputable def bivariateEquiv : CBivariate R ≃+* CMvPolynomial 2 R :=
+@[simp]
+lemma finSuccEquiv_symm_C
+    {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R]
+    {n : ℕ} (x : CMvPolynomial n R) :
+    CMvPolynomial.finSuccEquiv.symm (Polynomial.C x) =
+      CMvPolynomial.rename Fin.succ x := by
+  apply fromCMvPolynomial_injective
+  rw [fromCMvPolynomial_rename]
+  unfold finSuccEquiv
+  simp [RingEquiv.symm_trans_apply, CPoly.polynomialCMvPolyEquiv]
+  show polyRingEquiv (polyRingEquiv.symm
+      (((MvPolynomial.finSuccEquiv R n)).symm
+        (Polynomial.C (polyRingEquiv x)))) =
+    (MvPolynomial.rename Fin.succ) (fromCMvPolynomial x)
+  rw [polyRingEquiv.apply_symm_apply]
+  change (MvPolynomial.finSuccEquiv R n).symm
+      (Polynomial.C (fromCMvPolynomial x)) =
+    (MvPolynomial.rename Fin.succ) (fromCMvPolynomial x)
+  generalize fromCMvPolynomial x = p
+  apply (MvPolynomial.finSuccEquiv R n).injective
+  rw [AlgEquiv.apply_symm_apply]
+  induction p using MvPolynomial.induction_on with
+  | C r =>
+    simp [MvPolynomial.finSuccEquiv_apply, MvPolynomial.eval₂Hom_C]
+  | add p q hp hq => simp only [_root_.map_add, hp, hq]
+  | mul_X p i hp =>
+    simp only [_root_.map_mul, MvPolynomial.rename_X, hp,
+               MvPolynomial.finSuccEquiv_X_succ]
+
+end CMvPolynomial
+
+noncomputable def bivariateEquiv :
+    CBivariate R ≃+* CMvPolynomial 2 R :=
   let step1 := CBivariate.ringEquiv
-  let step2 := Polynomial.mapEquiv (Polynomial.mapEquiv CMvPolynomial.isEmptyRingEquiv.symm)
-  let step3 := Polynomial.mapEquiv (CMvPolynomial.finSuccEquiv (n:=0) (R:=R)).symm
-  let step4 := (CMvPolynomial.finSuccEquiv (n:=1) (R:=R)).symm
+  let step2 := Polynomial.mapEquiv
+    (Polynomial.mapEquiv CMvPolynomial.isEmptyRingEquiv.symm)
+  let step3 := Polynomial.mapEquiv
+    (CMvPolynomial.finSuccEquiv (n := 0) (R := R)).symm
+  let step4 :=
+    (CMvPolynomial.finSuccEquiv (n := 1) (R := R)).symm
   step1.trans <| step2.trans <| step3.trans step4
 
 lemma bivariateEquiv_add (p q : CBivariate R) :
-  bivariateEquiv (p + q) = bivariateEquiv p + bivariateEquiv q :=
-    bivariateEquiv.map_add p q
+    bivariateEquiv (p + q) =
+      bivariateEquiv p + bivariateEquiv q :=
+  bivariateEquiv.map_add p q
 
 lemma bivariateEquiv_mul (p q : CBivariate R) :
-  bivariateEquiv (p * q) = bivariateEquiv p *  bivariateEquiv q :=
-    bivariateEquiv.map_mul p q
+    bivariateEquiv (p * q) =
+      bivariateEquiv p * bivariateEquiv q :=
+  bivariateEquiv.map_mul p q
 
-lemma bivariateEquiv_zero : bivariateEquiv (0 : CBivariate R) = 0 :=
+lemma bivariateEquiv_zero :
+    bivariateEquiv (0 : CBivariate R) = 0 :=
   map_zero bivariateEquiv
 
-lemma bivariateEquiv_CC (r : R) : bivariateEquiv (CBivariate.CC r) = CMvPolynomial.C r := by
-  unfold CC
+lemma bivariateEquiv_CC (r : R) :
+    bivariateEquiv (CBivariate.CC r) = CMvPolynomial.C r := by
+  unfold bivariateEquiv
+  simp [ringEquiv, Polynomial.map_C, CC_toPoly,
+        CMvPolynomial.isEmptyRingEquiv_symm_apply,
+        CMvPolynomial.finSuccEquiv_symm_C]

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -5,13 +5,37 @@ Authors: Dimitris Mitsios
 -/
 
 import CompPoly.Bivariate.Basic
+import CompPoly.Bivariate.ToPoly
 import CompPoly.Multivariate.CMvPolynomial
+import CompPoly.Multivariate.MvPolyEquiv.Instances
+import CompPoly.Multivariate.FinSuccEquiv
 
-open CompPoly CPoly
+open CompPoly CPoly CBivariate
 
-variable {R : Type*} [CommSemiring R]
-
-noncomputable def univariateEquiv
+variable {R : Type*}
+variable [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
 
 /- theorem CBivariate_eq_CMvPolynomial {R : Type*}  [CommSemiring R] [BEq R] [LawfulBEq R] : CBivariate R ≃+* CMvPolynomial 2 R := by sorry -/
-noncomputable def bivariateEquiv {R : Type*} [Semiring R] : CBivariate R ≃+* CMvPolynomial 2 R := sorry
+noncomputable def bivariateEquiv : CBivariate R ≃+* CMvPolynomial 2 R :=
+  let step1 := CBivariate.ringEquiv
+  let step2 := Polynomial.mapEquiv (Polynomial.mapEquiv CMvPolynomial.isEmptyRingEquiv.symm)
+  let step3 := Polynomial.mapEquiv (CMvPolynomial.finSuccEquiv (n:=0) (R:=R)).symm
+  let step4 := (CMvPolynomial.finSuccEquiv (n:=1) (R:=R)).symm
+  step1.trans <| step2.trans <| step3.trans step4
+
+lemma bivariateEquiv_add (p q : CBivariate R) :
+  bivariateEquiv (p + q) = bivariateEquiv p + bivariateEquiv q :=
+    bivariateEquiv.map_add p q
+
+lemma bivariateEquiv_mul (p q : CBivariate R) :
+  bivariateEquiv (p * q) = bivariateEquiv p *  bivariateEquiv q :=
+    bivariateEquiv.map_mul p q
+
+lemma bivariateEquiv_zero : bivariateEquiv (0 : CBivariate R) = 0 :=
+  map_zero bivariateEquiv
+
+lemma bivariateEquiv_CC (r : R) : bivariateEquiv (CBivariate.CC r) = CMvPolynomial.C r := by
+  unfold CC
+
+
+#check toPoly

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -53,6 +53,7 @@ variable [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
 
 namespace CMvPolynomial
 
+/-- `isEmptyRingEquiv.symm` maps scalars to constants. -/
 @[simp]
 lemma isEmptyRingEquiv_symm_apply
     {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R] (r : R) :
@@ -61,6 +62,7 @@ lemma isEmptyRingEquiv_symm_apply
   rw [RingEquiv.symm_trans_apply, polyRingEquiv.symm_apply_eq]
   exact (CMvPolynomial.fromCMvPolynomial_C r).symm
 
+/-- `finSuccEquiv.symm` maps `Polynomial.C` to `rename Fin.succ`. -/
 @[simp]
 lemma finSuccEquiv_symm_C
     {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R]
@@ -90,6 +92,7 @@ lemma finSuccEquiv_symm_C
     simp only [_root_.map_mul, MvPolynomial.rename_X, hp,
                MvPolynomial.finSuccEquiv_X_succ]
 
+/-- `finSuccEquiv.symm` maps `Polynomial.X` to the zeroth variable. -/
 @[simp]
 lemma finSuccEquiv_symm_X
     {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R]
@@ -97,19 +100,23 @@ lemma finSuccEquiv_symm_X
     CMvPolynomial.finSuccEquiv.symm
       (Polynomial.X : Polynomial (CMvPolynomial n R)) =
       CMvPolynomial.X 0 := by
-    rw [finSuccEquiv, polyRingEquiv.symm_trans_apply,
-      polyRingEquiv.symm_apply_eq, RingEquiv.symm_trans_apply]
-    simp only [AlgEquiv.toRingEquiv_eq_coe, RingEquiv.symm_symm]
-    rw [polynomialCMvPolyEquiv, Polynomial.mapEquiv_apply, Polynomial.map_X]
-    have h : (MvPolynomial.finSuccEquiv R n).symm Polynomial.X = MvPolynomial.X 0 := by
-      apply (MvPolynomial.finSuccEquiv R n).injective
-      simp [MvPolynomial.finSuccEquiv_X_zero]
-    change (MvPolynomial.finSuccEquiv R n).symm Polynomial.X = polyRingEquiv (CMvPolynomial.X 0)
-    rw [h]
-    exact (fromCMvPolynomial_X (R := R) 0).symm
+  rw [finSuccEquiv, polyRingEquiv.symm_trans_apply,
+    polyRingEquiv.symm_apply_eq, RingEquiv.symm_trans_apply]
+  simp only [AlgEquiv.toRingEquiv_eq_coe, RingEquiv.symm_symm]
+  rw [polynomialCMvPolyEquiv, Polynomial.mapEquiv_apply,
+    Polynomial.map_X]
+  have h : (MvPolynomial.finSuccEquiv R n).symm
+      Polynomial.X = MvPolynomial.X 0 := by
+    apply (MvPolynomial.finSuccEquiv R n).injective
+    simp [MvPolynomial.finSuccEquiv_X_zero]
+  change (MvPolynomial.finSuccEquiv R n).symm
+      Polynomial.X = polyRingEquiv (CMvPolynomial.X 0)
+  rw [h]
+  exact (fromCMvPolynomial_X (R := R) 0).symm
 
 end CMvPolynomial
 
+/-- Ring equivalence between `CBivariate R` and `CMvPolynomial 2 R`. -/
 noncomputable def bivariateEquiv :
     CBivariate R ≃+* CMvPolynomial 2 R :=
   let toPolyEquiv := CBivariate.ringEquiv
@@ -122,20 +129,24 @@ noncomputable def bivariateEquiv :
   toPolyEquiv.trans <|
     embedCoeffs.trans <| foldInner.trans foldOuter
 
+/-- `bivariateEquiv` preserves addition. -/
 lemma bivariateEquiv_add (p q : CBivariate R) :
     bivariateEquiv (p + q) =
       bivariateEquiv p + bivariateEquiv q :=
   bivariateEquiv.map_add p q
 
+/-- `bivariateEquiv` preserves multiplication. -/
 lemma bivariateEquiv_mul (p q : CBivariate R) :
     bivariateEquiv (p * q) =
       bivariateEquiv p * bivariateEquiv q :=
   bivariateEquiv.map_mul p q
 
+/-- `bivariateEquiv` maps zero to zero. -/
 lemma bivariateEquiv_zero :
     bivariateEquiv (0 : CBivariate R) = 0 :=
   map_zero bivariateEquiv
 
+/-- `bivariateEquiv` maps bivariate constants to multivariate constants. -/
 lemma bivariateEquiv_CC (r : R) :
     bivariateEquiv (CBivariate.CC r) = CMvPolynomial.C r := by
   unfold bivariateEquiv
@@ -143,30 +154,35 @@ lemma bivariateEquiv_CC (r : R) :
         CMvPolynomial.isEmptyRingEquiv_symm_apply,
         CMvPolynomial.finSuccEquiv_symm_C]
 
+/-- `bivariateEquiv` maps `CBivariate.X` to the second variable. -/
 lemma bivariateEquiv_X :
     bivariateEquiv (CBivariate.X : CBivariate R) =
       CMvPolynomial.X 1 := by
-      simp [bivariateEquiv, ringEquiv, X_toPoly]
+  simp [bivariateEquiv, ringEquiv, X_toPoly]
 
+/-- `bivariateEquiv` maps `CBivariate.Y` to the first variable. -/
 lemma bivariateEquiv_Y :
     bivariateEquiv (CBivariate.Y : CBivariate R) =
       CMvPolynomial.X 0 := by
-     simp [bivariateEquiv, ringEquiv, Y_toPoly]
+  simp [bivariateEquiv, ringEquiv, Y_toPoly]
 
+/-- `bivariateEquiv.symm` maps multivariate constants to bivariate constants. -/
 lemma bivariateEquiv_symm_C (r : R) :
     bivariateEquiv.symm (CMvPolynomial.C r) =
       CBivariate.CC r := by
-    apply bivariateEquiv.injective
-    simp [bivariateEquiv_CC]
+  apply bivariateEquiv.injective
+  simp [bivariateEquiv_CC]
 
+/-- `bivariateEquiv.symm` maps the first variable to `CBivariate.Y`. -/
 lemma bivariateEquiv_symm_X0 :
     bivariateEquiv.symm (CMvPolynomial.X 0 : CMvPolynomial 2 R) =
       CBivariate.Y := by
-    apply bivariateEquiv.injective
-    simp [bivariateEquiv_Y]
+  apply bivariateEquiv.injective
+  simp [bivariateEquiv_Y]
 
+/-- `bivariateEquiv.symm` maps the second variable to `CBivariate.X`. -/
 lemma bivariateEquiv_symm_X1 :
     bivariateEquiv.symm (CMvPolynomial.X 1 : CMvPolynomial 2 R) =
       CBivariate.X := by
-    apply bivariateEquiv.injective
-    simp [bivariateEquiv_X]
+  apply bivariateEquiv.injective
+  simp [bivariateEquiv_X]

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -9,10 +9,9 @@ import CompPoly.Multivariate.CMvPolynomial
 
 open CompPoly CPoly
 
-variable R
+variable {R : Type*} [CommSemiring R]
 
-#check CPolynomial
-#print CPolynomial
+noncomputable def univariateEquiv
 
 /- theorem CBivariate_eq_CMvPolynomial {R : Type*}  [CommSemiring R] [BEq R] [LawfulBEq R] : CBivariate R ≃+* CMvPolynomial 2 R := by sorry -/
 noncomputable def bivariateEquiv {R : Type*} [Semiring R] : CBivariate R ≃+* CMvPolynomial 2 R := sorry

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -4,6 +4,25 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dimitris Mitsios
 -/
 
+/-!
+# Equivalence between `CBivariate` and `CMvPolynomial 2`
+
+This file establishes the ring equivalence
+`bivariateEquiv : CBivariate R ≃+* CMvPolynomial 2 R`
+by composing `CBivariate.ringEquiv` with `CMvPolynomial.finSuccEquiv`
+and `CMvPolynomial.isEmptyRingEquiv`.
+
+## Main definitions
+
+* `bivariateEquiv` — ring equivalence `CBivariate R ≃+* CMvPolynomial 2 R`
+
+## Helper lemmas
+
+* `CMvPolynomial.isEmptyRingEquiv_symm_apply` — `isEmptyRingEquiv.symm r = C r`
+* `CMvPolynomial.finSuccEquiv_symm_C` —
+  `finSuccEquiv.symm (Polynomial.C x) = rename Fin.succ x`
+-/
+
 import CompPoly.Bivariate.Basic
 import CompPoly.Bivariate.ToPoly
 import CompPoly.Multivariate.CMvPolynomial

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -163,12 +163,14 @@ lemma bivariateEquiv_CC (r : R) :
 lemma bivariateEquiv_X :
     bivariateEquiv (CBivariate.X : CBivariate R) =
       CMvPolynomial.X 1 := by
+  -- `finSuccEquiv_symm_X` is applied here by `simp`
   simp [bivariateEquiv, ringEquiv, X_toPoly]
 
 /-- `bivariateEquiv` maps `CBivariate.Y` to the first variable. -/
 lemma bivariateEquiv_Y :
     bivariateEquiv (CBivariate.Y : CBivariate R) =
       CMvPolynomial.X 0 := by
+  -- `finSuccEquiv_symm_X` is applied here by `simp`
   simp [bivariateEquiv, ringEquiv, Y_toPoly]
 
 /-- `bivariateEquiv.symm` maps multivariate constants to bivariate constants. -/

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -15,6 +15,24 @@ open CompPoly CPoly CBivariate
 variable {R : Type*}
 variable [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
 
+namespace CMvPolynomial
+
+@[simp]
+lemma isEmptyRingEquiv_symm_apply (r : R) :
+  CMvPolynomial.isEmptyRingEquiv.symm r = CMvPolynomial.C r := by
+    unfold CMvPolynomial.isEmptyRingEquiv
+    exact CPoly.polyRingEquiv.symm_apply_eq.mpr (CMvPolynomial.fromCMvPolynomial_C r).symm
+
+
+
+
+#check CPoly.polyRingEquiv.symm_apply_eq.mpr (CMvPolynomial.fromCMvPolynomial_C r).symm
+#check CMvPolynomial.isEmptyRingEquiv
+#check CMvPolynomial.C
+#check CMvPolynomial.fromCMvPolynomial_C
+
+end CMvPolynomial
+
 /- theorem CBivariate_eq_CMvPolynomial {R : Type*}  [CommSemiring R] [BEq R] [LawfulBEq R] : CBivariate R ≃+* CMvPolynomial 2 R := by sorry -/
 noncomputable def bivariateEquiv : CBivariate R ≃+* CMvPolynomial 2 R :=
   let step1 := CBivariate.ringEquiv
@@ -35,7 +53,5 @@ lemma bivariateEquiv_zero : bivariateEquiv (0 : CBivariate R) = 0 :=
   map_zero bivariateEquiv
 
 lemma bivariateEquiv_CC (r : R) : bivariateEquiv (CBivariate.CC r) = CMvPolynomial.C r := by
-  unfold CC
-
-
-#check toPoly
+  unfold bivariateEquiv
+  simp [ringEquiv]

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -27,7 +27,7 @@ The equivalence chain is:
 
 * `bivariateEquiv` — ring equivalence `CBivariate R ≃+* CMvPolynomial 2 R`
 
-## Generator mappings
+## Bridge lemmas
 
 * `bivariateEquiv_CC` — `bivariateEquiv (CC r) = C r`
 * `bivariateEquiv_X` — `bivariateEquiv X = CMvPolynomial.X 1`

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -99,7 +99,7 @@ lemma finSuccEquiv_symm_X
       CMvPolynomial.X 0 := by
   rw [finSuccEquiv, polyRingEquiv.symm_trans_apply,
     polyRingEquiv.symm_apply_eq, RingEquiv.symm_trans_apply]
-  simp only [AlgEquiv.toRingEquiv_eq_coe, RingEquiv.symm_symm]
+  simp only [RingEquiv.symm_symm]
   rw [polynomialCMvPolyEquiv, Polynomial.mapEquiv_apply,
     Polynomial.map_X]
   have h : (MvPolynomial.finSuccEquiv R n).symm
@@ -115,7 +115,7 @@ end CMvPolynomial
 
 namespace CompPoly.CBivariate
 
-open CPoly CompPoly.CBivariate
+open CPoly
 
 variable {R : Type*}
 variable [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -4,6 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dimitris Mitsios
 -/
 
+import CompPoly.Bivariate.Basic
+import CompPoly.Bivariate.ToPoly
+import CompPoly.Multivariate.CMvPolynomial
+import CompPoly.Multivariate.MvPolyEquiv.Instances
+import CompPoly.Multivariate.FinSuccEquiv
+import CompPoly.Multivariate.Rename
+
 /-!
 # Equivalence between `CBivariate` and `CMvPolynomial 2`
 
@@ -18,17 +25,11 @@ and `CMvPolynomial.isEmptyRingEquiv`.
 
 ## Helper lemmas
 
-* `CMvPolynomial.isEmptyRingEquiv_symm_apply` — `isEmptyRingEquiv.symm r = C r`
+* `CMvPolynomial.isEmptyRingEquiv_symm_apply` —
+  `isEmptyRingEquiv.symm r = C r`
 * `CMvPolynomial.finSuccEquiv_symm_C` —
   `finSuccEquiv.symm (Polynomial.C x) = rename Fin.succ x`
 -/
-
-import CompPoly.Bivariate.Basic
-import CompPoly.Bivariate.ToPoly
-import CompPoly.Multivariate.CMvPolynomial
-import CompPoly.Multivariate.MvPolyEquiv.Instances
-import CompPoly.Multivariate.FinSuccEquiv
-import CompPoly.Multivariate.Rename
 
 open CompPoly CPoly CBivariate
 
@@ -74,18 +75,37 @@ lemma finSuccEquiv_symm_C
     simp only [_root_.map_mul, MvPolynomial.rename_X, hp,
                MvPolynomial.finSuccEquiv_X_succ]
 
+@[simp]
+lemma finSuccEquiv_symm_X
+    {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R]
+    {n : ℕ} :
+    CMvPolynomial.finSuccEquiv.symm
+      (Polynomial.X : Polynomial (CMvPolynomial n R)) =
+      CMvPolynomial.X 0 := by
+    rw [finSuccEquiv, polyRingEquiv.symm_trans_apply,
+      polyRingEquiv.symm_apply_eq, RingEquiv.symm_trans_apply]
+    simp only [AlgEquiv.toRingEquiv_eq_coe, RingEquiv.symm_symm]
+    rw [polynomialCMvPolyEquiv, Polynomial.mapEquiv_apply, Polynomial.map_X]
+    have h : (MvPolynomial.finSuccEquiv R n).symm Polynomial.X = MvPolynomial.X 0 := by
+      apply (MvPolynomial.finSuccEquiv R n).injective
+      simp [MvPolynomial.finSuccEquiv_X_zero]
+    change (MvPolynomial.finSuccEquiv R n).symm Polynomial.X = polyRingEquiv (CMvPolynomial.X 0)
+    rw [h]
+    exact (fromCMvPolynomial_X (R := R) 0).symm
+
 end CMvPolynomial
 
 noncomputable def bivariateEquiv :
     CBivariate R ≃+* CMvPolynomial 2 R :=
-  let step1 := CBivariate.ringEquiv
-  let step2 := Polynomial.mapEquiv
+  let toPolyEquiv := CBivariate.ringEquiv
+  let embedCoeffs := Polynomial.mapEquiv
     (Polynomial.mapEquiv CMvPolynomial.isEmptyRingEquiv.symm)
-  let step3 := Polynomial.mapEquiv
+  let foldInner := Polynomial.mapEquiv
     (CMvPolynomial.finSuccEquiv (n := 0) (R := R)).symm
-  let step4 :=
+  let foldOuter :=
     (CMvPolynomial.finSuccEquiv (n := 1) (R := R)).symm
-  step1.trans <| step2.trans <| step3.trans step4
+  toPolyEquiv.trans <|
+    embedCoeffs.trans <| foldInner.trans foldOuter
 
 lemma bivariateEquiv_add (p q : CBivariate R) :
     bivariateEquiv (p + q) =
@@ -107,3 +127,31 @@ lemma bivariateEquiv_CC (r : R) :
   simp [ringEquiv, Polynomial.map_C, CC_toPoly,
         CMvPolynomial.isEmptyRingEquiv_symm_apply,
         CMvPolynomial.finSuccEquiv_symm_C]
+
+lemma bivariateEquiv_X :
+    bivariateEquiv (CBivariate.X : CBivariate R) =
+      CMvPolynomial.X 1 := by
+      simp [bivariateEquiv, ringEquiv, X_toPoly]
+
+lemma bivariateEquiv_Y :
+    bivariateEquiv (CBivariate.Y : CBivariate R) =
+      CMvPolynomial.X 0 := by
+     simp [bivariateEquiv, ringEquiv, Y_toPoly]
+
+lemma bivariateEquiv_symm_C (r : R) :
+    bivariateEquiv.symm (CMvPolynomial.C r) =
+      CBivariate.CC r := by
+    apply bivariateEquiv.injective
+    simp [bivariateEquiv_CC]
+
+lemma bivariateEquiv_symm_X0 :
+    bivariateEquiv.symm (CMvPolynomial.X 0 : CMvPolynomial 2 R) =
+      CBivariate.Y := by
+    apply bivariateEquiv.injective
+    simp [bivariateEquiv_Y]
+
+lemma bivariateEquiv_symm_X1 :
+    bivariateEquiv.symm (CMvPolynomial.X 1 : CMvPolynomial 2 R) =
+      CBivariate.X := by
+    apply bivariateEquiv.injective
+    simp [bivariateEquiv_X]

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -46,12 +46,9 @@ The equivalence chain is:
   `finSuccEquiv.symm Polynomial.X = CMvPolynomial.X 0`
 -/
 
-open CompPoly CPoly CBivariate
-
-variable {R : Type*}
-variable [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-
 namespace CMvPolynomial
+
+open CPoly
 
 /-- `isEmptyRingEquiv.symm` maps scalars to constants. -/
 @[simp]
@@ -115,6 +112,14 @@ lemma finSuccEquiv_symm_X
   exact (fromCMvPolynomial_X (R := R) 0).symm
 
 end CMvPolynomial
+
+namespace CompPoly.CBivariate
+
+open CPoly CompPoly.CBivariate
+
+variable {R : Type*}
+variable [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+  [DecidableEq R]
 
 /-- Ring equivalence between `CBivariate R` and `CMvPolynomial 2 R`. -/
 noncomputable def bivariateEquiv :
@@ -186,3 +191,5 @@ lemma bivariateEquiv_symm_X1 :
       CBivariate.X := by
   apply bivariateEquiv.injective
   simp [bivariateEquiv_X]
+
+end CompPoly.CBivariate

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -23,16 +23,6 @@ lemma isEmptyRingEquiv_symm_apply (r : R) :
     unfold CMvPolynomial.isEmptyRingEquiv
     exact CPoly.polyRingEquiv.symm_apply_eq.mpr (CMvPolynomial.fromCMvPolynomial_C r).symm
 
-
-
-
-#check CPoly.polyRingEquiv.symm_apply_eq.mpr (CMvPolynomial.fromCMvPolynomial_C r).symm
-#check CMvPolynomial.isEmptyRingEquiv
-#check CMvPolynomial.C
-#check CMvPolynomial.fromCMvPolynomial_C
-
-end CMvPolynomial
-
 /- theorem CBivariate_eq_CMvPolynomial {R : Type*}  [CommSemiring R] [BEq R] [LawfulBEq R] : CBivariate R ≃+* CMvPolynomial 2 R := by sorry -/
 noncomputable def bivariateEquiv : CBivariate R ≃+* CMvPolynomial 2 R :=
   let step1 := CBivariate.ringEquiv
@@ -53,5 +43,4 @@ lemma bivariateEquiv_zero : bivariateEquiv (0 : CBivariate R) = 0 :=
   map_zero bivariateEquiv
 
 lemma bivariateEquiv_CC (r : R) : bivariateEquiv (CBivariate.CC r) = CMvPolynomial.C r := by
-  unfold bivariateEquiv
-  simp [ringEquiv]
+  unfold CC

--- a/CompPoly/Bivariate/CMvEquiv.lean
+++ b/CompPoly/Bivariate/CMvEquiv.lean
@@ -19,16 +19,31 @@ This file establishes the ring equivalence
 by composing `CBivariate.ringEquiv` with `CMvPolynomial.finSuccEquiv`
 and `CMvPolynomial.isEmptyRingEquiv`.
 
+The equivalence chain is:
+  `CBivariate R ≃ R[X][Y] ≃ (CMvPolynomial 0 R)[X][Y]
+    ≃ (CMvPolynomial 1 R)[Y] ≃ CMvPolynomial 2 R`
+
 ## Main definitions
 
 * `bivariateEquiv` — ring equivalence `CBivariate R ≃+* CMvPolynomial 2 R`
 
-## Helper lemmas
+## Generator mappings
+
+* `bivariateEquiv_CC` — `bivariateEquiv (CC r) = C r`
+* `bivariateEquiv_X` — `bivariateEquiv X = CMvPolynomial.X 1`
+* `bivariateEquiv_Y` — `bivariateEquiv Y = CMvPolynomial.X 0`
+* `bivariateEquiv_symm_C` — `bivariateEquiv.symm (C r) = CC r`
+* `bivariateEquiv_symm_X0` — `bivariateEquiv.symm (X 0) = Y`
+* `bivariateEquiv_symm_X1` — `bivariateEquiv.symm (X 1) = X`
+
+## Helper lemmas (for `CMvPolynomial.finSuccEquiv`)
 
 * `CMvPolynomial.isEmptyRingEquiv_symm_apply` —
   `isEmptyRingEquiv.symm r = C r`
 * `CMvPolynomial.finSuccEquiv_symm_C` —
   `finSuccEquiv.symm (Polynomial.C x) = rename Fin.succ x`
+* `CMvPolynomial.finSuccEquiv_symm_X` —
+  `finSuccEquiv.symm Polynomial.X = CMvPolynomial.X 0`
 -/
 
 open CompPoly CPoly CBivariate

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,7 +97,7 @@ CompPoly aims to be the premier formally verified library for computable polynom
 7. **Bivariate polynomial operations**
    - Optimize the existing bivariate polynomial type `CPolynomial (CPolynomial R)` and evaluate whether a more specialized representation is beneficial
    - Efficient factorization algorithms for bivariate polynomials
-   - Integration with existing `CMvPolynomial 2 R` with equivalence proofs
+   - ✅ Integration with existing `CMvPolynomial 2 R` with equivalence proofs
 
 7. **Error-correcting interpolation algorithms**
    - Implement Berlekamp-Welch algorithm for Reed-Solomon decoding


### PR DESCRIPTION
This PR adds a `RingEquiv` proof between `CBivariate R` and `CMvPolynomial 2 R` and bridge lemmas. It is part of Phase 2 of the Roadmap on integration with existing `CMvPolynomial 2 R` with equivalence proofs.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>