### PR TITLE
feat(comp-poly): add CMvPolynomial univariate eval-ext and LawfulBEq helper

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -3,6 +3,7 @@ import CompPoly.Bivariate.CMvEquiv
 import CompPoly.Bivariate.ToPoly
 import CompPoly.Data.Array.Lemmas
 import CompPoly.Data.Classes.DCast
+import CompPoly.Data.Classes.LawfulBEq
 import CompPoly.Data.ExtTreeMap.DTreeMap
 import CompPoly.Data.ExtTreeMap.ExtDTreeMap
 import CompPoly.Data.ExtTreeMap.ExtTreeMap

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -94,6 +94,7 @@ import CompPoly.Univariate.BatchEval.Context
 import CompPoly.Univariate.BatchEval.Correctness
 import CompPoly.Univariate.BatchEval.Naive
 import CompPoly.Univariate.BatchEval.SubproductTree
+import CompPoly.Univariate.CMvEquiv
 import CompPoly.Univariate.DivisionCorrectness
 import CompPoly.Univariate.Lagrange
 import CompPoly.Univariate.Linear

--- a/CompPoly/Data/Classes/LawfulBEq.lean
+++ b/CompPoly/Data/Classes/LawfulBEq.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Zitek-Estrada
+-/
+import Mathlib.Init
+
+/-!
+# `LawfulBEq` from `DecidableEq`
+
+A canonical `LawfulBEq` derived from `DecidableEq`, suitable for `letI` use at
+call sites that need to satisfy `BEq`/`LawfulBEq` constraints (for example on
+`CMvPolynomial` API surfaces) from a `DecidableEq`-only context.
+
+This is intentionally *not* registered as an instance: doing so would conflict
+with other `BEq` paths chosen by typeclass synthesis.
+-/
+
+namespace CPoly
+
+/-- A canonical `LawfulBEq` instance derived from `DecidableEq`. Intended for
+`letI` use at call sites that need to satisfy `BEq`/`LawfulBEq` constraints
+from a `DecidableEq`-only context. -/
+@[reducible] def lawfulBEqOfDecidableEq {α : Type*} [DecidableEq α] :
+    @LawfulBEq α (instBEqOfDecidableEq) where
+  rfl := by intro a; simp
+  eq_of_beq := by
+    intro a b h
+    simpa [instBEqOfDecidableEq] using of_decide_eq_true h
+
+end CPoly

--- a/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
+++ b/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
@@ -5,10 +5,7 @@ Authors: Natalia Klaus, Frantisek Silvasi, Derek Sorensen, Andrew Zitek-Estrada
 -/
 import CompPoly.Multivariate.MvPolyEquiv.Eval
 import CompPoly.Multivariate.MvPolyEquiv.Instances
-import CompPoly.Univariate.ToPoly.Impl
-import Mathlib.Algebra.MvPolynomial.Equiv
-import Mathlib.Algebra.MvPolynomial.Polynomial
-import Mathlib.Algebra.Polynomial.Degree.Lemmas
+import CompPoly.Univariate.CMvEquiv
 
 /-!
 # simp/grind lemmas for `CPoly.CMvPolynomial.eval`
@@ -83,107 +80,10 @@ section EvalExtUnivariate
 
 variable {R : Type*}
 
