### PR TITLE
perf(univariate): defer trim to the end of Raw.powBySq

### DIFF
--- a/CompPoly/Univariate/Basic.lean
+++ b/CompPoly/Univariate/Basic.lean
@@ -32,16 +32,21 @@ variable {R : Type*}
   the raw normalization algorithms available separately.
 
   `Raw.mul` defers trimming to the end of its convolution fold (it accumulates with the
-  untrimmed `Raw.mulRaw` and trims once). `CPolynomial.divX` skips trimming entirely:
-  the input is canonical and `extract 1 size` only strips from the front, so the leading
-  coefficient (when present) is preserved and the result is already canonical. The division
-  wrappers (`divByMonic`, `modByMonic`, `modByMonicRemainderOnly`, `modByMonicByReversal`,
-  `div`, `mod`) likewise skip the redundant post-trim: each underlying `Raw` algorithm
-  bottoms out in operations (`Raw.add`, `Raw.sub`, `subScaledShift`) that already trim.
+  untrimmed `Raw.mulRaw` and trims once). `Raw.powBySq` likewise routes through an
+  untrimmed `powBySqUntrimmed` and trims once at the top of the repeated-squaring
+  recursion. `CPolynomial.divX` skips trimming entirely: the input is canonical and
+  `extract 1 size` only strips from the front, so the leading coefficient (when present)
+  is preserved and the result is already canonical. The division wrappers (`divByMonic`,
+  `modByMonic`, `modByMonicRemainderOnly`, `modByMonicByReversal`, `div`, `mod`) likewise
+  skip the redundant post-trim: each underlying `Raw` algorithm bottoms out in operations
+  (`Raw.add`, `Raw.sub`, `subScaledShift`) that already trim.
   Remaining opportunities to trim only at the end of an iterative computation:
