### PR TITLE
feat(univariate): add partial extended euclidean algorithm

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -95,6 +95,7 @@ import CompPoly.Univariate.BatchEval.Correctness
 import CompPoly.Univariate.BatchEval.Naive
 import CompPoly.Univariate.BatchEval.SubproductTree
 import CompPoly.Univariate.DivisionCorrectness
+import CompPoly.Univariate.EuclideanAlgorithm
 import CompPoly.Univariate.Lagrange
 import CompPoly.Univariate.Linear
 import CompPoly.Univariate.ManyEval

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -22,7 +22,9 @@ variable {R : Type*}
 
 /-- Extended euclidean algorithm on `p, q`.
 
-Stops when `r = 0`, `r.natDegree < threshold`, or fuel `n` exhausted.
+Stops when `r.natDegree < threshold`, `r = 0`, or fuel `n` exhausted.
+
+If `threshold > 0` then `xgcdAux` will not compute the greatest commmon divisor.
 
 Potential optimization: the raw long division behind `r' / r` already computes
 `r' - (r' / r) * r` but it's not exposed through `CPolynomial R`.
@@ -33,10 +35,10 @@ def xgcdAux [Field R] [BEq R] [LawfulBEq R]
   match n with
   | 0 => (r', s', t')
   | k + 1 =>
-    if r == 0 then
-      (r', s', t')
-    else if r.natDegree < threshold then
+    if r.natDegree < threshold then
       (r, s, t)
+    else if r == 0 then
+      (r', s', t')
     else
       let q := r' / r
       xgcdAux threshold k
@@ -47,7 +49,10 @@ def xgcdAux [Field R] [BEq R] [LawfulBEq R]
 Returns `(r, s, t)` with `r = s * p + t * q`.
 
 With the default `threshold = 0` returns the gcd of `p` and `q`.
-With `threshold > 0` stops when `r.natDegree < threshold`. -/
+With `threshold > 0` stops when `r.natDegree < threshold`.
+
+If `threshold > 0` then `xgcdAux` will not compute the greatest commmon divisor.
+-/
 def xgcd [Field R] [BEq R] [LawfulBEq R]
     (p q : CPolynomial R) (threshold : ℕ := 0) :
     CPolynomial R × CPolynomial R × CPolynomial R :=

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -24,7 +24,7 @@ variable {R : Type*}
 
 Stops when `r.natDegree < threshold`, `r = 0`, or fuel `n` exhausted.
 
-If `threshold > 0` then `xgcdAux` will not compute the greatest commmon divisor.
+If `threshold > 0` then `xgcdAux` need not compute the greatest commmon divisor.
 
 Potential optimization: the raw long division behind `r' / r` already computes
 `r' - (r' / r) * r` but it's not exposed through `CPolynomial R`.
@@ -51,7 +51,7 @@ Returns `(r, s, t)` with `r = s * p + t * q`.
 With the default `threshold = 0` returns the gcd of `p` and `q`.
 With `threshold > 0` stops when `r.natDegree < threshold`.
 
-If `threshold > 0` then `xgcdAux` will not compute the greatest commmon divisor.
+If `threshold > 0` then `xgcdAux` need not compute the greatest commmon divisor.
 -/
 def xgcd [Field R] [BEq R] [LawfulBEq R]
     (p q : CPolynomial R) (threshold : ℕ := 0) :

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -81,3 +81,81 @@ theorem xgcd_bezout [Field R] [BEq R] [LawfulBEq R]
   apply xgcdAux_bezout p q threshold p.val.size
   all_goals (simp only [Bezout]; ring)
 
+/-! # `xgcd` correctness (threshold 0)
+
+Correctness theorems for `xgcd` with the default threshold 0.
+-/
+
+private lemma toPoly_sub_div_mul [Field R] [BEq R] [LawfulBEq R]
+    (r r' a b : CPolynomial R) :
+    (a - (r' / r) * b).toPoly = a.toPoly - (r'.toPoly / r.toPoly) * b.toPoly := by
+  rw [show r' / r = r'.div r from rfl, toPoly_sub, toPoly_mul, div_toPoly_eq_div]
+
+/-- The gcd component of CompPoly's `xgcdAux` at threshold `0` coincides with
+Mathlib's `EuclideanDomain.gcd`. -/
+lemma xgcdAux_toPoly_eq_gcd
+    [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (n : ℕ) (r r' s t s' t' : CPolynomial R)
+    (hn : r.toPoly.degree < n) :
+    (xgcdAux 0 n r s t r' s' t').1.toPoly =
+      EuclideanDomain.gcd r.toPoly r'.toPoly := by
+  induction n generalizing r r' s t s' t' with
+  | zero =>
+    have hr : r = 0 := (toPoly_eq_zero_iff r).mp
+      (Polynomial.degree_eq_bot.mp (Nat.WithBot.lt_zero_iff.mp hn))
+    rw [xgcdAux, hr, toPoly_zero, EuclideanDomain.gcd_zero_left]
+  | succ k ih =>
+    rw [xgcdAux, if_neg (Nat.not_lt_zero _)]
+    by_cases hr : r = 0; simp [hr, toPoly_zero, EuclideanDomain.gcd_zero_left]
+    rw [if_neg (by simpa), ih] <;>
+    rw [toPoly_sub_div_mul, _root_.mul_comm, ←EuclideanDomain.mod_eq_sub_mul_div]
+    · rw [EuclideanDomain.gcd_val r.toPoly r'.toPoly]
+    · have hrtp : r.toPoly ≠ 0 := (toPoly_eq_zero_iff r).not.mpr hr
+      exact lt_of_lt_of_le (Polynomial.degree_mod_lt _ hrtp) (Order.le_of_lt_succ hn)
+
+/-- The gcd component of CompPoly's `xgcd` at threshold `0`
+coincides with Mathlib's `EuclideanDomain.gcd`. -/
+theorem xgcd_toPoly_eq_gcd [Field R] [BEq R] [LawfulBEq R] [DecidableEq R] (p q : CPolynomial R) :
+    (xgcd p q).1.toPoly = EuclideanDomain.gcd p.toPoly q.toPoly := by
+  unfold xgcd; apply xgcdAux_toPoly_eq_gcd
+  rw [←degree_toPoly]; exact mem_degreeLT_iff_size_le.mpr le_rfl
+
+/-- CompPoly's `xgcdAux` at threshold `0` coincides with
+Mathlib's `EuclideanDomain.xgcdAux`. -/
+lemma xgcdAux_toPoly_eq_xgcdAux
+    [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (n : ℕ) (r s t r' s' t' : CPolynomial R)
+    (hn : r.toPoly.degree < n) :
+    Prod.map (·.toPoly) (·.map (·.toPoly) (·.toPoly))
+      (xgcdAux 0 n r s t r' s' t') =
+      EuclideanDomain.xgcdAux r.toPoly s.toPoly t.toPoly r'.toPoly s'.toPoly t'.toPoly := by
+  induction n generalizing r s t r' s' t' with
+  | zero =>
+    have hr : r.toPoly = 0 := Polynomial.degree_eq_bot.mp (Nat.WithBot.lt_zero_iff.mp hn)
+    rw [xgcdAux, hr, EuclideanDomain.xgcd_zero_left]
+    rfl
+  | succ k ih =>
+    rw [xgcdAux, if_neg (Nat.not_lt_zero _)]
+    by_cases hr : r = 0
+    · rw [if_pos (by simpa), hr, toPoly_zero, EuclideanDomain.xgcd_zero_left]
+      rfl
+    · rw [if_neg (by simpa)]
+      have hrtp : r.toPoly ≠ 0 := (toPoly_eq_zero_iff r).not.mpr hr
+      rw [ih, EuclideanDomain.xgcdAux_rec hrtp] <;>
+      rw [toPoly_sub_div_mul, _root_.mul_comm, ←EuclideanDomain.mod_eq_sub_mul_div] <;>
+      try exact lt_of_lt_of_le (Polynomial.degree_mod_lt _ hrtp) (Order.le_of_lt_succ hn)
+      rw [toPoly_sub_div_mul, toPoly_sub_div_mul]
+
+/-- The Bezout component of CompPoly's `xgcd` coincides with
+Mathlib's `EuclideanDomain.xgcd`. -/
+theorem xgcd_toPoly_eq_xgcd
+    [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (p q : CPolynomial R) :
+    (xgcd p q).2.map (·.toPoly) (·.toPoly) =
+      EuclideanDomain.xgcd p.toPoly q.toPoly := by
+  unfold xgcd EuclideanDomain.xgcd
+  have h := xgcdAux_toPoly_eq_xgcdAux p.val.size p 1 0 q 0 1
+    (by rw [←degree_toPoly]; exact mem_degreeLT_iff_size_le.mpr le_rfl)
+  rw [toPoly_one, toPoly_zero] at h
+  exact congrArg Prod.snd h
+

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -52,3 +52,32 @@ def xgcd [Field R] [BEq R] [LawfulBEq R]
   (p q : CPolynomial R) (threshold : ℕ := 0) :
   CPolynomial R × CPolynomial R × CPolynomial R :=
   xgcdAux threshold p.val.size p 1 0 q 0 1
+
+/-! ### Bezout-identity correctness -/
+
+/-- Bezout predicate on a triple `(r, s, t)`: `r = s * p + t * q`. -/
+def Bezout [Semiring R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) :
+  CPolynomial R × CPolynomial R × CPolynomial R → Prop
+  | (r, s, t) => r = s * p + t * q
+
+/-- `xgcdAux` preserves the Bezout identity. -/
+theorem xgcdAux_bezout [Field R] [BEq R] [LawfulBEq R]
+    (p q : CPolynomial R) (threshold n : ℕ)
+    {r r' : CPolynomial R} {s t s' t'}
+    (h : Bezout p q (r, s, t)) (h' : Bezout p q (r', s', t')) :
+    Bezout p q (xgcdAux threshold n r s t r' s' t') := by
+  induction n generalizing r s t r' s' t' with
+  | zero => exact h'
+  | succ k ih =>
+    unfold xgcdAux; split_ifs <;> try assumption
+    apply ih ?_ h; simp only [Bezout] at *
+    rw [h, h']; ring
+
+/-- The output of `xgcd` is a Bezout triple for `(p, q)`. -/
+theorem xgcd_bezout [Field R] [BEq R] [LawfulBEq R]
+    (p q : CPolynomial R) (threshold : ℕ) :
+    Bezout p q (xgcd p q threshold) := by
+  unfold xgcd
+  apply xgcdAux_bezout p q threshold p.val.size
+  all_goals (simp only [Bezout]; ring)
+

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -11,7 +11,7 @@ import CompPoly.Univariate.DivisionCorrectness
 
 `xgcd p q` returns a triple `(r, s, t)` with `r = s * p + t * q`.
 Early stop when `r.natDegree < threshold`.
-The default `threshold = 0` makes `r` the Greatest Common Divisior of `p` and `q`.
+The default `threshold = 0` makes `r` the Greatest Common Divisor of `p` and `q`.
 -/
 
 namespace CompPoly

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -28,8 +28,8 @@ Potential optimization: the raw long division behind `r' / r` already computes
 `r' - (r' / r) * r` but it's not exposed through `CPolynomial R`.
 -/
 def xgcdAux [Field R] [BEq R] [LawfulBEq R]
-  (threshold n : ℕ) (r s t r' s' t' : CPolynomial R) :
-  CPolynomial R × CPolynomial R × CPolynomial R :=
+    (threshold n : ℕ) (r s t r' s' t' : CPolynomial R) :
+    CPolynomial R × CPolynomial R × CPolynomial R :=
   match n with
   | 0 => (r', s', t')
   | k + 1 =>
@@ -49,15 +49,15 @@ Returns `(r, s, t)` with `r = s * p + t * q`.
 With the default `threshold = 0` returns the gcd of `p` and `q`.
 With `threshold > 0` stops when `r.natDegree < threshold`. -/
 def xgcd [Field R] [BEq R] [LawfulBEq R]
-  (p q : CPolynomial R) (threshold : ℕ := 0) :
-  CPolynomial R × CPolynomial R × CPolynomial R :=
+    (p q : CPolynomial R) (threshold : ℕ := 0) :
+    CPolynomial R × CPolynomial R × CPolynomial R :=
   xgcdAux threshold p.val.size p 1 0 q 0 1
 
 /-! ### Bezout-identity correctness -/
 
 /-- Bezout predicate on a triple `(r, s, t)`: `r = s * p + t * q`. -/
 def Bezout [Semiring R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) :
-  CPolynomial R × CPolynomial R × CPolynomial R → Prop
+    CPolynomial R × CPolynomial R × CPolynomial R → Prop
   | (r, s, t) => r = s * p + t * q
 
 /-- `xgcdAux` preserves the Bezout identity. -/

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Conejero
+-/
+import CompPoly.Univariate.Basic
+import CompPoly.Univariate.DivisionCorrectness
+
+/-!
+# Extended Euclidean Algorithm for `CPolynomial`
+
+`xgcd p q` returns a triple `(r, s, t)` with `r = s * p + t * q`.
+Early stop when `r.natDegree < threshold`.
+The default `threshold = 0` makes `r` the Greatest Common Divisior of `p` and `q`.
+-/
+
+namespace CompPoly
+
+namespace CPolynomial
+
+variable {R : Type*}
+
+/-- Extended euclidean algorithm on `p, q`.
+
+Stops when `r = 0`, `r.natDegree < threshold`, or fuel `n` exhausted.
+
+Potential optimization: the raw long division behind `r' / r` already computes
+`r' - (r' / r) * r` but it's not exposed through `CPolynomial R`.
+-/
+def xgcdAux [Field R] [BEq R] [LawfulBEq R]
+  (threshold n : ℕ) (r s t r' s' t' : CPolynomial R) :
+  CPolynomial R × CPolynomial R × CPolynomial R :=
+  match n with
+  | 0 => (r', s', t')
+  | k + 1 =>
+    if r == 0 then
+      (r', s', t')
+    else if r.natDegree < threshold then
+      (r, s, t)
+    else
+      let q := r' / r
+      xgcdAux threshold k
+        (r' - q * r) (s' - q * s) (t' - q * t) r s t
+
+/-- Extended euclidean algorithm for `(p, q)`.
+
+Returns `(r, s, t)` with `r = s * p + t * q`.
+
+With the default `threshold = 0` returns the gcd of `p` and `q`.
+With `threshold > 0` stops when `r.natDegree < threshold`. -/
+def xgcd [Field R] [BEq R] [LawfulBEq R]
+  (p q : CPolynomial R) (threshold : ℕ := 0) :
+  CPolynomial R × CPolynomial R × CPolynomial R :=
+  xgcdAux threshold p.val.size p 1 0 q 0 1

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -159,3 +159,55 @@ theorem xgcd_toPoly_eq_xgcd
   rw [toPoly_one, toPoly_zero] at h
   exact congrArg Prod.snd h
 
+/-! ### Normalized `xgcd` -/
+
+/-- CompPoly's `xgcd p q` scaled by the inverse leading coefficient
+of the gcd component, normalizing it to monic. -/
+def normXgcd [Field R] [BEq R] [LawfulBEq R]
+    (p q : CPolynomial R) (threshold : ℕ := 0) :
+    CPolynomial R × CPolynomial R × CPolynomial R :=
+  let res := xgcd p q threshold
+  let c := res.1.leadingCoeff⁻¹
+  (c • res.1, c • res.2.1, c • res.2.2)
+
+/-- The gcd component of CompPoly's `normXgcd` is the normalization
+of Mathlib's `EuclideanDomain.gcd` -/
+theorem normXgcd_fst_toPoly
+    [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (p q : CPolynomial R) :
+    (normXgcd p q).1.toPoly = normalize (EuclideanDomain.gcd p.toPoly q.toPoly) := by
+  simp only [normXgcd, toPoly_smul, leadingCoeff_toPoly, xgcd_toPoly_eq_gcd]
+  set G := EuclideanDomain.gcd p.toPoly q.toPoly
+  by_cases h : G = 0; simp [h]
+  rw [Polynomial.smul_eq_C_mul, normalize_apply,
+    Polynomial.coe_normUnit_of_ne_zero h, _root_.mul_comm]
+
+/-- The Bezout component of `normXgcd` under `toPoly` is Mathlib's
+`EuclideanDomain.xgcd` scaled by the inverse leading coefficient
+of the gcd -/
+theorem normXgcd_snd_toPoly
+    [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (p q : CPolynomial R) :
+    (normXgcd p q).2.map (·.toPoly) (·.toPoly) =
+      (EuclideanDomain.gcd p.toPoly q.toPoly).leadingCoeff⁻¹ •
+        EuclideanDomain.xgcd p.toPoly q.toPoly := by
+  rw [←xgcd_toPoly_eq_xgcd, ←xgcd_toPoly_eq_gcd, ←leadingCoeff_toPoly]
+  refine Prod.ext ?_ ?_ <;>
+    simp only [normXgcd, Prod.map_fst, Prod.map_snd, Prod.smul_fst, Prod.smul_snd, toPoly_smul]
+
+/-- `normXgcd` is commutative for the gcd component -/
+theorem normXgcd_fst_comm
+    [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (p q : CPolynomial R) :
+    (normXgcd p q).1 = (normXgcd q p).1 := by
+  apply toPolyLinearEquiv.injective
+  show (normXgcd p q).1.toPoly = (normXgcd q p).1.toPoly
+  rw [normXgcd_fst_toPoly, normXgcd_fst_toPoly]
+  open EuclideanDomain in
+  refine normalize_eq_normalize_iff_associated.mpr
+    (associated_of_dvd_dvd ?_ ?_) <;>
+  exact dvd_gcd (gcd_dvd_right ..) (gcd_dvd_left ..)
+
+end CPolynomial
+
+end CompPoly

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -24,7 +24,7 @@ variable {R : Type*}
 
 Stops when `r.natDegree < threshold`, `r = 0`, or fuel `n` exhausted.
 
-If `threshold > 0` then `xgcdAux` need not compute the greatest commmon divisor.
+If `threshold > 0` then `xgcdAux` need not compute the greatest common divisor.
 
 Potential optimization: the raw long division behind `r' / r` already computes
 `r' - (r' / r) * r` but it's not exposed through `CPolynomial R`.
@@ -51,7 +51,7 @@ Returns `(r, s, t)` with `r = s * p + t * q`.
 With the default `threshold = 0` returns the gcd of `p` and `q`.
 With `threshold > 0` stops when `r.natDegree < threshold`.
 
-If `threshold > 0` then `xgcdAux` need not compute the greatest commmon divisor.
+If `threshold > 0` then `xgcdAux` need not compute the greatest common divisor.
 -/
 def xgcd [Field R] [BEq R] [LawfulBEq R]
     (p q : CPolynomial R) (threshold : ℕ := 0) :

--- a/tests/CompPolyTests.lean
+++ b/tests/CompPolyTests.lean
@@ -20,6 +20,7 @@ import CompPolyTests.Multivariate.TypeclassMinimization
 import CompPolyTests.Multivariate.VarsDegrees
 import CompPolyTests.Univariate.Barycentric
 import CompPolyTests.Univariate.Basic
+import CompPolyTests.Univariate.EuclideanAlgorithm
 import CompPolyTests.Univariate.Linear
 import CompPolyTests.Univariate.NTT.FastMul
 import CompPolyTests.Univariate.NTT.Forward

--- a/tests/CompPolyTests/Univariate/EuclideanAlgorithm.lean
+++ b/tests/CompPolyTests/Univariate/EuclideanAlgorithm.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Juan Conejero
+-/
+import CompPoly.Univariate.EuclideanAlgorithm
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Algebra.Field.ZMod
+
+/-!
+# Tests: `xgcd` gcd and partial (threshold) behavior
+
+`#guard` checks over `ZMod 7`. Mathlib's `Polynomial` arithmetic is
+`noncomputable`, so we can't evaluate `EuclideanDomain.gcd` at runtime; the
+expected gcds are hardcoded as `CPolynomial` values and compared with `==`.
+-/
+
+open CompPoly
+
+namespace CompPolyTests
+namespace EuclideanAlgorithmTest
+
+instance : Fact (Nat.Prime 7) := ⟨by decide⟩
+
+abbrev F : Type := ZMod 7
+
+/-! ### Test 1: `gcd(X² - 1, X - 1) = X - 1` -/
+
+private def p₁ : CPolynomial F := CPolynomial.X ^ 2 - 1
+private def q₁ : CPolynomial F := CPolynomial.X - 1
+
+-- `X - 1`, stored as `[6, 1]` since `-1 = 6` in `ZMod 7`.
+private def gcd₁ : CPolynomial F := CPolynomial.X - 1
+
+#guard (CPolynomial.xgcd p₁ q₁ 0).1 == gcd₁
+
+/-! ### Test 2: `gcd((X-1)(X-2), (X-1)(X-3))`, associate of `X - 1`. -/
+
+private def p₂ : CPolynomial F :=
+  (CPolynomial.X - 1) * (CPolynomial.X - CPolynomial.C 2)
+private def q₂ : CPolynomial F :=
+  (CPolynomial.X - 1) * (CPolynomial.X - CPolynomial.C 3)
+
+-- xgcd gives `1 - X`, an associate of `X - 1` (`-1 = 6` is a unit in
+-- `ZMod 7`); stored as `[1, 6]`.
+private def gcd₂ : CPolynomial F := 1 - CPolynomial.X
+
+#guard (CPolynomial.xgcd p₂ q₂ 0).1 == gcd₂
+
+/-! ### Test 3: coprime inputs `X + 1`, `X + 2`. xgcd returns the unit `1`. -/
+
+private def p₃ : CPolynomial F := CPolynomial.X + 1
+private def q₃ : CPolynomial F := CPolynomial.X + CPolynomial.C 2
+
+private def gcd₃ : CPolynomial F := 1
+
+#guard (CPolynomial.xgcd p₃ q₃ 0).1 == gcd₃
+
+/-! ### Bezout-identity sanity checks (`threshold = 0`) -/
+
+#guard
+  let t := CPolynomial.xgcd p₁ q₁ 0
+  t.2.1 * p₁ + t.2.2 * q₁ == t.1
+
+#guard
+  let t := CPolynomial.xgcd p₂ q₂ 0
+  t.2.1 * p₂ + t.2.2 * q₂ == t.1
+
+#guard
+  let t := CPolynomial.xgcd p₃ q₃ 0
+  t.2.1 * p₃ + t.2.2 * q₃ == t.1
+
+/-! ### Threshold behavior (`threshold > 0`) -/
+
+/-! #### Test 4: overshoot to `r = 0` returns the gcd, not `(0, s, t)`.
+
+`gcd(X², X) = X` has degree `1`, not `< threshold = 1`, so the run reaches
+`r = 0` and the `r == 0` branch returns the previous triple, the gcd `X`.
+Regression guard: the old `r.natDegree < threshold`-first ordering returned
+`(0, …)` here, since `natDegree 0 = 0 < 1`. -/
+
+private def p₄ : CPolynomial F := CPolynomial.X ^ 2
+private def q₄ : CPolynomial F := CPolynomial.X
+
+#guard (CPolynomial.xgcd p₄ q₄ 1).1 == CPolynomial.X
+-- Overshoot at `threshold = 1` agrees with the full `threshold = 0` gcd.
+#guard (CPolynomial.xgcd p₄ q₄ 1).1 == (CPolynomial.xgcd p₄ q₄ 0).1
+#guard
+  let t := CPolynomial.xgcd p₄ q₄ 1
+  t.2.1 * p₄ + t.2.2 * q₄ == t.1
+
+/-! #### Test 5: coprime, stops one iteration early via the threshold branch.
+
+At `threshold = 1` the final loop has `r = 1 ≠ 0` with `natDegree 0 < 1`, so
+the threshold branch fires and returns `(1, …)`, one step before the
+`threshold = 0` run reaches `r = 0`. Same triple either way. -/
+
+#guard (CPolynomial.xgcd p₃ q₃ 1).1 == gcd₃
+-- Same triple as the full run.
+#guard CPolynomial.xgcd p₃ q₃ 1 == CPolynomial.xgcd p₃ q₃ 0
+#guard
+  let t := CPolynomial.xgcd p₃ q₃ 1
+  t.2.1 * p₃ + t.2.2 * q₃ == t.1
+
+/-! #### Test 6: genuine truncation, threshold returns a non-gcd remainder.
+
+`X³` and `X² + 1` are coprime (gcd `1`), but `threshold = 2` stops at the
+first remainder of degree `< 2`, the degree-`1` one, not the gcd. The result
+depends on the threshold, and Bezout still holds for the truncated triple. -/
+
+private def p₆ : CPolynomial F := CPolynomial.X ^ 3
+private def q₆ : CPolynomial F := CPolynomial.X ^ 2 + 1
+
+-- Full gcd is the unit.
+#guard (CPolynomial.xgcd p₆ q₆ 0).1 == gcd₃
+-- Partial run stops at a degree-1 remainder (≠ the degree-0 gcd).
+#guard (CPolynomial.xgcd p₆ q₆ 2).1.natDegree == 1
+#guard
+  let t := CPolynomial.xgcd p₆ q₆ 2
+  t.2.1 * p₆ + t.2.2 * q₆ == t.1
+
+end EuclideanAlgorithmTest
+end CompPolyTests

--- a/tests/CompPolyTests/Univariate/EuclideanAlgorithm.lean
+++ b/tests/CompPolyTests/Univariate/EuclideanAlgorithm.lean
@@ -72,19 +72,17 @@ private def gcd₃ : CPolynomial F := 1
 
 /-! ### Threshold behavior (`threshold > 0`) -/
 
-/-! #### Test 4: overshoot to `r = 0` returns the gcd, not `(0, s, t)`.
+/-! #### Test 4: positive `threshold` gives non-gcd output.
 
-`gcd(X², X) = X` has degree `1`, not `< threshold = 1`, so the run reaches
-`r = 0` and the `r == 0` branch returns the previous triple, the gcd `X`.
-Regression guard: the old `r.natDegree < threshold`-first ordering returned
-`(0, …)` here, since `natDegree 0 = 0 < 1`. -/
+`gcd(X², X) = X` has degree `1`, not `< threshold = 1`. This means that with
+`threshold = 0` it returns the actual gcd `X`, but with `threshold = 1` it
+returns `0`. -/
 
 private def p₄ : CPolynomial F := CPolynomial.X ^ 2
 private def q₄ : CPolynomial F := CPolynomial.X
 
-#guard (CPolynomial.xgcd p₄ q₄ 1).1 == CPolynomial.X
--- Overshoot at `threshold = 1` agrees with the full `threshold = 0` gcd.
-#guard (CPolynomial.xgcd p₄ q₄ 1).1 == (CPolynomial.xgcd p₄ q₄ 0).1
+#guard (CPolynomial.xgcd p₄ q₄ 1).1 == 0
+#guard (CPolynomial.xgcd p₄ q₄ 0).1 == CPolynomial.X
 #guard
   let t := CPolynomial.xgcd p₄ q₄ 1
   t.2.1 * p₄ + t.2.2 * q₄ == t.1


### PR DESCRIPTION
This PR adds the partial extended euclidean algorithm for univariate polynomials. In particular:
- Adds `xgcdAux` and `xgcd` such that for any `p`, `q`:
  - They compute a triple `(r, s, t)` such that the Bezout identity `r = s * p + t * q` holds.
  - There's a `threshold` parameter (with default to 0) that makes an early stop when `r.natDegree < threshold`.
  - If `threshold = 0` then `r` is the greatest common divisor or `p` and `q`.
- Adds theorems for the correctness of the Bezout identity (any `threshold`).
- Adds theorems for the correctness of the greatest common divisor (`threshold = 0`).
- Adds `normXgcd`, a normalized version of `xgcd` by the leading coefficient of `xgcd.1`.
- Proves commutativity of `normXgcd`.
- Adds tests for `xgcd` (which we might discuss if we want, given the theorems).