-/-- Bridge a single-variable `MvPolynomial (Fin 1) R` to `Polynomial R` by
-sending the unique variable to `Polynomial.X`. -/
-private noncomputable def toUnivariate [CommSemiring R]
-    (p : MvPolynomial (Fin 1) R) : Polynomial R :=
-  MvPolynomial.eval₂ Polynomial.C (fun _ => Polynomial.X) p
-
-/-- The map `toUnivariate` factors through `finSuccEquiv` and `isEmptyRingEquiv`.
-This is needed to transport degree information from `degreeOf` to `natDegree`. -/
-private lemma toUnivariate_eq_map_finSuccEquiv [CommSemiring R]
-    (p : MvPolynomial (Fin 1) R) :
-    toUnivariate p =
-      Polynomial.map (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom
-        (MvPolynomial.finSuccEquiv R 0 p) := by
-  -- Both sides are ring-homomorphism evaluations of `p`; equate the ring homs
-  -- by `MvPolynomial.ringHom_ext` and then evaluate on generators.
-  have :
-      (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X) :
-          MvPolynomial (Fin 1) R →+* Polynomial R)
-        = (Polynomial.mapRingHom
-            (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom).comp
-            (MvPolynomial.finSuccEquiv R 0).toRingHom := by
-    refine MvPolynomial.ringHom_ext ?_ ?_
-    · intro r
-      simp [MvPolynomial.finSuccEquiv_apply, Polynomial.map_C,
-            MvPolynomial.isEmptyRingEquiv]
-    · intro i
-      have hi : i = 0 := Subsingleton.elim _ _
-      subst hi
-      simp [MvPolynomial.finSuccEquiv_X_zero]
-  exact congrArg (fun f : MvPolynomial (Fin 1) R →+* Polynomial R ↦ f p) this
-
-private lemma toUnivariate_sub [CommRing R]
-    (p q : MvPolynomial (Fin 1) R) :
-    toUnivariate (p - q) = toUnivariate p - toUnivariate q := by
-  change
-    (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X)) (p - q) =
-      (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X)) p -
-        (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X)) q
-  exact RingHom.map_sub _ _ _
-
-/-- `toUnivariate` preserves the (univariate) degree: its `natDegree` matches
-the `degreeOf 0` of the original `MvPolynomial (Fin 1) R`. -/
-private lemma natDegree_toUnivariate [CommSemiring R]
-    (p : MvPolynomial (Fin 1) R) :
-    (toUnivariate p).natDegree = p.degreeOf 0 := by
-  rw [toUnivariate_eq_map_finSuccEquiv]
-  have hmap : (Polynomial.map (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom
-        (MvPolynomial.finSuccEquiv R 0 p)).natDegree =
-      (MvPolynomial.finSuccEquiv R 0 p).natDegree :=
-    Polynomial.natDegree_map_eq_of_injective
-      (MvPolynomial.isEmptyRingEquiv R (Fin 0)).injective _
-  rw [hmap, MvPolynomial.natDegree_finSuccEquiv]
-
-/-- Evaluating `toUnivariate p` at `x : R` agrees with evaluating the
-original `MvPolynomial (Fin 1) R` at the constant assignment `fun _ ↦ x`. -/
-private lemma eval_toUnivariate [CommSemiring R]
-    (p : MvPolynomial (Fin 1) R) (x : R) :
-    (toUnivariate p).eval x = MvPolynomial.eval (fun _ ↦ x) p := by
-  -- `Polynomial.eval x (eval₂ Polynomial.C (fun _ => X) p) = eval (fun _ => x) p`.
-  show Polynomial.eval x
-      (MvPolynomial.eval₂ Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X) p) = _
-  rw [MvPolynomial.polynomial_eval_eval₂]
-  congr 1
-  · ext r; simp
-  · funext _; simp
-
-/-- `toUnivariate` reflects non-zeroness: a non-zero `MvPolynomial (Fin 1) R`
-maps to a non-zero `Polynomial R`. -/
-private lemma toUnivariate_ne_zero [CommSemiring R]
-    {p : MvPolynomial (Fin 1) R} (hp : p ≠ 0) : toUnivariate p ≠ 0 := by
-  intro h
-  apply hp
-  rw [toUnivariate_eq_map_finSuccEquiv] at h
-  have h2 : MvPolynomial.finSuccEquiv R 0 p = 0 :=
-    (Polynomial.map_eq_zero_iff
-      (MvPolynomial.isEmptyRingEquiv R (Fin 0)).injective).mp h
-  exact (MvPolynomial.finSuccEquiv R 0).injective (by simpa using h2)
-
-private noncomputable def toUnivariateCPolynomial
-  [CommSemiring R] [BEq R] [LawfulBEq R]
-    (p : CMvPolynomial 1 R) : CompPoly.CPolynomial R :=
-  ⟨(toUnivariate (fromCMvPolynomial p)).toImpl,
-    CompPoly.CPolynomial.Raw.isCanonical_toImpl _⟩
-
-private lemma toUnivariateCPolynomial_toPoly
-    [CommSemiring R] [BEq R] [LawfulBEq R]
-    (p : CMvPolynomial 1 R) :
-    (toUnivariateCPolynomial p).toPoly = toUnivariate (fromCMvPolynomial p) :=
-  CompPoly.CPolynomial.Raw.toPoly_toImpl
-
-private lemma eval_toUnivariateCPolynomial
-    [CommSemiring R] [BEq R] [LawfulBEq R]
-    (p : CMvPolynomial 1 R) (x : R) :
-    (toUnivariateCPolynomial p).eval x = p.eval (fun _ ↦ x) := by
-  rw [CompPoly.CPolynomial.eval_toPoly, toUnivariateCPolynomial_toPoly,
-    eval_toUnivariate, ← eval_equiv]
-
 /-- **Bridge from univariate eval-extensionality.** Two single-variable
 `CMvPolynomial`s over an integral domain that agree on more than $d$ points
 of a `Finset S` are equal, when $d$ bounds the `degreeOf 0` of their
-difference through the `MvPolynomial` bridge.
+difference through the `CPolynomial.cmvEquiv` bridge.
 
 The hypothesis form matches Schwartz–Zippel usage at call sites: callers
 typically have a degree bound on the difference polynomial, not on `p` and
@@ -196,35 +96,24 @@ theorem CMvPolynomial.eval_ext_univariate
       d < (S.filter
               (fun r ↦ p.eval (fun _ ↦ r) = q.eval (fun _ ↦ r))).card) :
     p = q := by
-  let pUni := toUnivariateCPolynomial p
-  let qUni := toUnivariateCPolynomial q
+  let pUni := (CompPoly.CPolynomial.cmvEquiv (R := R)).symm p
+  let qUni := (CompPoly.CPolynomial.cmvEquiv (R := R)).symm q
   have hdegUni : (pUni - qUni).natDegree ≤ d := by
-    rw [CompPoly.CPolynomial.natDegree_toPoly, CompPoly.CPolynomial.toPoly_sub,
-      toUnivariateCPolynomial_toPoly, toUnivariateCPolynomial_toPoly,
-      ← toUnivariate_sub, natDegree_toUnivariate]
+    rw [show pUni = (CompPoly.CPolynomial.cmvEquiv (R := R)).symm p from rfl,
+      show qUni = (CompPoly.CPolynomial.cmvEquiv (R := R)).symm q from rfl,
+      CompPoly.CPolynomial.natDegree_cmvEquiv_symm_sub]
     exact hdeg
   have hagreeUni :
       d < (S.filter (fun r ↦ pUni.eval r = qUni.eval r)).card := by
     convert hagree using 3
     · ext r
-      rw [show pUni = toUnivariateCPolynomial p from rfl,
-        show qUni = toUnivariateCPolynomial q from rfl,
-        eval_toUnivariateCPolynomial, eval_toUnivariateCPolynomial]
+      rw [show pUni = (CompPoly.CPolynomial.cmvEquiv (R := R)).symm p from rfl,
+        show qUni = (CompPoly.CPolynomial.cmvEquiv (R := R)).symm q from rfl,
+        CompPoly.CPolynomial.eval_cmvEquiv_symm,
+        CompPoly.CPolynomial.eval_cmvEquiv_symm]
   have hUni : pUni = qUni :=
     CompPoly.CPolynomial.eval_ext (p := pUni) (q := qUni) hdegUni hagreeUni