-  `Raw.powBySq` (currently trims after every squaring) and the fold-sums in
-  `Univariate/Lagrange.lean` and the NTT `butterflyStage`
-  (`Univariate/NTT/Transform.lean`).
+  the `Finset.prod`/`Finset.sum` folds in `Univariate/Lagrange.lean` (the `basis`
+  product and the `interpolate` sum each pay one `Raw.mul`/`Raw.add` trim per term),
+  the `Array.foldl` accumulator in `Bivariate/ToPoly.lean` (`toPoly_foldl_zipIdx_eq_sum`),
+  and the two `ExtTreeMap.foldl` monomial accumulators in `Multivariate/Operations.lean`.
+  The NTT `butterflyStage` in `Univariate/NTT/Transform.lean` is not on this list: it
+  operates on a scalar coefficient `Array R` and never calls `trim`.
 -/
 def CPolynomial (R : Type*) [Zero R] := { p : CPolynomial.Raw R // IsCanonical p }
 

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -111,21 +111,30 @@ This is the specification; `powBySq` is the efficient O(log n) implementation. -
 def pow [Semiring R] [BEq R] (p : CPolynomial.Raw R) (n : Nat) : CPolynomial.Raw R :=
   (mul p)^[n] (C 1)
 
-/-- Exponentiation via repeated squaring: $ O(\log n) $ multiplications
-instead of $ O(n) $.
+/-- Repeated-squaring core that accumulates with the untrimmed `mulRaw`, deferring
+the canonicalization trim to the outer `powBySq` wrapper. The output may carry
+trailing zeros and is not in canonical form.
 
 For $ n > 0 $, computes $ p ^ n $ by recursing on $ n / 2 $:
 * If $ n $ is even: $ (p ^ {n/2})^2 $
 * If $ n $ is odd:  $ p \cdot (p ^ {n/2})^2 $
 -/
 @[inline, specialize]
-def powBySq [Semiring R] [BEq R] (p : CPolynomial.Raw R) : Nat → CPolynomial.Raw R
+def powBySqUntrimmed [Semiring R] (p : CPolynomial.Raw R) : Nat → CPolynomial.Raw R
   | 0 => C 1
   | n + 1 =>
-    let half := powBySq p ((n + 1) / 2)
-    let sq := mul half half
-    if (n + 1) % 2 = 0 then sq else mul p sq
+    let half := powBySqUntrimmed p ((n + 1) / 2)
+    let sq := mulRaw half half
+    if (n + 1) % 2 = 0 then sq else mulRaw p sq
   decreasing_by omega
+
+/-- Exponentiation via repeated squaring: $ O(\log n) $ multiplications
+instead of $ O(n) $. Delegates to `powBySqUntrimmed` and trims only once
+at the end, rather than after every squaring step.
+-/
+@[inline, specialize]
+def powBySq [Semiring R] [BEq R] (p : CPolynomial.Raw R) (n : Nat) : CPolynomial.Raw R :=
+  (powBySqUntrimmed p n).trim
 
 instance : Zero (CPolynomial.Raw R) := ⟨#[]⟩
 instance [One R] : One (CPolynomial.Raw R) := ⟨C 1⟩

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -1343,18 +1343,61 @@ theorem pow_add (p : CPolynomial.Raw R) (a b : ℕ) :
 omit [LawfulBEq R] [Nontrivial R] in
 private theorem mul_eq_hmul (a b : CPolynomial.Raw R) : a.mul b = a * b := rfl
 
-/-- `powBySq` agrees with `pow` (repeated squaring = repeated multiplication). -/
+omit [Nontrivial R] in
+/-- Multiplication depends only on the coefficient sequences of its inputs,
+so trimming either side preserves the product. -/
+lemma mul_trim_eq_mul (a b : CPolynomial.Raw R) : a.trim * b.trim = a * b := by
+  have hequiv : Trim.equiv (a.trim * b.trim) (a * b) := by
+    intro k
+    rw [mul_coeff, mul_coeff]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [Trim.coeff_eq_coeff, Trim.coeff_eq_coeff]
+  have h := Trim.eq_of_equiv hequiv
+  rw [mul_is_trimmed, mul_is_trimmed] at h
+  exact h
+
+/-- `powBySq` agrees with `pow` (repeated squaring = repeated multiplication).
+
+`powBySq` accumulates intermediate squarings with the untrimmed `mulRaw` and trims
+once at the end, so the proof bridges through `mul_trim_eq_mul` to relate each
+`mulRaw` step back to the spec `pow`. -/
 theorem powBySq_eq_pow (p : CPolynomial.Raw R) : ∀ n : ℕ, powBySq p n = p ^ n
-  | 0 => by unfold powBySq; exact (pow_zero p).symm
+  | 0 => by
+    show (powBySqUntrimmed p 0).trim = p ^ 0
+    unfold powBySqUntrimmed
+    rw [pow_zero]
+    exact Trim.push_trim #[] 1 one_ne_zero
   | n + 1 => by
-    unfold powBySq
-    have ih : powBySq p ((n + 1) / 2) = p ^ ((n + 1) / 2) :=
+    show (powBySqUntrimmed p (n + 1)).trim = p ^ (n + 1)
+    have ih : (powBySqUntrimmed p ((n + 1) / 2)).trim = p ^ ((n + 1) / 2) :=
       powBySq_eq_pow p ((n + 1) / 2)
-    simp only [ih, mul_eq_hmul, ← pow_add]
+    unfold powBySqUntrimmed
+    -- The recursive call also gets unfolded to a `match`; refold it via `ih`
+    -- before resolving the if-branch. We use that `(mulRaw a b).trim = a * b`
+    -- definitionally, then `mul_trim_eq_mul` to swap inputs for their trims.
     by_cases heven : (n + 1) % 2 = 0
     · simp only [heven, ↓reduceIte]
+      -- Goal: (mulRaw (powBySqUntrimmed p ((n+1)/2)) (powBySqUntrimmed p ((n+1)/2))).trim = p^(n+1)
+      -- (mulRaw a b).trim is definitionally `a * b` (def of `mul`).
+      show (powBySqUntrimmed p ((n + 1) / 2)) *
+        (powBySqUntrimmed p ((n + 1) / 2)) = p ^ (n + 1)
+      rw [← mul_trim_eq_mul, ih, ← pow_add]
       congr 1; omega
-    · simp only [heven, ↓reduceIte, ← pow_succ]
+    · simp only [heven, ↓reduceIte]
+      show p * (mulRaw (powBySqUntrimmed p ((n + 1) / 2))
+        (powBySqUntrimmed p ((n + 1) / 2))) = p ^ (n + 1)
+      rw [← mul_trim_eq_mul p (mulRaw _ _)]
+      show p.trim * ((powBySqUntrimmed p ((n + 1) / 2)) *
+        (powBySqUntrimmed p ((n + 1) / 2))) = p ^ (n + 1)
+      rw [← mul_trim_eq_mul (powBySqUntrimmed p ((n + 1) / 2))
+        (powBySqUntrimmed p ((n + 1) / 2)), ih, ← pow_add]
+      -- p.trim * p ^ k = p ^ (k + 1) for the odd case
+      rw [show p.trim * p ^ ((n + 1) / 2 + (n + 1) / 2) =
+            p * p ^ ((n + 1) / 2 + (n + 1) / 2) by
+        conv_lhs => rw [← pow_is_trimmed p ((n + 1) / 2 + (n + 1) / 2)]
+        exact mul_trim_eq_mul _ _]
+      rw [← pow_succ]
       congr 1; omega
 termination_by n => n
 decreasing_by omega


### PR DESCRIPTION
## Summary

- Split out `powBySqUntrimmed`, which mirrors the repeated-squaring recursion but accumulates via the untrimmed `mulRaw`. `powBySq` now delegates to it and trims once at the top.
- Previously `powBySq` invoked the trimming `mul` for every squaring step (and twice per odd step), incurring an `O(size)` trim scan at each level of the log-depth recursion.
- `powBySq_eq_pow` now bridges through a new `mul_trim_eq_mul` lemma showing that polynomial multiplication depends only on the coefficient sequence of its inputs, hence is invariant under trimming either side.

Follows the same trim-deferral pattern as #224 (`Raw.mul`) and #225 (`CPolynomial.divX`). The comment in `CPolynomial/Univariate/Basic.lean` already lists `Raw.powBySq` as a remaining opportunity; this PR closes that item.

## Test plan

- [x] `lake build`
- [x] `lake test`
- [x] `./scripts/lint-style.sh`
- [x] `./scripts/check-imports.sh`