-  rw [eq_iff_fromCMvPolynomial]
-  by_contra hne
-  set r : MvPolynomial (Fin 1) R :=
-    fromCMvPolynomial p - fromCMvPolynomial q with hr
-  have hrne : r ≠ 0 := sub_ne_zero.mpr hne
-  have hto_ne : toUnivariate r ≠ 0 := toUnivariate_ne_zero hrne
-  have hto_zero : toUnivariate r = 0 := by
-    have hpoly := congrArg CompPoly.CPolynomial.toPoly hUni
-    rw [toUnivariateCPolynomial_toPoly, toUnivariateCPolynomial_toPoly] at hpoly
-    have hsub : toUnivariate (fromCMvPolynomial p) -
-        toUnivariate (fromCMvPolynomial q) = 0 := sub_eq_zero.mpr hpoly
-    rwa [← toUnivariate_sub, ← hr] at hsub
-  exact hto_ne hto_zero
+  exact (CompPoly.CPolynomial.cmvEquiv (R := R)).symm.injective hUni
 
 end EvalExtUnivariate
 

--- a/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
+++ b/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
@@ -5,10 +5,10 @@ Authors: Natalia Klaus, Frantisek Silvasi, Derek Sorensen, Andrew Zitek-Estrada
 -/
 import CompPoly.Multivariate.MvPolyEquiv.Eval
 import CompPoly.Multivariate.MvPolyEquiv.Instances
+import CompPoly.Univariate.ToPoly.Impl
 import Mathlib.Algebra.MvPolynomial.Equiv
 import Mathlib.Algebra.MvPolynomial.Polynomial
 import Mathlib.Algebra.Polynomial.Degree.Lemmas
-import Mathlib.Algebra.Polynomial.Roots
 
 /-!
 # simp/grind lemmas for `CPoly.CMvPolynomial.eval`
@@ -99,7 +99,7 @@ private lemma toUnivariate_eq_map_finSuccEquiv [CommSemiring R]
   -- Both sides are ring-homomorphism evaluations of `p`; equate the ring homs
   -- by `MvPolynomial.ringHom_ext` and then evaluate on generators.
   have :
-      (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 => Polynomial.X) :
+      (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X) :
           MvPolynomial (Fin 1) R →+* Polynomial R)
         = (Polynomial.mapRingHom
             (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom).comp
@@ -112,7 +112,16 @@ private lemma toUnivariate_eq_map_finSuccEquiv [CommSemiring R]
       have hi : i = 0 := Subsingleton.elim _ _
       subst hi
       simp [MvPolynomial.finSuccEquiv_X_zero]
-  exact congrArg (fun f : MvPolynomial (Fin 1) R →+* Polynomial R => f p) this
+  exact congrArg (fun f : MvPolynomial (Fin 1) R →+* Polynomial R ↦ f p) this
+
+private lemma toUnivariate_sub [CommRing R]
+    (p q : MvPolynomial (Fin 1) R) :
+    toUnivariate (p - q) = toUnivariate p - toUnivariate q := by
+  change
+    (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X)) (p - q) =
+      (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X)) p -
+        (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X)) q
+  exact RingHom.map_sub _ _ _
 
 /-- `toUnivariate` preserves the (univariate) degree: its `natDegree` matches
 the `degreeOf 0` of the original `MvPolynomial (Fin 1) R`. -/
@@ -131,10 +140,10 @@ private lemma natDegree_toUnivariate [CommSemiring R]
 original `MvPolynomial (Fin 1) R` at the constant assignment `fun _ ↦ x`. -/
 private lemma eval_toUnivariate [CommSemiring R]
     (p : MvPolynomial (Fin 1) R) (x : R) :
-    (toUnivariate p).eval x = MvPolynomial.eval (fun _ => x) p := by
+    (toUnivariate p).eval x = MvPolynomial.eval (fun _ ↦ x) p := by
   -- `Polynomial.eval x (eval₂ Polynomial.C (fun _ => X) p) = eval (fun _ => x) p`.
   show Polynomial.eval x
-      (MvPolynomial.eval₂ Polynomial.C (fun _ : Fin 1 => Polynomial.X) p) = _
+      (MvPolynomial.eval₂ Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X) p) = _
   rw [MvPolynomial.polynomial_eval_eval₂]
   congr 1
   · ext r; simp
@@ -152,13 +161,32 @@ private lemma toUnivariate_ne_zero [CommSemiring R]
       (MvPolynomial.isEmptyRingEquiv R (Fin 0)).injective).mp h
   exact (MvPolynomial.finSuccEquiv R 0).injective (by simpa using h2)
 
-/-- **Univariate eval-extensionality (degree-bounded).** Two single-variable
-`CMvPolynomial`s over an integral domain that agree on more than `d` points
-of a `Finset S` are equal, when `d` bounds the `degreeOf 0` of their
-difference (viewed through the `MvPolynomial` bridge).
+private noncomputable def toUnivariateCPolynomial
+  [CommSemiring R] [BEq R] [LawfulBEq R]
+    (p : CMvPolynomial 1 R) : CompPoly.CPolynomial R :=
+  ⟨(toUnivariate (fromCMvPolynomial p)).toImpl,
+    CompPoly.CPolynomial.Raw.isCanonical_toImpl _⟩
+
+private lemma toUnivariateCPolynomial_toPoly
+    [CommSemiring R] [BEq R] [LawfulBEq R]
+    (p : CMvPolynomial 1 R) :
+    (toUnivariateCPolynomial p).toPoly = toUnivariate (fromCMvPolynomial p) :=
+  CompPoly.CPolynomial.Raw.toPoly_toImpl
+
+private lemma eval_toUnivariateCPolynomial
+    [CommSemiring R] [BEq R] [LawfulBEq R]
+    (p : CMvPolynomial 1 R) (x : R) :
+    (toUnivariateCPolynomial p).eval x = p.eval (fun _ ↦ x) := by
+  rw [CompPoly.CPolynomial.eval_toPoly, toUnivariateCPolynomial_toPoly,
+    eval_toUnivariate, ← eval_equiv]
+
+/-- **Bridge from univariate eval-extensionality.** Two single-variable
+`CMvPolynomial`s over an integral domain that agree on more than $d$ points
+of a `Finset S` are equal, when $d$ bounds the `degreeOf 0` of their
+difference through the `MvPolynomial` bridge.
 
 The hypothesis form matches Schwartz–Zippel usage at call sites: callers
-typically have a degree bound on the *difference* polynomial, not on `p` and
+typically have a degree bound on the difference polynomial, not on `p` and
 `q` individually. -/
 theorem CMvPolynomial.eval_ext_univariate
     [CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [IsDomain R]
@@ -166,43 +194,37 @@ theorem CMvPolynomial.eval_ext_univariate
     (hdeg : (fromCMvPolynomial p - fromCMvPolynomial q).degreeOf 0 ≤ d)
     (hagree :
       d < (S.filter
-              (fun r => p.eval (fun _ => r) = q.eval (fun _ => r))).card) :
+              (fun r ↦ p.eval (fun _ ↦ r) = q.eval (fun _ ↦ r))).card) :
     p = q := by
+  let pUni := toUnivariateCPolynomial p
+  let qUni := toUnivariateCPolynomial q
+  have hdegUni : (pUni - qUni).natDegree ≤ d := by
+    rw [CompPoly.CPolynomial.natDegree_toPoly, CompPoly.CPolynomial.toPoly_sub,
+      toUnivariateCPolynomial_toPoly, toUnivariateCPolynomial_toPoly,
+      ← toUnivariate_sub, natDegree_toUnivariate]
+    exact hdeg
+  have hagreeUni :
+      d < (S.filter (fun r ↦ pUni.eval r = qUni.eval r)).card := by
+    convert hagree using 3
+    · ext r
+      rw [show pUni = toUnivariateCPolynomial p from rfl,
+        show qUni = toUnivariateCPolynomial q from rfl,
+        eval_toUnivariateCPolynomial, eval_toUnivariateCPolynomial]
+  have hUni : pUni = qUni :=
+    CompPoly.CPolynomial.eval_ext (p := pUni) (q := qUni) hdegUni hagreeUni
   rw [eq_iff_fromCMvPolynomial]
   by_contra hne
   set r : MvPolynomial (Fin 1) R :=
     fromCMvPolynomial p - fromCMvPolynomial q with hr
   have hrne : r ≠ 0 := sub_ne_zero.mpr hne
-  -- Bridge to `Polynomial R` and collect facts about the univariate image.
-  let rPoly : Polynomial R := toUnivariate r
-  have hrPolyNe : rPoly ≠ 0 := toUnivariate_ne_zero hrne
-  have hrPolyDeg : rPoly.natDegree ≤ d := by
-    show (toUnivariate r).natDegree ≤ d
-    rw [natDegree_toUnivariate]; exact hdeg
-  -- Build the witnessing `Finset` of zeros of `rPoly` from the agreement set.
-  let T : Finset R :=
-    S.filter (fun x => p.eval (fun _ => x) = q.eval (fun _ => x))
-  have hTcard : d < T.card := hagree
-  have heval_zero : ∀ x ∈ T, rPoly.eval x = 0 := by
-    intro x hx
-    have hxeq : p.eval (fun _ => x) = q.eval (fun _ => x) :=
-      (Finset.mem_filter.mp hx).2
-    show (toUnivariate r).eval x = 0
-    rw [eval_toUnivariate]
-    have hbridge : MvPolynomial.eval (fun _ => x) (fromCMvPolynomial p) =
-           MvPolynomial.eval (fun _ => x) (fromCMvPolynomial q) := by
-      rw [← eval_equiv, ← eval_equiv]; exact hxeq
-    show MvPolynomial.eval (fun _ => x) r = 0
-    have hsub : MvPolynomial.eval (fun _ => x)
-        (fromCMvPolynomial p - fromCMvPolynomial q) =
-        MvPolynomial.eval (fun _ => x) (fromCMvPolynomial p) -
-          MvPolynomial.eval (fun _ => x) (fromCMvPolynomial q) :=
-      RingHom.map_sub _ _ _
-    rw [hr, hsub, hbridge, sub_self]
-  -- Apply the univariate Schwartz–Zippel-style root bound.
-  exact hrPolyNe <|
-    Polynomial.eq_zero_of_natDegree_lt_card_of_eval_eq_zero' rPoly T
-      heval_zero (lt_of_le_of_lt hrPolyDeg hTcard)
+  have hto_ne : toUnivariate r ≠ 0 := toUnivariate_ne_zero hrne
+  have hto_zero : toUnivariate r = 0 := by
+    have hpoly := congrArg CompPoly.CPolynomial.toPoly hUni
+    rw [toUnivariateCPolynomial_toPoly, toUnivariateCPolynomial_toPoly] at hpoly
+    have hsub : toUnivariate (fromCMvPolynomial p) -
+        toUnivariate (fromCMvPolynomial q) = 0 := sub_eq_zero.mpr hpoly
+    rwa [← toUnivariate_sub, ← hr] at hsub
+  exact hto_ne hto_zero
 
 end EvalExtUnivariate
 

--- a/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
+++ b/CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean
@@ -1,15 +1,25 @@
 /-
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Natalia Klaus, Frantisek Silvasi, Derek Sorensen
+Authors: Natalia Klaus, Frantisek Silvasi, Derek Sorensen, Andrew Zitek-Estrada
 -/
 import CompPoly.Multivariate.MvPolyEquiv.Eval
+import CompPoly.Multivariate.MvPolyEquiv.Instances
+import Mathlib.Algebra.MvPolynomial.Equiv
+import Mathlib.Algebra.MvPolynomial.Polynomial
+import Mathlib.Algebra.Polynomial.Degree.Lemmas
+import Mathlib.Algebra.Polynomial.Roots
 
 /-!
 # simp/grind lemmas for `CPoly.CMvPolynomial.eval`
 
 These lemmas are meant to support proof automation (simp/grind normalization)
 when reasoning about polynomial evaluation (e.g. Horner correctness proofs).
+
+The final section provides a degree-bounded eval-extensionality lemma for
+single-variable `CMvPolynomial`s over an integral domain (a Schwartz–Zippel
+style result specialized to one variable), suitable for soundness proofs in
+protocols such as sumcheck.
 -/
 namespace CPoly
 
@@ -66,5 +76,134 @@ end
 
 attribute [grind =]
   eval_zero eval_one eval_C eval_add eval_mul eval_pow eval_neg eval_sub
+
+/-! ### Degree-bounded eval-extensionality (univariate) -/
+
+section EvalExtUnivariate
+
+variable {R : Type*}
+
+/-- Bridge a single-variable `MvPolynomial (Fin 1) R` to `Polynomial R` by
+sending the unique variable to `Polynomial.X`. -/
+private noncomputable def toUnivariate [CommSemiring R]
+    (p : MvPolynomial (Fin 1) R) : Polynomial R :=
+  MvPolynomial.eval₂ Polynomial.C (fun _ => Polynomial.X) p
+
+/-- The map `toUnivariate` factors through `finSuccEquiv` and `isEmptyRingEquiv`.
+This is needed to transport degree information from `degreeOf` to `natDegree`. -/
+private lemma toUnivariate_eq_map_finSuccEquiv [CommSemiring R]
+    (p : MvPolynomial (Fin 1) R) :
+    toUnivariate p =
+      Polynomial.map (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom
+        (MvPolynomial.finSuccEquiv R 0 p) := by
+  -- Both sides are ring-homomorphism evaluations of `p`; equate the ring homs
+  -- by `MvPolynomial.ringHom_ext` and then evaluate on generators.
+  have :
+      (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 => Polynomial.X) :
+          MvPolynomial (Fin 1) R →+* Polynomial R)
+        = (Polynomial.mapRingHom
+            (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom).comp
+            (MvPolynomial.finSuccEquiv R 0).toRingHom := by
+    refine MvPolynomial.ringHom_ext ?_ ?_
+    · intro r
+      simp [MvPolynomial.finSuccEquiv_apply, Polynomial.map_C,
+            MvPolynomial.isEmptyRingEquiv]
+    · intro i
+      have hi : i = 0 := Subsingleton.elim _ _
+      subst hi
+      simp [MvPolynomial.finSuccEquiv_X_zero]
+  exact congrArg (fun f : MvPolynomial (Fin 1) R →+* Polynomial R => f p) this
+
+/-- `toUnivariate` preserves the (univariate) degree: its `natDegree` matches
+the `degreeOf 0` of the original `MvPolynomial (Fin 1) R`. -/
+private lemma natDegree_toUnivariate [CommSemiring R]
+    (p : MvPolynomial (Fin 1) R) :
+    (toUnivariate p).natDegree = p.degreeOf 0 := by
+  rw [toUnivariate_eq_map_finSuccEquiv]
+  have hmap : (Polynomial.map (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom
+        (MvPolynomial.finSuccEquiv R 0 p)).natDegree =
+      (MvPolynomial.finSuccEquiv R 0 p).natDegree :=
+    Polynomial.natDegree_map_eq_of_injective
+      (MvPolynomial.isEmptyRingEquiv R (Fin 0)).injective _
+  rw [hmap, MvPolynomial.natDegree_finSuccEquiv]
+
+/-- Evaluating `toUnivariate p` at `x : R` agrees with evaluating the
+original `MvPolynomial (Fin 1) R` at the constant assignment `fun _ ↦ x`. -/
+private lemma eval_toUnivariate [CommSemiring R]
+    (p : MvPolynomial (Fin 1) R) (x : R) :
+    (toUnivariate p).eval x = MvPolynomial.eval (fun _ => x) p := by
+  -- `Polynomial.eval x (eval₂ Polynomial.C (fun _ => X) p) = eval (fun _ => x) p`.
+  show Polynomial.eval x
+      (MvPolynomial.eval₂ Polynomial.C (fun _ : Fin 1 => Polynomial.X) p) = _
+  rw [MvPolynomial.polynomial_eval_eval₂]
+  congr 1
+  · ext r; simp
+  · funext _; simp
+
+/-- `toUnivariate` reflects non-zeroness: a non-zero `MvPolynomial (Fin 1) R`
+maps to a non-zero `Polynomial R`. -/
+private lemma toUnivariate_ne_zero [CommSemiring R]
+    {p : MvPolynomial (Fin 1) R} (hp : p ≠ 0) : toUnivariate p ≠ 0 := by
+  intro h
+  apply hp
+  rw [toUnivariate_eq_map_finSuccEquiv] at h
+  have h2 : MvPolynomial.finSuccEquiv R 0 p = 0 :=
+    (Polynomial.map_eq_zero_iff
+      (MvPolynomial.isEmptyRingEquiv R (Fin 0)).injective).mp h
+  exact (MvPolynomial.finSuccEquiv R 0).injective (by simpa using h2)
+
+/-- **Univariate eval-extensionality (degree-bounded).** Two single-variable
+`CMvPolynomial`s over an integral domain that agree on more than `d` points
+of a `Finset S` are equal, when `d` bounds the `degreeOf 0` of their
+difference (viewed through the `MvPolynomial` bridge).
+
+The hypothesis form matches Schwartz–Zippel usage at call sites: callers
+typically have a degree bound on the *difference* polynomial, not on `p` and
+`q` individually. -/
+theorem CMvPolynomial.eval_ext_univariate
+    [CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [IsDomain R]
+    {p q : CMvPolynomial 1 R} {d : ℕ} {S : Finset R}
+    (hdeg : (fromCMvPolynomial p - fromCMvPolynomial q).degreeOf 0 ≤ d)
+    (hagree :
+      d < (S.filter
+              (fun r => p.eval (fun _ => r) = q.eval (fun _ => r))).card) :
+    p = q := by
+  rw [eq_iff_fromCMvPolynomial]
+  by_contra hne
+  set r : MvPolynomial (Fin 1) R :=
+    fromCMvPolynomial p - fromCMvPolynomial q with hr
+  have hrne : r ≠ 0 := sub_ne_zero.mpr hne
+  -- Bridge to `Polynomial R` and collect facts about the univariate image.
+  let rPoly : Polynomial R := toUnivariate r
+  have hrPolyNe : rPoly ≠ 0 := toUnivariate_ne_zero hrne
+  have hrPolyDeg : rPoly.natDegree ≤ d := by
+    show (toUnivariate r).natDegree ≤ d
+    rw [natDegree_toUnivariate]; exact hdeg
+  -- Build the witnessing `Finset` of zeros of `rPoly` from the agreement set.
+  let T : Finset R :=
+    S.filter (fun x => p.eval (fun _ => x) = q.eval (fun _ => x))
+  have hTcard : d < T.card := hagree
+  have heval_zero : ∀ x ∈ T, rPoly.eval x = 0 := by
+    intro x hx
+    have hxeq : p.eval (fun _ => x) = q.eval (fun _ => x) :=
+      (Finset.mem_filter.mp hx).2
+    show (toUnivariate r).eval x = 0
+    rw [eval_toUnivariate]
+    have hbridge : MvPolynomial.eval (fun _ => x) (fromCMvPolynomial p) =
+           MvPolynomial.eval (fun _ => x) (fromCMvPolynomial q) := by
+      rw [← eval_equiv, ← eval_equiv]; exact hxeq
+    show MvPolynomial.eval (fun _ => x) r = 0
+    have hsub : MvPolynomial.eval (fun _ => x)
+        (fromCMvPolynomial p - fromCMvPolynomial q) =
+        MvPolynomial.eval (fun _ => x) (fromCMvPolynomial p) -
+          MvPolynomial.eval (fun _ => x) (fromCMvPolynomial q) :=
+      RingHom.map_sub _ _ _
+    rw [hr, hsub, hbridge, sub_self]
+  -- Apply the univariate Schwartz–Zippel-style root bound.
+  exact hrPolyNe <|
+    Polynomial.eq_zero_of_natDegree_lt_card_of_eval_eq_zero' rPoly T
+      heval_zero (lt_of_le_of_lt hrPolyDeg hTcard)
+
+end EvalExtUnivariate
 
 end CPoly

--- a/CompPoly/Univariate/CMvEquiv.lean
+++ b/CompPoly/Univariate/CMvEquiv.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Zitek-Estrada
+-/
+
+import CompPoly.Multivariate.FinSuccEquiv
+import CompPoly.Multivariate.MvPolyEquiv.Eval
+import CompPoly.Univariate.ToPoly.Impl
+import Mathlib.Algebra.MvPolynomial.Polynomial
+import Mathlib.Algebra.Polynomial.Degree.Lemmas
+
+/-!
+# Equivalence between `CPolynomial` and `CMvPolynomial 1`
+
+This file establishes the ring equivalence
+`CPolynomial.cmvEquiv : CPolynomial R ≃+* CMvPolynomial 1 R`.
+
+The equivalence chain is:
+  `CPolynomial R ≃ R[X] ≃ (CMvPolynomial 0 R)[X] ≃ CMvPolynomial 1 R`
+
+The bridge lemmas expose how the inverse equivalence interacts with evaluation
+and degree, so one-variable results proved for `CPolynomial` can be transported
+to callers that still use `CMvPolynomial 1`.
+-/
+
+namespace CompPoly.CPolynomial
+
+open CPoly
+open CMvPolynomial
+
+variable {R : Type*}
+
+/-- Ring equivalence between computable univariate polynomials and
+single-variable computable multivariate polynomials. -/
+noncomputable def cmvEquiv
+    [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R] :
+    CPolynomial R ≃+* CMvPolynomial 1 R :=
+  (ringEquiv (R := R)).trans <|
+    (Polynomial.mapEquiv (CMvPolynomial.isEmptyRingEquiv (R := R))).symm.trans
+      (CMvPolynomial.finSuccEquiv (n := 0) (R := R)).symm
+
+/-- Bridge a single-variable `MvPolynomial (Fin 1) R` to `Polynomial R` by
+sending the unique variable to `Polynomial.X`. -/
+private noncomputable def mvToUnivariate [CommSemiring R]
+    (p : MvPolynomial (Fin 1) R) : Polynomial R :=
+  MvPolynomial.eval₂ Polynomial.C (fun _ ↦ Polynomial.X) p
+
+/-- The `MvPolynomial (Fin 1)` to `Polynomial` bridge factors through
+`finSuccEquiv` and `isEmptyRingEquiv`. -/
+private lemma mvToUnivariate_eq_map_finSuccEquiv [CommSemiring R]
+    (p : MvPolynomial (Fin 1) R) :
+    mvToUnivariate p =
+      Polynomial.map (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom
+        (MvPolynomial.finSuccEquiv R 0 p) := by
+  have :
+      (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X) :
+          MvPolynomial (Fin 1) R →+* Polynomial R)
+        = (Polynomial.mapRingHom
+            (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom).comp
+            (MvPolynomial.finSuccEquiv R 0).toRingHom := by
+    refine MvPolynomial.ringHom_ext ?_ ?_
+    · intro r
+      simp [MvPolynomial.finSuccEquiv_apply, Polynomial.map_C,
+            MvPolynomial.isEmptyRingEquiv]
+    · intro i
+      have hi : i = 0 := Subsingleton.elim _ _
+      subst hi
+      simp [MvPolynomial.finSuccEquiv_X_zero]
+  exact congrArg (fun f : MvPolynomial (Fin 1) R →+* Polynomial R ↦ f p) this
+
+private lemma mvToUnivariate_sub [CommRing R]
+    (p q : MvPolynomial (Fin 1) R) :
+    mvToUnivariate (p - q) = mvToUnivariate p - mvToUnivariate q := by
+  change
+    (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X)) (p - q) =
+      (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X)) p -
+        (MvPolynomial.eval₂Hom Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X)) q
+  exact RingHom.map_sub _ _ _
+
+/-- The `MvPolynomial (Fin 1)` to `Polynomial` bridge preserves univariate
+degree. -/
+private lemma natDegree_mvToUnivariate [CommSemiring R]
+    (p : MvPolynomial (Fin 1) R) :
+    (mvToUnivariate p).natDegree = p.degreeOf 0 := by
+  rw [mvToUnivariate_eq_map_finSuccEquiv]
+  have hmap : (Polynomial.map (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom
+        (MvPolynomial.finSuccEquiv R 0 p)).natDegree =
+      (MvPolynomial.finSuccEquiv R 0 p).natDegree :=
+    Polynomial.natDegree_map_eq_of_injective
+      (MvPolynomial.isEmptyRingEquiv R (Fin 0)).injective _
+  rw [hmap, MvPolynomial.natDegree_finSuccEquiv]
+
+/-- Evaluating the `MvPolynomial (Fin 1)` to `Polynomial` bridge at `x` agrees
+with evaluating the original multivariate polynomial at the constant assignment
+`fun _ ↦ x`. -/
+private lemma eval_mvToUnivariate [CommSemiring R]
+    (p : MvPolynomial (Fin 1) R) (x : R) :
+    (mvToUnivariate p).eval x = MvPolynomial.eval (fun _ ↦ x) p := by
+  show Polynomial.eval x
+      (MvPolynomial.eval₂ Polynomial.C (fun _ : Fin 1 ↦ Polynomial.X) p) = _
+  rw [MvPolynomial.polynomial_eval_eval₂]
+  congr 1
+  · ext r; simp
+  · funext _; simp
+
+private theorem cmvEquiv_symm_toPoly
+    [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (p : CMvPolynomial 1 R) :
+    ((cmvEquiv (R := R)).symm p).toPoly =
+      mvToUnivariate (fromCMvPolynomial p) := by
+  rw [mvToUnivariate_eq_map_finSuccEquiv]
+  change ((ringEquiv (R := R)).symm
+      ((Polynomial.mapEquiv (CMvPolynomial.isEmptyRingEquiv (R := R)))
+        (CMvPolynomial.finSuccEquiv (n := 0) (R := R) p))).toPoly =
+    Polynomial.map (MvPolynomial.isEmptyRingEquiv R (Fin 0)).toRingHom
+      (MvPolynomial.finSuccEquiv R 0 (fromCMvPolynomial p))
+  rw [show ((ringEquiv (R := R)).symm
+      ((Polynomial.mapEquiv (CMvPolynomial.isEmptyRingEquiv (R := R)))
+        (CMvPolynomial.finSuccEquiv (n := 0) (R := R) p))).toPoly =
+      (Polynomial.mapEquiv (CMvPolynomial.isEmptyRingEquiv (R := R)))
+        (CMvPolynomial.finSuccEquiv (n := 0) (R := R) p) from
+    (ringEquiv (R := R)).right_inv _]
+  unfold CMvPolynomial.finSuccEquiv CPoly.polynomialCMvPolyEquiv
+    CMvPolynomial.isEmptyRingEquiv
+  ext n
+  simp [RingEquiv.trans_apply, Polynomial.coeff_map, CPoly.polyRingEquiv, CPoly.polyEquiv]
+
+/-- The inverse of `cmvEquiv` preserves the univariate degree of a
+single-variable `CMvPolynomial`. -/
+theorem natDegree_cmvEquiv_symm
+    [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (p : CMvPolynomial 1 R) :
+    ((cmvEquiv (R := R)).symm p).natDegree =
+      (fromCMvPolynomial p).degreeOf 0 := by
+  rw [natDegree_toPoly, cmvEquiv_symm_toPoly, natDegree_mvToUnivariate]
+
+/-- Evaluation after converting a single-variable `CMvPolynomial` back to
+`CPolynomial` agrees with multivariate evaluation at the constant assignment. -/
+theorem eval_cmvEquiv_symm
+    [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (p : CMvPolynomial 1 R) (x : R) :
+    ((cmvEquiv (R := R)).symm p).eval x = p.eval (fun _ ↦ x) := by
+  rw [eval_toPoly, cmvEquiv_symm_toPoly, eval_mvToUnivariate, ← eval_equiv]
+
+/-- Degree transport for differences through the inverse of `cmvEquiv`. -/
+theorem natDegree_cmvEquiv_symm_sub
+    [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (p q : CMvPolynomial 1 R) :
+    (((cmvEquiv (R := R)).symm p - (cmvEquiv (R := R)).symm q).natDegree) =
+      (fromCMvPolynomial p - fromCMvPolynomial q).degreeOf 0 := by
+  rw [natDegree_toPoly, toPoly_sub, cmvEquiv_symm_toPoly, cmvEquiv_symm_toPoly,
+    ← mvToUnivariate_sub, natDegree_mvToUnivariate]
+
+end CompPoly.CPolynomial

--- a/CompPoly/Univariate/CMvEquiv.lean
+++ b/CompPoly/Univariate/CMvEquiv.lean
@@ -126,15 +126,6 @@ private theorem cmvEquiv_symm_toPoly
   ext n
   simp [RingEquiv.trans_apply, Polynomial.coeff_map, CPoly.polyRingEquiv, CPoly.polyEquiv]
 
-/-- The inverse of `cmvEquiv` preserves the univariate degree of a
-single-variable `CMvPolynomial`. -/
-theorem natDegree_cmvEquiv_symm
-    [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    (p : CMvPolynomial 1 R) :
-    ((cmvEquiv (R := R)).symm p).natDegree =
-      (fromCMvPolynomial p).degreeOf 0 := by
-  rw [natDegree_toPoly, cmvEquiv_symm_toPoly, natDegree_mvToUnivariate]
-
 /-- Evaluation after converting a single-variable `CMvPolynomial` back to
 `CPolynomial` agrees with multivariate evaluation at the constant assignment. -/
 theorem eval_cmvEquiv_symm

--- a/CompPoly/Univariate/ToPoly/Impl.lean
+++ b/CompPoly/Univariate/ToPoly/Impl.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen
 -/
 import CompPoly.Univariate.ToPoly.Equiv
+import Mathlib.Algebra.Polynomial.Roots
 
 /-!
 # Proofs of Correctness for CPolynomial Operations, wrt Mathlib Specs
@@ -219,6 +220,42 @@ theorem eval_mul [CommSemiring R] [BEq R] [LawfulBEq R]
     (p q : CPolynomial R) (x : R) :
     (p * q).eval x = p.eval x * q.eval x := by
   rw [eval_toPoly, toPoly_mul, Polynomial.eval_mul, ← eval_toPoly, ← eval_toPoly]
+
+/-- **Univariate eval-extensionality (degree-bounded).** Two `CPolynomial`s
+over an integral domain that agree on more than $d$ points of a `Finset S` are
+equal, when $d$ bounds the natural degree of their difference.
+
+The degree bound is needed over finite fields, where two distinct polynomials
+may agree on every field element. -/
+theorem eval_ext
+    [CommRing R] [DecidableEq R] [BEq R] [LawfulBEq R] [IsDomain R]
+    {p q : CPolynomial R} {d : ℕ} {S : Finset R}
+    (hdeg : (p - q).natDegree ≤ d)
+    (hagree :
+      d < (S.filter
+              (fun r ↦ p.eval r = q.eval r)).card) :
+    p = q := by
+  by_contra hne
+  let r : CPolynomial R := p - q
+  have hrne : r ≠ 0 := sub_ne_zero.mpr hne
+  have hrPolyNe : r.toPoly ≠ 0 := by
+    intro h
+    exact hrne ((toPoly_eq_zero_iff r).mp h)
+  have hrPolyDeg : r.toPoly.natDegree ≤ d := by
+    rwa [← natDegree_toPoly]
+  let T : Finset R :=
+    S.filter (fun x ↦ p.eval x = q.eval x)
+  have hTcard : d < T.card := hagree
+  have heval_zero : ∀ x ∈ T, r.toPoly.eval x = 0 := by
+    intro x hx
+    have hxeq : p.eval x = q.eval x := (Finset.mem_filter.mp hx).2
+    rw [← eval_toPoly]
+    show r.eval x = 0
+    rw [show r = p - q from rfl, eval_toPoly, toPoly_sub, Polynomial.eval_sub,
+      ← eval_toPoly, ← eval_toPoly, hxeq, sub_self]
+  exact hrPolyNe <|
+    Polynomial.eq_zero_of_natDegree_lt_card_of_eval_eq_zero' r.toPoly T
+      heval_zero (lt_of_le_of_lt hrPolyDeg hTcard)
 
 namespace Raw
 


### PR DESCRIPTION
## What this changes

**`CPoly.lawfulBEqOfDecidableEq`** — new file
`CompPoly/Data/Classes/LawfulBEq.lean`. A `LawfulBEq` derived from
`DecidableEq`, intended for `letI` use at call sites that need to satisfy
`BEq`/`LawfulBEq` constraints (for example on `CMvPolynomial` API surfaces)
from a `DecidableEq`-only context. Deliberately *not* a global `instance`
because that would clash with other `BEq` paths typeclass synthesis already
picks.

**`CPoly.CMvPolynomial.eval_ext_univariate`** — appended to
`CompPoly/Multivariate/CMvPolynomialEvalLemmas.lean`. A degree-bounded
univariate eval-extensionality lemma: two `CMvPolynomial 1 R` over an
integral domain are equal whenever they agree on more than `d` points of
some `Finset S`, where `d` bounds the `degreeOf 0` of their difference
(viewed through the `MvPolynomial` bridge). The signature takes the bound
on the *difference* polynomial (not on `p` and `q` individually) because
that's the shape Schwartz–Zippel callers actually have at hand.

The degree bound is what keeps this sound over finite fields — `x^p` and
`x` over `F_p` agree everywhere but differ, so unconditional eval-ext
would be false there.

## Contrast with previous behavior

Previously, every downstream proof that needed `CMvPolynomial`'s `==` to
behave from a `DecidableEq R`-only context hand-built a local
`LawfulBEq R` in roughly ten lines of `letI` boilerplate. With this PR it
collapses to one line.

Previously, the eval-extensionality chain
`g ≠ h → differencePoly g h ≠ 0 → bounded-many roots` was open-coded
through the `MvPolynomial` bridge over roughly sixty lines in each
downstream caller. With this PR it collapses to a single application.

No existing API changes; only additions.

This code was written with assistance from AI.