### PR TITLE
feat(bivariate): exact division by a linear factor and monic division over CommRing

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -1,5 +1,7 @@
 import CompPoly.Bivariate.Basic
 import CompPoly.Bivariate.CMvEquiv
+import CompPoly.Bivariate.Factor
+import CompPoly.Bivariate.FactorMonic
 import CompPoly.Bivariate.ToPoly
 import CompPoly.Data.Array.Lemmas
 import CompPoly.Data.Classes.DCast

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -20,13 +20,11 @@ bivariate polynomial by the monic linear factor `Y - f(X)`).
 
 `divByLinearY` is the computable factor theorem for the nested representation
 `CBivariate R = CPolynomial (CPolynomial R)`: given a root `f(X)`, it deflates
-`Q` by `Y - f(X)` over an arbitrary commutative ring (no field required). It is
+`Q` by `Y - f(X)` over an arbitrary commutative ring. It is
 the degree-one special case of monic Euclidean division; division by an
 arbitrary monic divisor in `Y` is available generically through
 `CPolynomial.divByMonic` / `CPolynomial.modByMonic` over the coefficient ring
-`CPolynomial R` (see `CPolynomial.modByMonic_add_mul_divByMonic`). These are
-general-purpose primitives — root deflation, multiplicity, and Euclidean
-reduction all build on them, independently of any particular decoding algorithm.
+`CPolynomial R` (see `CPolynomial.modByMonic_add_mul_divByMonic`).
 -/
 
 namespace CompPoly
@@ -110,21 +108,6 @@ def divByLinearY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     let quotArr : CPolynomial.Raw (CPolynomial R) := coeffs.reverse
     (⟨quotArr.trim, CPolynomial.Raw.Trim.isCanonical_trim quotArr⟩, rem)
 
-/-
-`divByLinearY_spec` is proved coefficient-wise: the remainder formula and the
-quotient recurrence give the value of every coefficient of `toPoly Q` in terms of
-the computed quotient and remainder, and `Polynomial.ext` assembles them (checking
-coefficient `0` and `j + 1` separately). No integral-domain hypothesis is needed.
-
-`divByLinearY_rem_eq_eval` then follows from the spec by evaluating the identity
-`toPoly Q = toPoly quot * (X - C f.toPoly) + C rem.toPoly` at `Y = f.toPoly`: the
-`X - C f.toPoly` factor vanishes, leaving `rem.toPoly = (toPoly Q).eval f.toPoly`.
--/
-
--- `divByLinearY_rem_eq_eval` (the remainder of synthetic division equals evaluation
--- at `f`) is proved further below, directly from `divByLinearY_spec`.
-
--- Step 2–4: main correctness theorem
 theorem divByLinearY_const [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (a f : CPolynomial R) :
   divByLinearY (CPolynomial.C a : CBivariate R) f = (0, a) := by
@@ -524,10 +507,9 @@ theorem divByLinearY_quot_recurrence [CommRing R] [BEq R] [LawfulBEq R]
         CPolynomial.coeff_divX] at h
       simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using h
 
-/-- Correctness of `divByLinearY`: over `R[X][Y]` the computed quotient and
+/-- Correctness of `divByLinearY`: in `R[X][Y]` the computed quotient and
 remainder satisfy the Euclidean division identity
-`Q = quotient · (Y - f) + remainder`. Proved coefficient-wise; no integral-domain
-assumption on `R` is needed. -/
+`Q = quotient · (Y - f) + remainder`, over any commutative ring. -/
 theorem divByLinearY_spec [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     let quot := (divByLinearY Q f).1
@@ -572,10 +554,8 @@ theorem divByLinearY_spec [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [Dec
       simpa using hcoeffS
 
 
-/-- The remainder of dividing `Q` by `Y - f` equals the evaluation `Q(X, f(X))`
-(`evalYPoly f Q`) — the Horner-remainder identity. It falls out of
-`divByLinearY_spec` by evaluating the division identity at `Y = f.toPoly`, where
-the `Y - f` factor vanishes. -/
+/-- The remainder of dividing `Q` by `Y - f` is the substitution `Q(X, f(X))`
+(`evalYPoly f Q`), by the factor/remainder theorem. -/
 theorem divByLinearY_rem_eq_eval [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     (divByLinearY Q f).2 = evalYPoly f Q := by
@@ -590,9 +570,8 @@ theorem divByLinearY_rem_eq_eval [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial 
   intro i
   rw [CPolynomial.coeff_toPoly, CPolynomial.coeff_toPoly, evalYPoly_toPoly, hev]
 
-/-- When `Y - f` actually divides `Q` (i.e. `isLinearYFactor Q f`), the synthetic
-division is exact: the remainder is `0`. Combines `divByLinearY_rem_eq_eval` with
-`isLinearYFactor_iff`. -/
+/-- If `Y - f` divides `Q` (`isLinearYFactor Q f`), the division is exact:
+the remainder is `0`. -/
 theorem divByLinearY_exact [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) (h : isLinearYFactor Q f = true) :
     (divByLinearY Q f).2 = 0 := by

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -121,7 +121,7 @@ theorem divByLinearY_const [CommRing R] [BEq R] [LawfulBEq R]
   simp [hdeg]
   simpa [CPolynomial.coeff] using (CPolynomial.coeff_C (R := CPolynomial R) (r := a) (i := 0))
 
-theorem divByLinearY_fold_split [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divByLinearY_fold_split [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (h : 1 < natDegreeY Q) :
   let n := natDegreeY Q
   let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
@@ -140,7 +140,7 @@ theorem divByLinearY_fold_split [CommRing R] [BEq R] [LawfulBEq R]
   simp only [List.foldl_cons, List.foldl_nil]
   congr <;> omega
 
-theorem divByLinearY_pair_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divByLinearY_pair_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R]
   (Q : CBivariate R) (f : CPolynomial R) (h : 1 < natDegreeY Q) :
   let n := natDegreeY Q
@@ -172,18 +172,18 @@ theorem divByLinearY_pair_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
   dsimp [n, a, step, res1, r1]
   rw [hsplit]
 
-theorem divByLinearY_quot_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divByLinearY_quot_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (h : natDegreeY Q = 1) :
   (divByLinearY Q f).1 = CPolynomial.C (CPolynomial.coeff Q 1) := by
   simp [divByLinearY, h, CPolynomial.C]
   rfl
 
-theorem divByLinearY_quot_of_natDegreeY_zero [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divByLinearY_quot_of_natDegreeY_zero [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (h : natDegreeY Q = 0) :
   (divByLinearY Q f).1 = 0 := by
   simp [divByLinearY, h]
 
-theorem divByLinearY_rem_formula [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divByLinearY_rem_formula [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) :
   let quot := (divByLinearY Q f).1
   let rem := (divByLinearY Q f).2
@@ -226,7 +226,7 @@ theorem divByLinearY_zero [CommRing R] [BEq R] [LawfulBEq R]
   change divByLinearY (⟨#[], CPolynomial.Raw.Trim.isCanonical_empty⟩ : CBivariate R) f = (0, 0)
   simp [divByLinearY, CBivariate.natDegreeY, CPolynomial.natDegree, CPolynomial.coeff]
 
-theorem divX_eq_C_coeff_one_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divX_eq_C_coeff_one_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (h : natDegreeY Q = 1) :
   CPolynomial.divX Q = CPolynomial.C (CPolynomial.coeff Q 1) := by
   apply CPolynomial.eq_iff_coeff.mpr
@@ -248,7 +248,7 @@ theorem divX_eq_C_coeff_one_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R]
         exact (CPolynomial.toPoly_eq_zero_iff (CPolynomial.coeff Q (k + 2))).mp hzero_toPoly
       simpa using hzero
 
-theorem divX_zero_of_natDegreeY_zero [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divX_zero_of_natDegreeY_zero [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (h : natDegreeY Q = 0) :
   CPolynomial.divX Q = 0 := by
   rw [CPolynomial.eq_zero_iff_coeff_zero]
@@ -260,7 +260,7 @@ theorem divX_zero_of_natDegreeY_zero [CommRing R] [BEq R] [LawfulBEq R]
     rw [CBivariate.natDegreeY_toPoly, h]
   exact Polynomial.coeff_eq_zero_of_natDegree_lt (by rw [hdeg]; omega)
 
-theorem natDegreeY_divX_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
+private theorem natDegreeY_divX_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (h : 1 < natDegreeY Q) :
   natDegreeY (CPolynomial.divX Q) = natDegreeY Q - 1 := by
   unfold CBivariate.natDegreeY CPolynomial.natDegree at h ⊢
@@ -274,7 +274,7 @@ theorem natDegreeY_divX_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
       | succ k =>
           simp [CPolynomial.divX, hs, Array.size_extract]
 
-theorem divByLinearY_divX_pair_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divByLinearY_divX_pair_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R]
   (Q : CBivariate R) (f : CPolynomial R) (h : 1 < natDegreeY Q) :
   let n := natDegreeY Q
@@ -356,7 +356,7 @@ theorem divByLinearY_divX_pair_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
     exact congrArg g hfold
   simpa [g, n, a, step, step1, res1, r1] using hpair
 
-theorem raw_trim_reverse_push_coeff_succ [Zero R] [BEq R] [LawfulBEq R]
+private theorem raw_trim_reverse_push_coeff_succ [Zero R] [BEq R] [LawfulBEq R]
     (arr : Array R) (a : R) (j : ℕ) :
   CPolynomial.Raw.coeff (CPolynomial.Raw.trim ((arr.push a).reverse)) (j + 1) =
     CPolynomial.Raw.coeff (CPolynomial.Raw.trim (arr.reverse)) j := by
@@ -368,7 +368,7 @@ theorem raw_trim_reverse_push_coeff_succ [Zero R] [BEq R] [LawfulBEq R]
   rw [Array.getElem?_append_right (xs := #[a]) (ys := arr.reverse) (i := j + 1) h1]
   simp
 
-theorem divByLinearY_divX_quot_coeff [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divByLinearY_divX_quot_coeff [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
   let quot := (divByLinearY Q f).1
   CPolynomial.coeff ((divByLinearY (CPolynomial.divX Q) f).1) j
@@ -434,14 +434,14 @@ theorem divByLinearY_divX_quot_coeff [CommRing R] [BEq R] [LawfulBEq R]
         (raw_trim_reverse_push_coeff_succ (R := CPolynomial R)
           (arr := res1.2) (a := r1) (j := j)).symm
 
-theorem raw_trim_reverse_push_coeff_zero [Zero R] [BEq R] [LawfulBEq R]
+private theorem raw_trim_reverse_push_coeff_zero [Zero R] [BEq R] [LawfulBEq R]
     (arr : Array R) (a : R) :
   CPolynomial.Raw.coeff (CPolynomial.Raw.trim ((arr.push a).reverse)) 0 = a := by
   rw [CPolynomial.Raw.Trim.coeff_eq_coeff]
   rw [Array.reverse_push]
   simp [CPolynomial.Raw.coeff, Array.getD_eq_getD_getElem?]
 
-theorem divByLinearY_divX_rem [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divByLinearY_divX_rem [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) :
   let quot := (divByLinearY Q f).1
   (divByLinearY (CPolynomial.divX Q) f).2 = CPolynomial.coeff quot 0 := by
@@ -487,7 +487,7 @@ theorem divByLinearY_divX_rem [CommRing R] [BEq R] [LawfulBEq R]
       simpa [CPolynomial.coeff] using
         (raw_trim_reverse_push_coeff_zero (arr := res1.2) (a := r1)).symm
 
-theorem divByLinearY_quot_recurrence [CommRing R] [BEq R] [LawfulBEq R]
+private theorem divByLinearY_quot_recurrence [CommRing R] [BEq R] [LawfulBEq R]
     [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
   let quot := (divByLinearY Q f).1
   CPolynomial.coeff quot j = CPolynomial.coeff Q (j + 1) + f * CPolynomial.coeff quot (j + 1) := by

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -24,14 +24,20 @@ namespace CompPoly
 
 namespace CBivariate
 
+/-- Substitute `Y ↦ f(X)` into a bivariate polynomial `Q`, i.e. evaluate `Q` at
+`f` in the `Y` variable. The result is the univariate polynomial `Q(X, f(X))`. -/
 def evalYPoly [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (f : CPolynomial R) (Q : CBivariate R) : CPolynomial R :=
   Q.val.eval f
 
+/-- Decide whether `Y - f(X)` divides `Q`, i.e. whether `Q(X, f(X)) = 0`. By the
+factor theorem this is exactly the divisibility test used in the Roth–Ruckenstein
+root-finding step. -/
 def isLinearYFactor [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) : Bool :=
   evalYPoly f Q == 0
 
+/-- `evalYPoly` sends the zero polynomial to `0`. -/
 theorem evalYPoly_zero [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (f : CPolynomial R) :
     evalYPoly f (0 : CBivariate R) = 0 := by
@@ -40,6 +46,7 @@ theorem evalYPoly_zero [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
   rw [h, ← CPolynomial.Raw.eval_toPoly_eq_eval f (0 : CPolynomial.Raw (CPolynomial R)),
     CPolynomial.Raw.toPoly_zero, Polynomial.eval_zero]
 
+/-- `evalYPoly` is additive in the polynomial being evaluated. -/
 theorem evalYPoly_add [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (f : CPolynomial R) (P Q : CBivariate R) :
     evalYPoly f (P + Q) = evalYPoly f P + evalYPoly f Q := by
@@ -50,11 +57,14 @@ theorem evalYPoly_add [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     ← CPolynomial.Raw.eval_toPoly_eq_eval f Q.val,
     CPolynomial.Raw.toPoly_add, Polynomial.eval_add]
 
+/-- The `isLinearYFactor` boolean test agrees with the proposition `Q(X, f(X)) = 0`. -/
 theorem isLinearYFactor_iff [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     isLinearYFactor Q f = true ↔ evalYPoly f Q = 0 := by
   simp [isLinearYFactor, beq_iff_eq]
 
+/-- Bridge to Mathlib: evaluating `Q` at `f` and mapping to `Polynomial R` agrees
+with evaluating the mapped `toPoly Q : R[X][Y]` at `f.toPoly`. -/
 theorem evalYPoly_toPoly [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (f : CPolynomial R) (Q : CBivariate R) :
     (evalYPoly f Q).toPoly = (toPoly Q).eval (f.toPoly) := by
@@ -68,6 +78,14 @@ theorem evalYPoly_toPoly [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [Deci
   rw [Polynomial.hom_eval₂, RingHom.comp_id]
   rfl
 
+/-- Synthetic (Horner) division of a bivariate polynomial `Q` by the linear factor
+`Y - f(X)`, performed in the `Y` variable. Returns the pair `(quotient, remainder)`
+where the quotient is a `CBivariate R` and the remainder is a `CPolynomial R`.
+
+Writing `Q = Σ_{j=0}^n aⱼ Yʲ` with `aⱼ = coeff Q j`, the quotient coefficients
+`bⱼ` and the remainder `r` satisfy the synthetic-division recurrence
+`b_{n-1} = aₙ`, `b_{j-1} = aⱼ + f · bⱼ`, `r = a₀ + f · b₀`, so that
+`Q = quotient · (Y - f) + r`. See `divByLinearY_spec`. -/
 def divByLinearY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (Q : CBivariate R) (f : CPolynomial R) : CBivariate R × CPolynomial R :=
   let n := natDegreeY Q
@@ -498,6 +516,10 @@ theorem divByLinearY_quot_recurrence [CommRing R] [BEq R] [LawfulBEq R]
         CPolynomial.coeff_divX] at h
       simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using h
 
+/-- Correctness of `divByLinearY`: over `R[X][Y]` the computed quotient and
+remainder satisfy the Euclidean division identity
+`Q = quotient · (Y - f) + remainder`. Proved coefficient-wise; no integral-domain
+assumption on `R` is needed. -/
 theorem divByLinearY_spec [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     let quot := (divByLinearY Q f).1
@@ -542,9 +564,10 @@ theorem divByLinearY_spec [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [Dec
       simpa using hcoeffS
 
 
--- The remainder of synthetic division equals the evaluation `evalYPoly f Q`.
--- This is the Horner-remainder identity; it falls out of `divByLinearY_spec` by
--- evaluating the division identity at `Y = f.toPoly`.
+/-- The remainder of dividing `Q` by `Y - f` equals the evaluation `Q(X, f(X))`
+(`evalYPoly f Q`) — the Horner-remainder identity. It falls out of
+`divByLinearY_spec` by evaluating the division identity at `Y = f.toPoly`, where
+the `Y - f` factor vanishes. -/
 theorem divByLinearY_rem_eq_eval [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     (divByLinearY Q f).2 = evalYPoly f Q := by
@@ -559,8 +582,9 @@ theorem divByLinearY_rem_eq_eval [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial 
   intro i
   rw [CPolynomial.coeff_toPoly, CPolynomial.coeff_toPoly, evalYPoly_toPoly, hev]
 
--- Follows from divByLinearY_rem_eq_eval + isLinearYFactor_iff:
--- isLinearYFactor Q f = true ↔ evalYPoly f Q = 0, and rem = evalYPoly f Q
+/-- When `Y - f` actually divides `Q` (i.e. `isLinearYFactor Q f`), the synthetic
+division is exact: the remainder is `0`. Combines `divByLinearY_rem_eq_eval` with
+`isLinearYFactor_iff`. -/
 theorem divByLinearY_exact [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) (h : isLinearYFactor Q f = true) :
     (divByLinearY Q f).2 = 0 := by

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2025 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+
+import CompPoly.Bivariate.Basic
+import CompPoly.Bivariate.ToPoly
+
+/-!
+# Factorisation of Computable Bivariate Polynomials
+
+Defines `evalYPoly` (substitute Y ↦ f(X)), `isLinearYFactor` (check
+divisibility by Y - f(X)), and `divByLinearY` (synthetic division in Y).
+These operations support the Roth-Ruckenstein root-finding step in
+Guruswami–Sudan interpolation.
+-/
+
+namespace CompPoly
+
+namespace CBivariate
+
+def evalYPoly [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+  (f : CPolynomial R) (Q : CBivariate R) : CPolynomial R :=
+  Q.val.eval f
+
+def isLinearYFactor [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) : Bool :=
+  evalYPoly f Q == 0
+
+theorem evalYPoly_zero [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (f : CPolynomial R) :
+    evalYPoly f (0 : CBivariate R) = 0 := by
+  show (0 : CBivariate R).val.eval f = 0
+  have h : (0 : CBivariate R).val = (0 : CPolynomial.Raw (CPolynomial R)) := rfl
+  rw [h, ← CPolynomial.Raw.eval_toPoly_eq_eval f (0 : CPolynomial.Raw (CPolynomial R)),
+    CPolynomial.Raw.toPoly_zero, Polynomial.eval_zero]
+
+theorem evalYPoly_add [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (f : CPolynomial R) (P Q : CBivariate R) :
+    evalYPoly f (P + Q) = evalYPoly f P + evalYPoly f Q := by
+  show (P + Q).val.eval f = P.val.eval f + Q.val.eval f
+  have h : (P + Q).val = P.val + Q.val := rfl
+  rw [h, ← CPolynomial.Raw.eval_toPoly_eq_eval f (P.val + Q.val),
+    ← CPolynomial.Raw.eval_toPoly_eq_eval f P.val,
+    ← CPolynomial.Raw.eval_toPoly_eq_eval f Q.val,
+    CPolynomial.Raw.toPoly_add, Polynomial.eval_add]
+
+theorem isLinearYFactor_iff [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    isLinearYFactor Q f = true ↔ evalYPoly f Q = 0 := by
+  simp [isLinearYFactor, beq_iff_eq]
+
+theorem evalYPoly_toPoly [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (f : CPolynomial R) (Q : CBivariate R) :
+    (evalYPoly f Q).toPoly = (toPoly Q).eval (f.toPoly) := by
+  show (Q.val.eval f).toPoly = (toPoly Q).eval (f.toPoly)
+  rw [← CPolynomial.Raw.eval_toPoly_eq_eval f Q.val]
+  rw [toPoly_eq_map, Polynomial.eval_map]
+  change (CPolynomial.ringEquiv (R := R)).toRingHom ((CPolynomial.toPoly Q).eval f) =
+    (CPolynomial.toPoly Q).eval₂ (CPolynomial.ringEquiv (R := R)).toRingHom (f.toPoly)
+  rw [show Polynomial.eval f (CPolynomial.toPoly Q) =
+    (CPolynomial.toPoly Q).eval₂ (RingHom.id _) f from rfl]
+  rw [Polynomial.hom_eval₂, RingHom.comp_id]
+  rfl
+
+def divByLinearY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (Q : CBivariate R) (f : CPolynomial R) : CBivariate R × CPolynomial R :=
+  let n := natDegreeY Q
+  if n = 0 then (0, CPolynomial.coeff Q 0)
+  else
+    let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
+    let b_init := a n
+    let (b_last, coeffs) := (List.range (n - 1)).foldl
+      (fun (b, acc) k =>
+        let bj := a (n - 1 - k) + f * b
+        (bj, acc.push bj))
+      (b_init, #[b_init])
+    let rem := a 0 + f * b_last
+    let quotArr : CPolynomial.Raw (CPolynomial R) := coeffs.reverse
+    (⟨quotArr.trim, CPolynomial.Raw.Trim.isCanonical_trim quotArr⟩, rem)
+
+end CBivariate
+
+end CompPoly

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -7,6 +7,10 @@ Authors: Dimitris Mitsios
 import CompPoly.Bivariate.Basic
 import CompPoly.Bivariate.ToPoly
 
+import Mathlib.Data.List.GetD
+import Mathlib.Data.List.Range
+import Mathlib.Algebra.Polynomial.Coeff
+import Mathlib.Algebra.Polynomial.Degree.Operations
 /-!
 # Factorisation of Computable Bivariate Polynomials
 
@@ -21,7 +25,7 @@ namespace CompPoly
 namespace CBivariate
 
 def evalYPoly [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
-  (f : CPolynomial R) (Q : CBivariate R) : CPolynomial R :=
+    (f : CPolynomial R) (Q : CBivariate R) : CPolynomial R :=
   Q.val.eval f
 
 def isLinearYFactor [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
@@ -81,291 +85,100 @@ def divByLinearY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (⟨quotArr.trim, CPolynomial.Raw.Trim.isCanonical_trim quotArr⟩, rem)
 
 /-
-Proof strategy for divByLinearY_spec (approach A — via Mathlib division theorem):
+`divByLinearY_spec` is proved coefficient-wise: the remainder formula and the
+quotient recurrence give the value of every coefficient of `toPoly Q` in terms of
+the computed quotient and remainder, and `Polynomial.ext` assembles them (checking
+coefficient `0` and `j + 1` separately). No integral-domain hypothesis is needed.
 
-Step 1: Prove `divByLinearY_rem_eq_eval`: the remainder of synthetic division
-equals `evalYPoly f Q`. Both compute Σ aⱼ fʲ (Horner's method = synthetic
-division remainder). This is an induction on the fold, showing the running
-accumulator `b` satisfies `b = Σ_{j≥k} a_j * f^{j-k}` after processing
-coefficient k.
-
-Step 2: Combine `divByLinearY_rem_eq_eval` with `evalYPoly_toPoly` to get
-  `rem.toPoly = (toPoly Q).eval (f.toPoly)`
-which is also
-  `rem.toPoly = ((toPoly Q) %ₘ (X - C f.toPoly)).coeff 0`  (by modByMonic_X_sub_C_eq_C_eval)
-
-Step 3: Use Mathlib's `modByMonic_add_div` to get
-  `toPoly Q = (X - C f.toPoly) * ((toPoly Q) /ₘ (X - C f.toPoly)) + C ((toPoly Q).eval f.toPoly)`
-
-Step 4: Subtract our decomposition from the Mathlib decomposition. This gives
-  `(toPoly quot - (toPoly Q) /ₘ (X - C f.toPoly)) * (X - C f.toPoly) = 0`
-Since `X - C f.toPoly` is monic (hence nonzero), and `R[X]` is an integral
-domain (assuming `IsDomain R`), the other factor is zero, proving
-  `toPoly quot = (toPoly Q) /ₘ (X - C f.toPoly)`
-and thus the spec.
-
-Note: Step 4 uses `IsDomain R` (or `IsDomain R[X]`). If we want to avoid that,
-the alternative is to show `degree (toPoly quot) < degree (X - C f.toPoly)` is
-impossible, so the factor must be zero by Mathlib's uniqueness of divByMonic.
-Alternatively, use `Polynomial.eq_of_dvd_of_degree_le_of_leadingCoeff` or
-`divByMonic_eq_of_lt_and_lt` if available.
+`divByLinearY_rem_eq_eval` then follows from the spec by evaluating the identity
+`toPoly Q = toPoly quot * (X - C f.toPoly) + C rem.toPoly` at `Y = f.toPoly`: the
+`X - C f.toPoly` factor vanishes, leaving `rem.toPoly = (toPoly Q).eval f.toPoly`.
 -/
 
--- Helper: fold on Q aligns with fold on divX Q via coeff_divX
-theorem divByLinearY_prefix_fold_eq_divX_fold [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    (Q : CBivariate R) (f : CPolynomial R) (k : ℕ) :
-    List.foldl
-      (fun x k_1 =>
-        (CPolynomial.coeff Q (k + 1 - k_1) + f * x.1,
-          x.2.push (CPolynomial.coeff Q (k + 1 - k_1) + f * x.1)))
-      (CPolynomial.coeff Q (k + 2), #[CPolynomial.coeff Q (k + 2)])
-      (List.range k) =
-    List.foldl
-      (fun x k_1 =>
-        ((CPolynomial.divX Q).coeff (k - k_1) + f * x.1,
-          x.2.push ((CPolynomial.divX Q).coeff (k - k_1) + f * x.1)))
-      ((CPolynomial.divX Q).coeff (k + 1), #[(CPolynomial.divX Q).coeff (k + 1)])
-      (List.range k) := by
-  rw [show (CPolynomial.coeff Q (k + 2), #[CPolynomial.coeff Q (k + 2)]) =
-      ((CPolynomial.divX Q).coeff (k + 1), #[(CPolynomial.divX Q).coeff (k + 1)]) by
-    simpa using congrArg (fun c => (c, #[c]))
-      ((CPolynomial.coeff_divX (p := Q) (i := k + 1)).symm)]
-  apply List.foldl_ext
-  intro a i hi
-  rcases a with ⟨b, acc⟩
-  have hi' : i < k := List.mem_range.mp hi
-  have hidx : k + 1 - i = (k - i) + 1 := by omega
-  simpa [hidx] using congrArg (fun c => (c + f * b, acc.push (c + f * b)))
-    ((CPolynomial.coeff_divX (p := Q) (i := k - i)).symm)
+-- `divByLinearY_rem_eq_eval` (the remainder of synthetic division equals evaluation
+-- at `f`) is proved further below, directly from `divByLinearY_spec`.
 
--- Helper: Horner step for evalYPoly via divX
-theorem evalYPoly_divX_step [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    (Q : CBivariate R) (f : CPolynomial R) :
-    evalYPoly f Q = CPolynomial.coeff Q 0 + f * evalYPoly f (CPolynomial.divX Q) := by
-  change CPolynomial.eval f Q =
-    CPolynomial.coeff Q 0 + f * CPolynomial.eval f (CPolynomial.divX Q)
-  conv_lhs => rw [CPolynomial.X_mul_divX_add (p := Q)]
-  rw [CPolynomial.eval_toPoly, CPolynomial.toPoly_add, Polynomial.eval_add]
-  rw [CPolynomial.toPoly_mul, Polynomial.eval_mul]
-  rw [CPolynomial.X_toPoly, Polynomial.eval_X]
-  rw [CPolynomial.C_toPoly, Polynomial.eval_C]
-  rw [← CPolynomial.eval_toPoly (x := f) (p := CPolynomial.divX Q)]
-  rw [add_comm]
-
--- Helper: natDegreeY decreases under divX
-theorem natDegreeY_divX [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    (Q : CBivariate R) :
-    natDegreeY (CPolynomial.divX Q) = natDegreeY Q - 1 := by
-  show CPolynomial.natDegree (CPolynomial.divX Q) = CPolynomial.natDegree Q - 1
-  rw [CPolynomial.natDegree_toPoly (p := CPolynomial.divX Q)]
-  rw [CPolynomial.divX_toPoly (p := Q)]
-  rw [Polynomial.natDegree_divX_eq_natDegree_tsub_one]
-  rw [← CPolynomial.natDegree_toPoly (p := Q)]
-
--- Helper: remainder recursion via divX
-theorem divByLinearY_rem_recursion [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    (Q : CBivariate R) (f : CPolynomial R) (hQ : natDegreeY Q ≠ 0) :
-    (divByLinearY Q f).2 =
-      CPolynomial.coeff Q 0 + f * (divByLinearY (CPolynomial.divX Q) f).2 := by
-  cases hdeg : natDegreeY Q with
-  | zero => exact (hQ hdeg).elim
-  | succ m =>
-    cases m with
-    | zero =>
-      have hdivdeg : natDegreeY (CPolynomial.divX Q) = 0 := by
-        simpa [hdeg] using (natDegreeY_divX (Q := Q))
-      rw [divByLinearY, hdeg, if_neg (Nat.succ_ne_zero 0)]
-      conv_rhs => rw [divByLinearY, hdivdeg, if_pos rfl]
-      change CPolynomial.coeff Q 0 + f * CPolynomial.coeff Q 1 =
-        CPolynomial.coeff Q 0 + f * CPolynomial.coeff (CPolynomial.divX Q) 0
-      rw [CPolynomial.coeff_divX]
-    | succ k =>
-      have hdeg' : natDegreeY Q = k + 2 := by
-        simpa [Nat.succ_eq_add_one, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hdeg
-      have hdivdeg : natDegreeY (CPolynomial.divX Q) = k + 1 := by
-        simpa [hdeg', Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using
-          (natDegreeY_divX (Q := Q))
-      have hk2nz : k + 2 ≠ 0 := by omega
-      have hk1nz : k + 1 ≠ 0 := by omega
-      have hk21 : k + 2 - 1 = k + 1 := by omega
-      rw [divByLinearY, hdeg', if_neg hk2nz]
-      rw [hk21]
-      conv_rhs => rw [divByLinearY, hdivdeg, if_neg hk1nz]
-      change
-        CPolynomial.coeff Q 0 +
-            f *
-              (List.foldl
-                  (fun x k_1 =>
-                    (CPolynomial.coeff Q (k + 1 - k_1) + f * x.1,
-                      x.2.push (CPolynomial.coeff Q (k + 1 - k_1) + f * x.1)))
-                  (CPolynomial.coeff Q (k + 2), #[CPolynomial.coeff Q (k + 2)])
-                  (List.range (k + 1))).1
-          =
-        CPolynomial.coeff Q 0 +
-            f *
-              (CPolynomial.coeff (CPolynomial.divX Q) 0 +
-                f *
-                  (List.foldl
-                      (fun x k_1 =>
-                        (CPolynomial.coeff (CPolynomial.divX Q) (k - k_1) + f * x.1,
-                          x.2.push
-                            (CPolynomial.coeff (CPolynomial.divX Q) (k - k_1) + f * x.1)))
-                      (CPolynomial.coeff (CPolynomial.divX Q) (k + 1),
-                        #[CPolynomial.coeff (CPolynomial.divX Q) (k + 1)])
-                      (List.range k)).1)
-      congr 1
-      congr 1
-      rw [List.range_succ]
-      simp only [List.foldl_concat]
-      rw [divByLinearY_prefix_fold_eq_divX_fold (Q := Q) (f := f) (k := k)]
-      have hlast : k + 1 - k = 1 := by omega
-      rw [hlast]
-      have hcoeff0 : CPolynomial.coeff (CPolynomial.divX Q) 0 = CPolynomial.coeff Q 1 := by
-        simpa using (CPolynomial.coeff_divX (p := Q) (i := 0))
-      rw [hcoeff0]
-
--- Step 1: remainder of synthetic division = evaluation at f
-theorem divByLinearY_rem_eq_eval [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-    (Q : CBivariate R) (f : CPolynomial R) :
-    (divByLinearY Q f).2 = evalYPoly f Q := by
-  refine Nat.strong_induction_on
-    (p := fun n => ∀ Q : CBivariate R, Q.val.size = n →
-      (divByLinearY Q f).2 = evalYPoly f Q)
-    Q.val.size ?_ Q rfl
-  intro n ih Q hsize
-  by_cases hdeg : natDegreeY Q = 0
-  · rw [divByLinearY, if_pos hdeg]
-    change CPolynomial.coeff Q 0 = CPolynomial.eval f Q
-    rw [CPolynomial.eval_toPoly]
-    have hQnat : Q.natDegree = 0 := by
-      simpa [CBivariate.natDegreeY] using hdeg
-    have hdeg_toPoly : (CPolynomial.toPoly Q).natDegree = 0 := by
-      simpa [hQnat] using (CPolynomial.natDegree_toPoly (p := Q)).symm
-    rcases Polynomial.natDegree_eq_zero.mp hdeg_toPoly with ⟨a, ha⟩
-    have ha0 : a = (CPolynomial.toPoly Q).coeff 0 := by
-      have hcoeff := congrArg (fun p : Polynomial (CPolynomial R) => p.coeff 0) ha
-      simpa using hcoeff
-    rw [← ha, Polynomial.eval_C, CPolynomial.coeff_toPoly]
-    exact ha0.symm
-  · have hpos : 0 < Q.val.size := by
-      by_contra hzero
-      have hs : Q.val.size = 0 := Nat.eq_zero_of_not_pos hzero
-      have hval : Q.val = (#[] : CPolynomial.Raw (CPolynomial R)) :=
-        Array.eq_empty_of_size_eq_zero hs
-      have hQ0 : Q = 0 := by
-        apply CPolynomial.ext
-        simpa using hval
-      have hdeg0 : natDegreeY Q = 0 := by
-        rw [hQ0]
-        rfl
-      exact hdeg hdeg0
-    have hlt : (CPolynomial.divX Q).val.size < n := by
-      rw [← hsize]
-      exact CPolynomial.divX_size_lt Q hpos
-    have hrec := ih (CPolynomial.divX Q).val.size hlt (CPolynomial.divX Q) rfl
-    rw [divByLinearY_rem_recursion Q f hdeg]
-    rw [hrec]
-    exact (evalYPoly_divX_step Q f).symm
-
--- Helpers for divByLinearY_spec (coefficient-by-coefficient approach)
-
-theorem divByLinearY_const [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-    (a : CPolynomial R) (f : CPolynomial R) :
-    divByLinearY (CPolynomial.C a : CBivariate R) f = (0, a) := by
+-- Step 2–4: main correctness theorem
+theorem divByLinearY_const [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (a f : CPolynomial R) :
+  divByLinearY (CPolynomial.C a : CBivariate R) f = (0, a) := by
   unfold divByLinearY
   have hdeg : natDegreeY (CPolynomial.C a : CBivariate R) = 0 := by
     rw [CBivariate.natDegreeY, CPolynomial.natDegree_toPoly, CPolynomial.C_toPoly]
     by_cases ha : a = 0
-    · subst ha; simp only [map_zero, Polynomial.natDegree_zero]
-    · simp [ha]
+    · subst ha
+      simp
+    · simp
   simp [hdeg]
   simpa [CPolynomial.coeff] using (CPolynomial.coeff_C (R := CPolynomial R) (r := a) (i := 0))
 
-theorem divByLinearY_fold_split [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-    (Q : CBivariate R) (f : CPolynomial R) (h : 1 < natDegreeY Q) :
-    let n := natDegreeY Q
-    let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
-    let step : CPolynomial R × Array (CPolynomial R) → ℕ →
-        CPolynomial R × Array (CPolynomial R) :=
-      fun x k =>
-        let bj := a (n - 1 - k) + f * x.1
-        (bj, x.2.push bj)
-    let res1 := (List.range (n - 2)).foldl step (a n, #[(a n)])
-    (List.range (n - 1)).foldl step (a n, #[(a n)]) =
-      (a 1 + f * res1.1, res1.2.push (a 1 + f * res1.1)) := by
+theorem divByLinearY_fold_split [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (h : 1 < natDegreeY Q) :
+  let n := natDegreeY Q
+  let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
+  let step : CPolynomial R × Array (CPolynomial R) → ℕ → CPolynomial R × Array (CPolynomial R) :=
+    fun x k =>
+      let bj := a (n - 1 - k) + f * x.1
+      (bj, x.2.push bj)
+  let res1 := (List.range (n - 2)).foldl step (a n, #[(a n)])
+  (List.range (n - 1)).foldl step (a n, #[(a n)]) =
+    (a 1 + f * res1.1, res1.2.push (a 1 + f * res1.1)) := by
   dsimp
+  have hn2 : 2 ≤ natDegreeY Q := by omega
   rw [show natDegreeY Q - 1 = (natDegreeY Q - 2) + 1 by omega]
   rw [List.range_succ]
   rw [List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   congr <;> omega
 
-theorem divByLinearY_quot_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    [DecidableEq R]
-    (Q : CBivariate R) (f : CPolynomial R) (h : natDegreeY Q = 1) :
-    (divByLinearY Q f).1 = CPolynomial.C (CPolynomial.coeff Q 1) := by
+theorem divByLinearY_pair_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R]
+  (Q : CBivariate R) (f : CPolynomial R) (h : 1 < natDegreeY Q) :
+  let n := natDegreeY Q
+  let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
+  let step : CPolynomial R × Array (CPolynomial R) → ℕ → CPolynomial R × Array (CPolynomial R) :=
+    fun x k =>
+      let bj := a (n - 1 - k) + f * x.1
+      (bj, x.2.push bj)
+  let res1 := (List.range (n - 2)).foldl step (a n, #[(a n)])
+  let r1 := a 1 + f * res1.1
+  divByLinearY Q f =
+    (⟨CPolynomial.Raw.trim ((res1.2.push r1).reverse),
+      CPolynomial.Raw.Trim.isCanonical_trim ((res1.2.push r1).reverse)⟩, a 0 + f * r1) := by
+  let n := natDegreeY Q
+  let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
+  let step : CPolynomial R × Array (CPolynomial R) → ℕ → CPolynomial R × Array (CPolynomial R) :=
+    fun x k =>
+      let bj := a (n - 1 - k) + f * x.1
+      (bj, x.2.push bj)
+  let res1 := (List.range (n - 2)).foldl step (a n, #[(a n)])
+  let r1 := a 1 + f * res1.1
+  have h0 : natDegreeY Q ≠ 0 := by
+    omega
+  have hsplit :
+      (List.range (n - 1)).foldl step (a n, #[(a n)]) = (r1, res1.2.push r1) := by
+    simpa [n, a, step, res1, r1] using (divByLinearY_fold_split (Q := Q) (f := f) h)
+  unfold divByLinearY
+  rw [if_neg h0]
+  dsimp [n, a, step, res1, r1]
+  rw [hsplit]
+
+theorem divByLinearY_quot_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (h : natDegreeY Q = 1) :
+  (divByLinearY Q f).1 = CPolynomial.C (CPolynomial.coeff Q 1) := by
   simp [divByLinearY, h, CPolynomial.C]
   rfl
 
-theorem divX_zero_of_natDegreeY_zero [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    [DecidableEq R]
-    (Q : CBivariate R) (h : natDegreeY Q = 0) :
-    CPolynomial.divX Q = 0 := by
-  rw [CPolynomial.eq_zero_iff_coeff_zero]
-  intro i
-  rw [CPolynomial.coeff_divX]
-  apply (CPolynomial.toPoly_eq_zero_iff (p := CPolynomial.coeff Q (i + 1))).mp
-  rw [← CBivariate.toPoly_coeff]
-  have hdeg : (toPoly Q).natDegree = 0 := by
-    rw [CBivariate.natDegreeY_toPoly, h]
-  exact Polynomial.coeff_eq_zero_of_natDegree_lt (by rw [hdeg]; omega)
+theorem divByLinearY_quot_of_natDegreeY_zero [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (h : natDegreeY Q = 0) :
+  (divByLinearY Q f).1 = 0 := by
+  simp [divByLinearY, h]
 
-theorem divX_eq_C_coeff_one_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    [DecidableEq R]
-    (Q : CBivariate R) (h : natDegreeY Q = 1) :
-    CPolynomial.divX Q = CPolynomial.C (CPolynomial.coeff Q 1) := by
-  apply CPolynomial.eq_iff_coeff.mpr
-  intro i
-  rw [CPolynomial.coeff_divX, CPolynomial.coeff_C]
-  cases i with
-  | zero => simp
-  | succ k =>
-    have hdeg : (CBivariate.toPoly Q).natDegree = 1 := by
-      simpa [h] using (CBivariate.natDegreeY_toPoly (f := Q))
-    have hlt : (CBivariate.toPoly Q).natDegree < k + 2 := by
-      rw [hdeg]; omega
-    have hzero_toPoly : (CPolynomial.coeff Q (k + 2)).toPoly = 0 := by
-      simpa [CBivariate.toPoly_coeff] using
-        (Polynomial.coeff_eq_zero_of_natDegree_lt
-          (p := CBivariate.toPoly Q) (n := k + 2) hlt)
-    have hzero : CPolynomial.coeff Q (k + 2) = 0 := by
-      exact (CPolynomial.toPoly_eq_zero_iff (CPolynomial.coeff Q (k + 2))).mp hzero_toPoly
-    simpa using hzero
-
-theorem raw_trim_reverse_push_coeff_succ {S : Type*} [Zero S] [BEq S] [LawfulBEq S]
-    (arr : Array S) (a : S) (j : ℕ) :
-    CPolynomial.Raw.coeff (CPolynomial.Raw.trim ((arr.push a).reverse)) (j + 1) =
-      CPolynomial.Raw.coeff (CPolynomial.Raw.trim (arr.reverse)) j := by
-  rw [CPolynomial.Raw.Trim.coeff_eq_coeff, CPolynomial.Raw.Trim.coeff_eq_coeff]
-  rw [Array.reverse_push]
-  unfold CPolynomial.Raw.coeff
-  rw [Array.getD_eq_getD_getElem?, Array.getD_eq_getD_getElem?]
-  have h1 : (#[a] : Array S).size ≤ j + 1 := by simp
-  rw [Array.getElem?_append_right (xs := #[a]) (ys := arr.reverse) (i := j + 1) h1]
-  simp
-
-theorem raw_trim_reverse_push_coeff_zero {S : Type*} [Zero S] [BEq S] [LawfulBEq S]
-    (arr : Array S) (a : S) :
-    CPolynomial.Raw.coeff (CPolynomial.Raw.trim ((arr.push a).reverse)) 0 = a := by
-  rw [CPolynomial.Raw.Trim.coeff_eq_coeff]
-  rw [Array.reverse_push]
-  simp [CPolynomial.Raw.coeff, Array.getD_eq_getD_getElem?]
-
-theorem divByLinearY_rem_formula [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-    (Q : CBivariate R) (f : CPolynomial R) :
-    let quot := (divByLinearY Q f).1
-    let rem := (divByLinearY Q f).2
-    rem = CPolynomial.coeff Q 0 + f * CPolynomial.coeff quot 0 := by
+theorem divByLinearY_rem_formula [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) :
+  let quot := (divByLinearY Q f).1
+  let rem := (divByLinearY Q f).2
+  rem = CPolynomial.coeff Q 0 + f * CPolynomial.coeff quot 0 := by
   unfold divByLinearY
   by_cases h0 : natDegreeY Q = 0
   · simp [h0]
@@ -374,8 +187,7 @@ theorem divByLinearY_rem_formula [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial 
   · simp [h0]
     let n := Q.natDegreeY
     let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
-    let step : CPolynomial R × Array (CPolynomial R) → ℕ →
-        CPolynomial R × Array (CPolynomial R) :=
+    let step : CPolynomial R × Array (CPolynomial R) → ℕ → CPolynomial R × Array (CPolynomial R) :=
       fun x k =>
         let bj := a (n - 1 - k) + f * x.1
         (bj, x.2.push bj)
@@ -386,113 +198,366 @@ theorem divByLinearY_rem_formula [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial 
       intro l
       induction l with
       | nil =>
-        intro b acc
-        simp [step]
+          intro b acc
+          simp [step]
       | cons k l ih =>
-        intro b acc
-        simpa [List.foldl_cons, step] using ih (a (n - 1 - k) + f * b) (acc.push b)
+          intro b acc
+          simpa [List.foldl_cons, step] using ih (a (n - 1 - k) + f * b) (acc.push b)
     have hres : (res.2.reverse)[0]?.getD 0 = res.1 := by
       simpa [res, step] using hfold (List.range (n - 1)) (a n) (#[])
-    have htrim0 : (CPolynomial.Raw.trim res.2.reverse)[0]?.getD 0 =
-        (res.2.reverse)[0]?.getD 0 := by
-      simpa [CPolynomial.Raw.coeff] using
-        (CPolynomial.Raw.Trim.coeff_eq_coeff (res.2.reverse) 0)
+    have htrim0 : (CPolynomial.Raw.trim res.2.reverse)[0]?.getD 0 = (res.2.reverse)[0]?.getD 0 := by
+      simpa [CPolynomial.Raw.coeff] using (CPolynomial.Raw.Trim.coeff_eq_coeff (res.2.reverse) 0)
     have hmain : f * res.1 = f * (CPolynomial.Raw.trim res.2.reverse)[0]?.getD 0 := by
       rw [htrim0, hres]
     simpa [n, a, step, res] using hmain
 
--- Key: coefficient j of divX-quotient = coefficient j+1 of original quotient
-theorem divByLinearY_divX_quot_coeff [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    [DecidableEq R]
-    (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
-    let quot := (divByLinearY Q f).1
-    CPolynomial.coeff ((divByLinearY (CPolynomial.divX Q) f).1) j =
-      CPolynomial.coeff quot (j + 1) := by
-  sorry
+theorem divByLinearY_zero [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (f : CPolynomial R) :
+  divByLinearY (0 : CBivariate R) f = (0, 0) := by
+  change divByLinearY (⟨#[], CPolynomial.Raw.Trim.isCanonical_empty⟩ : CBivariate R) f = (0, 0)
+  simp [divByLinearY, CBivariate.natDegreeY, CPolynomial.natDegree, CPolynomial.coeff]
 
--- Key: remainder of divX-division = coefficient 0 of original quotient
-theorem divByLinearY_divX_rem [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-    (Q : CBivariate R) (f : CPolynomial R) :
-    let quot := (divByLinearY Q f).1
-    (divByLinearY (CPolynomial.divX Q) f).2 = CPolynomial.coeff quot 0 := by
-  sorry
+theorem divX_eq_C_coeff_one_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (h : natDegreeY Q = 1) :
+  CPolynomial.divX Q = CPolynomial.C (CPolynomial.coeff Q 1) := by
+  apply CPolynomial.eq_iff_coeff.mpr
+  intro i
+  rw [CPolynomial.coeff_divX, CPolynomial.coeff_C]
+  cases i with
+  | zero =>
+      simp
+  | succ k =>
+      have hdeg : (CBivariate.toPoly Q).natDegree = 1 := by
+        simpa [h] using (CBivariate.natDegreeY_toPoly (f := Q))
+      have hlt : (CBivariate.toPoly Q).natDegree < k + 2 := by
+        rw [hdeg]
+        omega
+      have hzero_toPoly : (CPolynomial.coeff Q (k + 2)).toPoly = 0 := by
+        simpa [CBivariate.toPoly_coeff] using
+          (Polynomial.coeff_eq_zero_of_natDegree_lt (p := CBivariate.toPoly Q) (n := k + 2) hlt)
+      have hzero : CPolynomial.coeff Q (k + 2) = 0 := by
+        exact (CPolynomial.toPoly_eq_zero_iff (CPolynomial.coeff Q (k + 2))).mp hzero_toPoly
+      simpa using hzero
 
-theorem divByLinearY_quot_recurrence [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    [DecidableEq R]
-    (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
-    let quot := (divByLinearY Q f).1
-    CPolynomial.coeff quot j =
-      CPolynomial.coeff Q (j + 1) + f * CPolynomial.coeff quot (j + 1) := by
+theorem divX_zero_of_natDegreeY_zero [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (h : natDegreeY Q = 0) :
+  CPolynomial.divX Q = 0 := by
+  rw [CPolynomial.eq_zero_iff_coeff_zero]
+  intro i
+  rw [CPolynomial.coeff_divX]
+  apply (CPolynomial.toPoly_eq_zero_iff (p := CPolynomial.coeff Q (i + 1))).mp
+  rw [← CBivariate.toPoly_coeff]
+  have hdeg : (toPoly Q).natDegree = 0 := by
+    rw [CBivariate.natDegreeY_toPoly, h]
+  exact Polynomial.coeff_eq_zero_of_natDegree_lt (by rw [hdeg]; omega)
+
+theorem natDegreeY_divX_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (h : 1 < natDegreeY Q) :
+  natDegreeY (CPolynomial.divX Q) = natDegreeY Q - 1 := by
+  unfold CBivariate.natDegreeY CPolynomial.natDegree at h ⊢
+  cases hs : Q.val.size with
+  | zero =>
+      simp [hs] at h
+  | succ m =>
+      cases m with
+      | zero =>
+          simp [hs] at h
+      | succ k =>
+          simp [CPolynomial.divX, hs, Array.size_extract]
+
+theorem divByLinearY_divX_pair_of_one_lt [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R]
+  (Q : CBivariate R) (f : CPolynomial R) (h : 1 < natDegreeY Q) :
+  let n := natDegreeY Q
+  let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
+  let step : CPolynomial R × Array (CPolynomial R) → ℕ → CPolynomial R × Array (CPolynomial R) :=
+    fun x k =>
+      let bj := a (n - 1 - k) + f * x.1
+      (bj, x.2.push bj)
+  let res1 := (List.range (n - 2)).foldl step (a n, #[(a n)])
+  let r1 := a 1 + f * res1.1
+  divByLinearY (CPolynomial.divX Q) f =
+    (⟨CPolynomial.Raw.trim (res1.2.reverse),
+      CPolynomial.Raw.Trim.isCanonical_trim (res1.2.reverse)⟩, r1) := by
+  let n := natDegreeY Q
+  let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
+  let step : CPolynomial R × Array (CPolynomial R) → ℕ → CPolynomial R × Array (CPolynomial R) :=
+    fun x k =>
+      let bj := a (n - 1 - k) + f * x.1
+      (bj, x.2.push bj)
+  let res1 := (List.range (n - 2)).foldl step (a n, #[(a n)])
+  let r1 := a 1 + f * res1.1
+  have hn : 1 < n := by
+    simpa [n] using h
+  have hdivX : natDegreeY (CPolynomial.divX Q) = n - 1 := by
+    simpa [n] using (natDegreeY_divX_of_one_lt (Q := Q) h)
+  have hdivX0 : natDegreeY (CPolynomial.divX Q) ≠ 0 := by
+    rw [hdivX]
+    omega
+  unfold divByLinearY
+  simp only [hdivX0, if_false]
+  rw [hdivX]
+  simp only [CPolynomial.coeff_divX]
+  let step1 : CPolynomial R × Array (CPolynomial R) → ℕ → CPolynomial R × Array (CPolynomial R) :=
+    fun x k =>
+      let bj := CPolynomial.coeff Q (n - 1 - 1 - k + 1) + f * x.1
+      (bj, x.2.push bj)
+  let step2 : CPolynomial R × Array (CPolynomial R) → ℕ → CPolynomial R × Array (CPolynomial R) :=
+    fun x k =>
+      let bj := CPolynomial.coeff Q (n - 1 - k) + f * x.1
+      (bj, x.2.push bj)
+  have hfold :
+      List.foldl step1 (CPolynomial.coeff Q (n - 1 + 1), #[CPolynomial.coeff Q (n - 1 + 1)])
+        (List.range (n - 1 - 1)) =
+      res1 := by
+    have hfold₁ :
+        List.foldl step1 (CPolynomial.coeff Q (n - 1 + 1), #[CPolynomial.coeff Q (n - 1 + 1)])
+          (List.range (n - 1 - 1)) =
+        List.foldl step2 (CPolynomial.coeff Q (n - 1 + 1), #[CPolynomial.coeff Q (n - 1 + 1)])
+          (List.range (n - 1 - 1)) := by
+      apply List.foldl_ext
+      intro x k hk
+      have hklt : k < n - 1 - 1 := List.mem_range.mp hk
+      have hidx : n - 1 - 1 - k + 1 = n - 1 - k := by
+        omega
+      dsimp [step1, step2]
+      rw [hidx]
+    calc
+      List.foldl step1 (CPolynomial.coeff Q (n - 1 + 1), #[CPolynomial.coeff Q (n - 1 + 1)])
+          (List.range (n - 1 - 1))
+          = List.foldl step2 (CPolynomial.coeff Q (n - 1 + 1), #[CPolynomial.coeff Q (n - 1 + 1)])
+              (List.range (n - 1 - 1)) := hfold₁
+      _ = List.foldl step2 (CPolynomial.coeff Q n, #[CPolynomial.coeff Q n])
+            (List.range (n - 2)) := by
+            have hinit : n - 1 + 1 = n := by
+              omega
+            have hrange : n - 1 - 1 = n - 2 := by
+              omega
+            simp [hinit, hrange]
+      _ = res1 := by
+            dsimp [res1, step, a, step2]
+  let g : (CPolynomial R × Array (CPolynomial R)) → CBivariate R × CPolynomial R :=
+    fun z =>
+      (⟨CPolynomial.Raw.trim (z.2.reverse),
+        CPolynomial.Raw.Trim.isCanonical_trim (z.2.reverse)⟩,
+        CPolynomial.coeff Q (0 + 1) + f * z.1)
+  have hpair :
+      g (List.foldl step1 (CPolynomial.coeff Q (n - 1 + 1), #[CPolynomial.coeff Q (n - 1 + 1)])
+          (List.range (n - 1 - 1))) = g res1 := by
+    exact congrArg g hfold
+  simpa [g, n, a, step, step1, res1, r1] using hpair
+
+theorem raw_trim_reverse_push_coeff_succ [Zero R] [BEq R] [LawfulBEq R]
+    (arr : Array R) (a : R) (j : ℕ) :
+  CPolynomial.Raw.coeff (CPolynomial.Raw.trim ((arr.push a).reverse)) (j + 1) =
+    CPolynomial.Raw.coeff (CPolynomial.Raw.trim (arr.reverse)) j := by
+  rw [CPolynomial.Raw.Trim.coeff_eq_coeff, CPolynomial.Raw.Trim.coeff_eq_coeff]
+  rw [Array.reverse_push]
+  unfold CPolynomial.Raw.coeff
+  rw [Array.getD_eq_getD_getElem?, Array.getD_eq_getD_getElem?]
+  have h1 : (#[a] : Array R).size ≤ j + 1 := by simp
+  rw [Array.getElem?_append_right (xs := #[a]) (ys := arr.reverse) (i := j + 1) h1]
+  simp
+
+theorem divByLinearY_divX_quot_coeff [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
+  let quot := (divByLinearY Q f).1
+  CPolynomial.coeff ((divByLinearY (CPolynomial.divX Q) f).1) j
+      = CPolynomial.coeff quot (j + 1) := by
+  classical
+  change CPolynomial.coeff ((divByLinearY (CPolynomial.divX Q) f).1) j =
+    CPolynomial.coeff ((divByLinearY Q f).1) (j + 1)
+  by_cases h0 : natDegreeY Q = 0
+  · have hzeroquot : (divByLinearY (0 : CBivariate R) f).1 = 0 := by
+      simpa using congrArg Prod.fst (divByLinearY_zero (R := R) (f := f))
+    calc
+      CPolynomial.coeff ((divByLinearY (CPolynomial.divX Q) f).1) j
+          = CPolynomial.coeff ((divByLinearY (0 : CBivariate R) f).1) j := by
+              rw [divX_zero_of_natDegreeY_zero (Q := Q) h0]
+              rfl
+      _ = 0 := by
+            simpa using congrArg (fun p : CBivariate R => CPolynomial.coeff p j) hzeroquot
+      _ = CPolynomial.coeff ((divByLinearY Q f).1) (j + 1) := by
+            rw [divByLinearY_quot_of_natDegreeY_zero (Q := Q) (f := f) h0]
+            simpa using (CPolynomial.coeff_zero (R := CPolynomial R) (i := j + 1)).symm
+  · by_cases h1 : natDegreeY Q = 1
+    · have hconstquot :
+          (divByLinearY (CPolynomial.C (CPolynomial.coeff Q 1) : CBivariate R) f).1 = 0 := by
+        simpa using
+          congrArg Prod.fst (divByLinearY_const (R := R) (a := CPolynomial.coeff Q 1) (f := f))
+      calc
+        CPolynomial.coeff ((divByLinearY (CPolynomial.divX Q) f).1) j
+            = CPolynomial.coeff
+                ((divByLinearY (CPolynomial.C (CPolynomial.coeff Q 1) : CBivariate R) f).1) j := by
+                rw [divX_eq_C_coeff_one_of_natDegreeY_one (Q := Q) h1]
+        _ = 0 := by
+              simpa using congrArg (fun p : CBivariate R => CPolynomial.coeff p j) hconstquot
+        _ = CPolynomial.coeff ((divByLinearY Q f).1) (j + 1) := by
+              rw [divByLinearY_quot_of_natDegreeY_one (Q := Q) (f := f) h1]
+              simpa [Nat.succ_ne_zero] using
+                (CPolynomial.coeff_C (R := CPolynomial R)
+                  (r := CPolynomial.coeff Q 1) (i := j + 1)).symm
+    · have hgt : 1 < natDegreeY Q := by
+        omega
+      let n := natDegreeY Q
+      let a : ℕ → CPolynomial R := fun k => CPolynomial.coeff Q k
+      let step : CPolynomial R × Array (CPolynomial R) → ℕ →
+          CPolynomial R × Array (CPolynomial R) :=
+        fun x k =>
+          let bj := a (n - 1 - k) + f * x.1
+          (bj, x.2.push bj)
+      let res1 := (List.range (n - 2)).foldl step (a n, #[(a n)])
+      let r1 := a 1 + f * res1.1
+      have hshort :
+          divByLinearY (CPolynomial.divX Q) f =
+            (⟨CPolynomial.Raw.trim (res1.2.reverse),
+              CPolynomial.Raw.Trim.isCanonical_trim (res1.2.reverse)⟩, r1) := by
+        simpa [n, a, step, res1, r1] using
+          (divByLinearY_divX_pair_of_one_lt (R := R) (Q := Q) (f := f) hgt)
+      have hlong :
+          divByLinearY Q f =
+            (⟨CPolynomial.Raw.trim ((res1.2.push r1).reverse),
+              CPolynomial.Raw.Trim.isCanonical_trim ((res1.2.push r1).reverse)⟩, a 0 + f * r1) := by
+        simpa [n, a, step, res1, r1] using
+          (divByLinearY_pair_of_one_lt (R := R) (Q := Q) (f := f) hgt)
+      rw [hshort, hlong]
+      simpa [CPolynomial.coeff] using
+        (raw_trim_reverse_push_coeff_succ (R := CPolynomial R)
+          (arr := res1.2) (a := r1) (j := j)).symm
+
+theorem raw_trim_reverse_push_coeff_zero [Zero R] [BEq R] [LawfulBEq R]
+    (arr : Array R) (a : R) :
+  CPolynomial.Raw.coeff (CPolynomial.Raw.trim ((arr.push a).reverse)) 0 = a := by
+  rw [CPolynomial.Raw.Trim.coeff_eq_coeff]
+  rw [Array.reverse_push]
+  simp [CPolynomial.Raw.coeff, Array.getD_eq_getD_getElem?]
+
+theorem divByLinearY_divX_rem [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) :
+  let quot := (divByLinearY Q f).1
+  (divByLinearY (CPolynomial.divX Q) f).2 = CPolynomial.coeff quot 0 := by
+  classical
+  dsimp
+  by_cases h0 : natDegreeY Q = 0
+  · rw [divX_zero_of_natDegreeY_zero Q h0, divByLinearY_quot_of_natDegreeY_zero Q f h0]
+    have hrem0 : (divByLinearY (0 : CBivariate R) f).2 = (0 : CPolynomial R) := by
+      exact congrArg Prod.snd (divByLinearY_zero (R := R) (f := f))
+    simpa [CPolynomial.coeff_zero] using hrem0
+  · by_cases h1 : natDegreeY Q = 1
+    · rw [divX_eq_C_coeff_one_of_natDegreeY_one Q h1]
+      have hrem1 :
+          (divByLinearY (CPolynomial.C (CPolynomial.coeff Q 1) : CBivariate R) f).2 =
+            CPolynomial.coeff Q 1 := by
+        exact congrArg Prod.snd (divByLinearY_const (a := CPolynomial.coeff Q 1) (f := f))
+      rw [divByLinearY_quot_of_natDegreeY_one Q f h1]
+      have hcoeffC0 :
+          CPolynomial.coeff (CPolynomial.C (CPolynomial.coeff Q 1)) 0 = CPolynomial.coeff Q 1 := by
+        rw [CPolynomial.coeff_C]
+        simp
+      exact hrem1.trans hcoeffC0.symm
+    · have hgt : 1 < natDegreeY Q := by
+        omega
+      let n := natDegreeY Q
+      let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
+      let step : CPolynomial R × Array (CPolynomial R) → ℕ →
+          CPolynomial R × Array (CPolynomial R) :=
+        fun x k =>
+          let bj := a (n - 1 - k) + f * x.1
+          (bj, x.2.push bj)
+      let res1 := (List.range (n - 2)).foldl step (a n, #[(a n)])
+      let r1 := a 1 + f * res1.1
+      have hshort : divByLinearY (CPolynomial.divX Q) f =
+          (⟨CPolynomial.Raw.trim (res1.2.reverse),
+            CPolynomial.Raw.Trim.isCanonical_trim (res1.2.reverse)⟩, r1) := by
+        simpa [n, a, step, res1, r1] using (divByLinearY_divX_pair_of_one_lt (Q := Q) (f := f) hgt)
+      have hlong : divByLinearY Q f =
+          (⟨CPolynomial.Raw.trim ((res1.2.push r1).reverse),
+            CPolynomial.Raw.Trim.isCanonical_trim ((res1.2.push r1).reverse)⟩, a 0 + f * r1) := by
+        simpa [n, a, step, res1, r1] using (divByLinearY_pair_of_one_lt (Q := Q) (f := f) hgt)
+      rw [hshort, hlong]
+      simpa [CPolynomial.coeff] using
+        (raw_trim_reverse_push_coeff_zero (arr := res1.2) (a := r1)).symm
+
+theorem divByLinearY_quot_recurrence [CommRing R] [BEq R] [LawfulBEq R]
+    [Nontrivial R] [DecidableEq R] (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
+  let quot := (divByLinearY Q f).1
+  CPolynomial.coeff quot j = CPolynomial.coeff Q (j + 1) + f * CPolynomial.coeff quot (j + 1) := by
   dsimp
   induction j generalizing Q with
   | zero =>
-    have h := divByLinearY_rem_formula (Q := CPolynomial.divX Q) (f := f)
-    dsimp at h
-    rw [divByLinearY_divX_rem (Q := Q) (f := f)] at h
-    rw [divByLinearY_divX_quot_coeff (Q := Q) (f := f) 0] at h
-    rw [CPolynomial.coeff_divX] at h
-    simpa using h
+      have h := divByLinearY_rem_formula (Q := CPolynomial.divX Q) (f := f)
+      dsimp at h
+      rw [divByLinearY_divX_rem (Q := Q) (f := f)] at h
+      rw [divByLinearY_divX_quot_coeff (Q := Q) (f := f) 0] at h
+      rw [CPolynomial.coeff_divX] at h
+      simpa using h
   | succ j ih =>
-    have h := ih (Q := CPolynomial.divX Q)
-    rw [divByLinearY_divX_quot_coeff (Q := Q) (f := f) j,
-      divByLinearY_divX_quot_coeff (Q := Q) (f := f) (j + 1),
-      CPolynomial.coeff_divX] at h
-    simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using h
+      have h := ih (Q := CPolynomial.divX Q)
+      rw [divByLinearY_divX_quot_coeff (Q := Q) (f := f) j,
+        divByLinearY_divX_quot_coeff (Q := Q) (f := f) (j + 1),
+        CPolynomial.coeff_divX] at h
+      simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using h
 
-theorem divByLinearY_coeff_zero [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-    (Q : CBivariate R) (f : CPolynomial R) :
-    let quot := (divByLinearY Q f).1
-    let rem := (divByLinearY Q f).2
-    (toPoly Q).coeff 0 = rem.toPoly - (toPoly quot).coeff 0 * f.toPoly := by
-  dsimp
-  let quot := (divByLinearY Q f).1
-  let rem := (divByLinearY Q f).2
-  have hrem := divByLinearY_rem_formula Q f
-  dsimp at hrem
-  have hrem' := congrArg CPolynomial.toPoly hrem
-  rw [CPolynomial.toPoly_add, CPolynomial.toPoly_mul] at hrem'
-  rw [CBivariate.toPoly_coeff, CBivariate.toPoly_coeff]
-  rw [hrem']
-  ring_nf
-
-theorem divByLinearY_coeff_succ [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-    (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
-    let quot := (divByLinearY Q f).1
-    (toPoly Q).coeff (j + 1) =
-      (toPoly quot).coeff j - (toPoly quot).coeff (j + 1) * f.toPoly := by
-  classical
-  dsimp
-  let quot := (divByLinearY Q f).1
-  have hraw : CPolynomial.coeff quot j =
-      CPolynomial.coeff Q (j + 1) + f * CPolynomial.coeff quot (j + 1) := by
-    simpa [quot] using divByLinearY_quot_recurrence (Q := Q) (f := f) (j := j)
-  have hpoly : (toPoly quot).coeff j =
-      (toPoly Q).coeff (j + 1) + f.toPoly * (toPoly quot).coeff (j + 1) := by
-    rw [CBivariate.toPoly_coeff, CBivariate.toPoly_coeff, CBivariate.toPoly_coeff]
-    simpa [CPolynomial.toPoly_add, CPolynomial.toPoly_mul] using
-      congrArg CPolynomial.toPoly hraw
-  rw [eq_sub_iff_add_eq]
-  simpa [quot, mul_comm] using hpoly.symm
-
--- Step 2-4: main correctness theorem
 theorem divByLinearY_spec [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     let quot := (divByLinearY Q f).1
     let rem := (divByLinearY Q f).2
     toPoly Q = toPoly quot * (Polynomial.X - Polynomial.C (f.toPoly)) +
         Polynomial.C (rem.toPoly) := by
+  classical
   dsimp
   apply Polynomial.ext
   intro n
   cases n with
   | zero =>
-    simp only [Polynomial.coeff_add, Polynomial.mul_coeff_zero, Polynomial.coeff_C,
-      Polynomial.coeff_X_zero, sub_eq_add_neg, add_comm]
-    simpa [sub_eq_add_neg, add_comm] using
-      divByLinearY_coeff_zero Q f
+      -- coefficient 0: from the remainder formula `rem = a₀ + f · quot₀`
+      have hcoeff0 : (toPoly Q).coeff 0 =
+          (divByLinearY Q f).2.toPoly - (toPoly (divByLinearY Q f).1).coeff 0 * f.toPoly := by
+        have hrem := divByLinearY_rem_formula Q f
+        dsimp at hrem
+        have hrem' := congrArg CPolynomial.toPoly hrem
+        rw [CPolynomial.toPoly_add, CPolynomial.toPoly_mul] at hrem'
+        rw [CBivariate.toPoly_coeff, CBivariate.toPoly_coeff]
+        rw [hrem']
+        ring_nf
+      simp only [Polynomial.coeff_add, Polynomial.mul_coeff_zero, Polynomial.coeff_C,
+        Polynomial.coeff_X_zero, sub_eq_add_neg, add_comm]
+      simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using hcoeff0
   | succ j =>
-    simp only [Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_mul_X_sub_C]
-    simpa using divByLinearY_coeff_succ Q f j
+      -- coefficient j+1: from the quotient recurrence `quotⱼ = a_{j+1} + f · quot_{j+1}`
+      have hcoeffS : (toPoly Q).coeff (j + 1) =
+          (toPoly (divByLinearY Q f).1).coeff j -
+            (toPoly (divByLinearY Q f).1).coeff (j + 1) * f.toPoly := by
+        have hraw : CPolynomial.coeff (divByLinearY Q f).1 j =
+            CPolynomial.coeff Q (j + 1) + f * CPolynomial.coeff (divByLinearY Q f).1 (j + 1) := by
+          simpa using divByLinearY_quot_recurrence (Q := Q) (f := f) (j := j)
+        have hpoly : (toPoly (divByLinearY Q f).1).coeff j =
+            (toPoly Q).coeff (j + 1) + f.toPoly * (toPoly (divByLinearY Q f).1).coeff (j + 1) := by
+          rw [CBivariate.toPoly_coeff, CBivariate.toPoly_coeff, CBivariate.toPoly_coeff]
+          simpa [CPolynomial.toPoly_add, CPolynomial.toPoly_mul] using
+            congrArg CPolynomial.toPoly hraw
+        rw [eq_sub_iff_add_eq]
+        simpa [mul_comm] using hpoly.symm
+      simp only [Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_mul_X_sub_C]
+      simpa using hcoeffS
+
+
+-- The remainder of synthetic division equals the evaluation `evalYPoly f Q`.
+-- This is the Horner-remainder identity; it falls out of `divByLinearY_spec` by
+-- evaluating the division identity at `Y = f.toPoly`.
+theorem divByLinearY_rem_eq_eval [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    (divByLinearY Q f).2 = evalYPoly f Q := by
+  -- Evaluate `toPoly Q = toPoly quot * (X - C f.toPoly) + C rem.toPoly` at `Y = f.toPoly`.
+  have hspec := divByLinearY_spec Q f
+  dsimp only at hspec
+  have hev := congrArg (Polynomial.eval f.toPoly) hspec
+  rw [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.eval_sub, Polynomial.eval_X,
+    Polynomial.eval_C, sub_self, mul_zero, zero_add, Polynomial.eval_C] at hev
+  -- hev : (toPoly Q).eval f.toPoly = (divByLinearY Q f).2.toPoly
+  apply CPolynomial.eq_iff_coeff.2
+  intro i
+  rw [CPolynomial.coeff_toPoly, CPolynomial.coeff_toPoly, evalYPoly_toPoly, hev]
 
 -- Follows from divByLinearY_rem_eq_eval + isLinearYFactor_iff:
 -- isLinearYFactor Q f = true ↔ evalYPoly f Q = 0, and rem = evalYPoly f Q

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -115,7 +115,25 @@ Alternatively, use `Polynomial.eq_of_dvd_of_degree_le_of_leadingCoeff` or
 theorem divByLinearY_rem_eq_eval [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     (divByLinearY Q f).2 = evalYPoly f Q := by
-  sorry
+  show (divByLinearY Q f).2 = Q.val.eval f
+  unfold divByLinearY natDegreeY
+  simp only []
+  split
+  · -- n = 0: Q has degree 0, so rem = coeff Q 0 = eval f Q
+    rename_i h
+    change CPolynomial.coeff Q 0 = CPolynomial.Raw.eval f Q.val
+    change CPolynomial.coeff Q 0 = CPolynomial.eval f Q
+    rw [CPolynomial.eval_toPoly]
+    have hnd : (CPolynomial.toPoly Q).natDegree = 0 := CPolynomial.natDegree_toPoly Q ▸ h
+    rw [Polynomial.eq_C_of_natDegree_eq_zero hnd, Polynomial.eval_C]
+    exact CPolynomial.coeff_toPoly Q 0
+  · -- n > 0: the fold computes Horner evaluation
+    -- Goal: a_0 + f * b_last = Q.val.eval f
+    -- where b_last is the result of folding from a_n down to a_1
+    -- Both sides compute Σ aⱼ fʲ; the fold does it top-down (Horner),
+    -- eval does it bottom-up (sum of powers).
+    rename_i h
+    sorry
 
 -- Step 2–4: main correctness theorem
 theorem divByLinearY_spec [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -111,38 +111,388 @@ Alternatively, use `Polynomial.eq_of_dvd_of_degree_le_of_leadingCoeff` or
 `divByMonic_eq_of_lt_and_lt` if available.
 -/
 
+-- Helper: fold on Q aligns with fold on divX Q via coeff_divX
+theorem divByLinearY_prefix_fold_eq_divX_fold [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (Q : CBivariate R) (f : CPolynomial R) (k : ℕ) :
+    List.foldl
+      (fun x k_1 =>
+        (CPolynomial.coeff Q (k + 1 - k_1) + f * x.1,
+          x.2.push (CPolynomial.coeff Q (k + 1 - k_1) + f * x.1)))
+      (CPolynomial.coeff Q (k + 2), #[CPolynomial.coeff Q (k + 2)])
+      (List.range k) =
+    List.foldl
+      (fun x k_1 =>
+        ((CPolynomial.divX Q).coeff (k - k_1) + f * x.1,
+          x.2.push ((CPolynomial.divX Q).coeff (k - k_1) + f * x.1)))
+      ((CPolynomial.divX Q).coeff (k + 1), #[(CPolynomial.divX Q).coeff (k + 1)])
+      (List.range k) := by
+  rw [show (CPolynomial.coeff Q (k + 2), #[CPolynomial.coeff Q (k + 2)]) =
+      ((CPolynomial.divX Q).coeff (k + 1), #[(CPolynomial.divX Q).coeff (k + 1)]) by
+    simpa using congrArg (fun c => (c, #[c]))
+      ((CPolynomial.coeff_divX (p := Q) (i := k + 1)).symm)]
+  apply List.foldl_ext
+  intro a i hi
+  rcases a with ⟨b, acc⟩
+  have hi' : i < k := List.mem_range.mp hi
+  have hidx : k + 1 - i = (k - i) + 1 := by omega
+  simpa [hidx] using congrArg (fun c => (c + f * b, acc.push (c + f * b)))
+    ((CPolynomial.coeff_divX (p := Q) (i := k - i)).symm)
+
+-- Helper: Horner step for evalYPoly via divX
+theorem evalYPoly_divX_step [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    evalYPoly f Q = CPolynomial.coeff Q 0 + f * evalYPoly f (CPolynomial.divX Q) := by
+  change CPolynomial.eval f Q =
+    CPolynomial.coeff Q 0 + f * CPolynomial.eval f (CPolynomial.divX Q)
+  conv_lhs => rw [CPolynomial.X_mul_divX_add (p := Q)]
+  rw [CPolynomial.eval_toPoly, CPolynomial.toPoly_add, Polynomial.eval_add]
+  rw [CPolynomial.toPoly_mul, Polynomial.eval_mul]
+  rw [CPolynomial.X_toPoly, Polynomial.eval_X]
+  rw [CPolynomial.C_toPoly, Polynomial.eval_C]
+  rw [← CPolynomial.eval_toPoly (x := f) (p := CPolynomial.divX Q)]
+  rw [add_comm]
+
+-- Helper: natDegreeY decreases under divX
+theorem natDegreeY_divX [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (Q : CBivariate R) :
+    natDegreeY (CPolynomial.divX Q) = natDegreeY Q - 1 := by
+  show CPolynomial.natDegree (CPolynomial.divX Q) = CPolynomial.natDegree Q - 1
+  rw [CPolynomial.natDegree_toPoly (p := CPolynomial.divX Q)]
+  rw [CPolynomial.divX_toPoly (p := Q)]
+  rw [Polynomial.natDegree_divX_eq_natDegree_tsub_one]
+  rw [← CPolynomial.natDegree_toPoly (p := Q)]
+
+-- Helper: remainder recursion via divX
+theorem divByLinearY_rem_recursion [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (Q : CBivariate R) (f : CPolynomial R) (hQ : natDegreeY Q ≠ 0) :
+    (divByLinearY Q f).2 =
+      CPolynomial.coeff Q 0 + f * (divByLinearY (CPolynomial.divX Q) f).2 := by
+  cases hdeg : natDegreeY Q with
+  | zero => exact (hQ hdeg).elim
+  | succ m =>
+    cases m with
+    | zero =>
+      have hdivdeg : natDegreeY (CPolynomial.divX Q) = 0 := by
+        simpa [hdeg] using (natDegreeY_divX (Q := Q))
+      rw [divByLinearY, hdeg, if_neg (Nat.succ_ne_zero 0)]
+      conv_rhs => rw [divByLinearY, hdivdeg, if_pos rfl]
+      change CPolynomial.coeff Q 0 + f * CPolynomial.coeff Q 1 =
+        CPolynomial.coeff Q 0 + f * CPolynomial.coeff (CPolynomial.divX Q) 0
+      rw [CPolynomial.coeff_divX]
+    | succ k =>
+      have hdeg' : natDegreeY Q = k + 2 := by
+        simpa [Nat.succ_eq_add_one, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using hdeg
+      have hdivdeg : natDegreeY (CPolynomial.divX Q) = k + 1 := by
+        simpa [hdeg', Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using
+          (natDegreeY_divX (Q := Q))
+      have hk2nz : k + 2 ≠ 0 := by omega
+      have hk1nz : k + 1 ≠ 0 := by omega
+      have hk21 : k + 2 - 1 = k + 1 := by omega
+      rw [divByLinearY, hdeg', if_neg hk2nz]
+      rw [hk21]
+      conv_rhs => rw [divByLinearY, hdivdeg, if_neg hk1nz]
+      change
+        CPolynomial.coeff Q 0 +
+            f *
+              (List.foldl
+                  (fun x k_1 =>
+                    (CPolynomial.coeff Q (k + 1 - k_1) + f * x.1,
+                      x.2.push (CPolynomial.coeff Q (k + 1 - k_1) + f * x.1)))
+                  (CPolynomial.coeff Q (k + 2), #[CPolynomial.coeff Q (k + 2)])
+                  (List.range (k + 1))).1
+          =
+        CPolynomial.coeff Q 0 +
+            f *
+              (CPolynomial.coeff (CPolynomial.divX Q) 0 +
+                f *
+                  (List.foldl
+                      (fun x k_1 =>
+                        (CPolynomial.coeff (CPolynomial.divX Q) (k - k_1) + f * x.1,
+                          x.2.push
+                            (CPolynomial.coeff (CPolynomial.divX Q) (k - k_1) + f * x.1)))
+                      (CPolynomial.coeff (CPolynomial.divX Q) (k + 1),
+                        #[CPolynomial.coeff (CPolynomial.divX Q) (k + 1)])
+                      (List.range k)).1)
+      congr 1
+      congr 1
+      rw [List.range_succ]
+      simp only [List.foldl_concat]
+      rw [divByLinearY_prefix_fold_eq_divX_fold (Q := Q) (f := f) (k := k)]
+      have hlast : k + 1 - k = 1 := by omega
+      rw [hlast]
+      have hcoeff0 : CPolynomial.coeff (CPolynomial.divX Q) 0 = CPolynomial.coeff Q 1 := by
+        simpa using (CPolynomial.coeff_divX (p := Q) (i := 0))
+      rw [hcoeff0]
+
 -- Step 1: remainder of synthetic division = evaluation at f
 theorem divByLinearY_rem_eq_eval [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     (divByLinearY Q f).2 = evalYPoly f Q := by
-  show (divByLinearY Q f).2 = Q.val.eval f
-  unfold divByLinearY natDegreeY
-  simp only []
-  split
-  · -- n = 0: Q has degree 0, so rem = coeff Q 0 = eval f Q
-    rename_i h
-    change CPolynomial.coeff Q 0 = CPolynomial.Raw.eval f Q.val
+  refine Nat.strong_induction_on
+    (p := fun n => ∀ Q : CBivariate R, Q.val.size = n →
+      (divByLinearY Q f).2 = evalYPoly f Q)
+    Q.val.size ?_ Q rfl
+  intro n ih Q hsize
+  by_cases hdeg : natDegreeY Q = 0
+  · rw [divByLinearY, if_pos hdeg]
     change CPolynomial.coeff Q 0 = CPolynomial.eval f Q
     rw [CPolynomial.eval_toPoly]
-    have hnd : (CPolynomial.toPoly Q).natDegree = 0 := CPolynomial.natDegree_toPoly Q ▸ h
-    rw [Polynomial.eq_C_of_natDegree_eq_zero hnd, Polynomial.eval_C]
-    exact CPolynomial.coeff_toPoly Q 0
-  · -- n > 0: the fold computes Horner evaluation
-    -- Goal: a_0 + f * b_last = Q.val.eval f
-    -- where b_last is the result of folding from a_n down to a_1
-    -- Both sides compute Σ aⱼ fʲ; the fold does it top-down (Horner),
-    -- eval does it bottom-up (sum of powers).
-    rename_i h
-    sorry
+    have hQnat : Q.natDegree = 0 := by
+      simpa [CBivariate.natDegreeY] using hdeg
+    have hdeg_toPoly : (CPolynomial.toPoly Q).natDegree = 0 := by
+      simpa [hQnat] using (CPolynomial.natDegree_toPoly (p := Q)).symm
+    rcases Polynomial.natDegree_eq_zero.mp hdeg_toPoly with ⟨a, ha⟩
+    have ha0 : a = (CPolynomial.toPoly Q).coeff 0 := by
+      have hcoeff := congrArg (fun p : Polynomial (CPolynomial R) => p.coeff 0) ha
+      simpa using hcoeff
+    rw [← ha, Polynomial.eval_C, CPolynomial.coeff_toPoly]
+    exact ha0.symm
+  · have hpos : 0 < Q.val.size := by
+      by_contra hzero
+      have hs : Q.val.size = 0 := Nat.eq_zero_of_not_pos hzero
+      have hval : Q.val = (#[] : CPolynomial.Raw (CPolynomial R)) :=
+        Array.eq_empty_of_size_eq_zero hs
+      have hQ0 : Q = 0 := by
+        apply CPolynomial.ext
+        simpa using hval
+      have hdeg0 : natDegreeY Q = 0 := by
+        rw [hQ0]
+        rfl
+      exact hdeg hdeg0
+    have hlt : (CPolynomial.divX Q).val.size < n := by
+      rw [← hsize]
+      exact CPolynomial.divX_size_lt Q hpos
+    have hrec := ih (CPolynomial.divX Q).val.size hlt (CPolynomial.divX Q) rfl
+    rw [divByLinearY_rem_recursion Q f hdeg]
+    rw [hrec]
+    exact (evalYPoly_divX_step Q f).symm
 
--- Step 2–4: main correctness theorem
+-- Helpers for divByLinearY_spec (coefficient-by-coefficient approach)
+
+theorem divByLinearY_const [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (a : CPolynomial R) (f : CPolynomial R) :
+    divByLinearY (CPolynomial.C a : CBivariate R) f = (0, a) := by
+  unfold divByLinearY
+  have hdeg : natDegreeY (CPolynomial.C a : CBivariate R) = 0 := by
+    rw [CBivariate.natDegreeY, CPolynomial.natDegree_toPoly, CPolynomial.C_toPoly]
+    by_cases ha : a = 0
+    · subst ha; simp only [map_zero, Polynomial.natDegree_zero]
+    · simp [ha]
+  simp [hdeg]
+  simpa [CPolynomial.coeff] using (CPolynomial.coeff_C (R := CPolynomial R) (r := a) (i := 0))
+
+theorem divByLinearY_fold_split [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) (h : 1 < natDegreeY Q) :
+    let n := natDegreeY Q
+    let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
+    let step : CPolynomial R × Array (CPolynomial R) → ℕ →
+        CPolynomial R × Array (CPolynomial R) :=
+      fun x k =>
+        let bj := a (n - 1 - k) + f * x.1
+        (bj, x.2.push bj)
+    let res1 := (List.range (n - 2)).foldl step (a n, #[(a n)])
+    (List.range (n - 1)).foldl step (a n, #[(a n)]) =
+      (a 1 + f * res1.1, res1.2.push (a 1 + f * res1.1)) := by
+  dsimp
+  rw [show natDegreeY Q - 1 = (natDegreeY Q - 2) + 1 by omega]
+  rw [List.range_succ]
+  rw [List.foldl_append]
+  simp only [List.foldl_cons, List.foldl_nil]
+  congr <;> omega
+
+theorem divByLinearY_quot_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) (h : natDegreeY Q = 1) :
+    (divByLinearY Q f).1 = CPolynomial.C (CPolynomial.coeff Q 1) := by
+  simp [divByLinearY, h, CPolynomial.C]
+  rfl
+
+theorem divX_zero_of_natDegreeY_zero [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R]
+    (Q : CBivariate R) (h : natDegreeY Q = 0) :
+    CPolynomial.divX Q = 0 := by
+  rw [CPolynomial.eq_zero_iff_coeff_zero]
+  intro i
+  rw [CPolynomial.coeff_divX]
+  apply (CPolynomial.toPoly_eq_zero_iff (p := CPolynomial.coeff Q (i + 1))).mp
+  rw [← CBivariate.toPoly_coeff]
+  have hdeg : (toPoly Q).natDegree = 0 := by
+    rw [CBivariate.natDegreeY_toPoly, h]
+  exact Polynomial.coeff_eq_zero_of_natDegree_lt (by rw [hdeg]; omega)
+
+theorem divX_eq_C_coeff_one_of_natDegreeY_one [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R]
+    (Q : CBivariate R) (h : natDegreeY Q = 1) :
+    CPolynomial.divX Q = CPolynomial.C (CPolynomial.coeff Q 1) := by
+  apply CPolynomial.eq_iff_coeff.mpr
+  intro i
+  rw [CPolynomial.coeff_divX, CPolynomial.coeff_C]
+  cases i with
+  | zero => simp
+  | succ k =>
+    have hdeg : (CBivariate.toPoly Q).natDegree = 1 := by
+      simpa [h] using (CBivariate.natDegreeY_toPoly (f := Q))
+    have hlt : (CBivariate.toPoly Q).natDegree < k + 2 := by
+      rw [hdeg]; omega
+    have hzero_toPoly : (CPolynomial.coeff Q (k + 2)).toPoly = 0 := by
+      simpa [CBivariate.toPoly_coeff] using
+        (Polynomial.coeff_eq_zero_of_natDegree_lt
+          (p := CBivariate.toPoly Q) (n := k + 2) hlt)
+    have hzero : CPolynomial.coeff Q (k + 2) = 0 := by
+      exact (CPolynomial.toPoly_eq_zero_iff (CPolynomial.coeff Q (k + 2))).mp hzero_toPoly
+    simpa using hzero
+
+theorem raw_trim_reverse_push_coeff_succ {S : Type*} [Zero S] [BEq S] [LawfulBEq S]
+    (arr : Array S) (a : S) (j : ℕ) :
+    CPolynomial.Raw.coeff (CPolynomial.Raw.trim ((arr.push a).reverse)) (j + 1) =
+      CPolynomial.Raw.coeff (CPolynomial.Raw.trim (arr.reverse)) j := by
+  rw [CPolynomial.Raw.Trim.coeff_eq_coeff, CPolynomial.Raw.Trim.coeff_eq_coeff]
+  rw [Array.reverse_push]
+  unfold CPolynomial.Raw.coeff
+  rw [Array.getD_eq_getD_getElem?, Array.getD_eq_getD_getElem?]
+  have h1 : (#[a] : Array S).size ≤ j + 1 := by simp
+  rw [Array.getElem?_append_right (xs := #[a]) (ys := arr.reverse) (i := j + 1) h1]
+  simp
+
+theorem raw_trim_reverse_push_coeff_zero {S : Type*} [Zero S] [BEq S] [LawfulBEq S]
+    (arr : Array S) (a : S) :
+    CPolynomial.Raw.coeff (CPolynomial.Raw.trim ((arr.push a).reverse)) 0 = a := by
+  rw [CPolynomial.Raw.Trim.coeff_eq_coeff]
+  rw [Array.reverse_push]
+  simp [CPolynomial.Raw.coeff, Array.getD_eq_getD_getElem?]
+
+theorem divByLinearY_rem_formula [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    let quot := (divByLinearY Q f).1
+    let rem := (divByLinearY Q f).2
+    rem = CPolynomial.coeff Q 0 + f * CPolynomial.coeff quot 0 := by
+  unfold divByLinearY
+  by_cases h0 : natDegreeY Q = 0
+  · simp [h0]
+    change f * ((0 : CPolynomial.Raw (CPolynomial R)).coeff 0) = 0
+    simp [CPolynomial.Raw.coeff]
+  · simp [h0]
+    let n := Q.natDegreeY
+    let a : ℕ → CPolynomial R := fun j => CPolynomial.coeff Q j
+    let step : CPolynomial R × Array (CPolynomial R) → ℕ →
+        CPolynomial R × Array (CPolynomial R) :=
+      fun x k =>
+        let bj := a (n - 1 - k) + f * x.1
+        (bj, x.2.push bj)
+    let res := (List.range (n - 1)).foldl step (a n, #[a n])
+    have hfold : ∀ l (b : CPolynomial R) (acc : Array (CPolynomial R)),
+        ((List.foldl step (b, acc.push b) l).2.reverse)[0]?.getD 0 =
+          (List.foldl step (b, acc.push b) l).1 := by
+      intro l
+      induction l with
+      | nil =>
+        intro b acc
+        simp [step]
+      | cons k l ih =>
+        intro b acc
+        simpa [List.foldl_cons, step] using ih (a (n - 1 - k) + f * b) (acc.push b)
+    have hres : (res.2.reverse)[0]?.getD 0 = res.1 := by
+      simpa [res, step] using hfold (List.range (n - 1)) (a n) (#[])
+    have htrim0 : (CPolynomial.Raw.trim res.2.reverse)[0]?.getD 0 =
+        (res.2.reverse)[0]?.getD 0 := by
+      simpa [CPolynomial.Raw.coeff] using
+        (CPolynomial.Raw.Trim.coeff_eq_coeff (res.2.reverse) 0)
+    have hmain : f * res.1 = f * (CPolynomial.Raw.trim res.2.reverse)[0]?.getD 0 := by
+      rw [htrim0, hres]
+    simpa [n, a, step, res] using hmain
+
+-- Key: coefficient j of divX-quotient = coefficient j+1 of original quotient
+theorem divByLinearY_divX_quot_coeff [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
+    let quot := (divByLinearY Q f).1
+    CPolynomial.coeff ((divByLinearY (CPolynomial.divX Q) f).1) j =
+      CPolynomial.coeff quot (j + 1) := by
+  sorry
+
+-- Key: remainder of divX-division = coefficient 0 of original quotient
+theorem divByLinearY_divX_rem [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    let quot := (divByLinearY Q f).1
+    (divByLinearY (CPolynomial.divX Q) f).2 = CPolynomial.coeff quot 0 := by
+  sorry
+
+theorem divByLinearY_quot_recurrence [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
+    let quot := (divByLinearY Q f).1
+    CPolynomial.coeff quot j =
+      CPolynomial.coeff Q (j + 1) + f * CPolynomial.coeff quot (j + 1) := by
+  dsimp
+  induction j generalizing Q with
+  | zero =>
+    have h := divByLinearY_rem_formula (Q := CPolynomial.divX Q) (f := f)
+    dsimp at h
+    rw [divByLinearY_divX_rem (Q := Q) (f := f)] at h
+    rw [divByLinearY_divX_quot_coeff (Q := Q) (f := f) 0] at h
+    rw [CPolynomial.coeff_divX] at h
+    simpa using h
+  | succ j ih =>
+    have h := ih (Q := CPolynomial.divX Q)
+    rw [divByLinearY_divX_quot_coeff (Q := Q) (f := f) j,
+      divByLinearY_divX_quot_coeff (Q := Q) (f := f) (j + 1),
+      CPolynomial.coeff_divX] at h
+    simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using h
+
+theorem divByLinearY_coeff_zero [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    let quot := (divByLinearY Q f).1
+    let rem := (divByLinearY Q f).2
+    (toPoly Q).coeff 0 = rem.toPoly - (toPoly quot).coeff 0 * f.toPoly := by
+  dsimp
+  let quot := (divByLinearY Q f).1
+  let rem := (divByLinearY Q f).2
+  have hrem := divByLinearY_rem_formula Q f
+  dsimp at hrem
+  have hrem' := congrArg CPolynomial.toPoly hrem
+  rw [CPolynomial.toPoly_add, CPolynomial.toPoly_mul] at hrem'
+  rw [CBivariate.toPoly_coeff, CBivariate.toPoly_coeff]
+  rw [hrem']
+  ring_nf
+
+theorem divByLinearY_coeff_succ [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) (j : ℕ) :
+    let quot := (divByLinearY Q f).1
+    (toPoly Q).coeff (j + 1) =
+      (toPoly quot).coeff j - (toPoly quot).coeff (j + 1) * f.toPoly := by
+  classical
+  dsimp
+  let quot := (divByLinearY Q f).1
+  have hraw : CPolynomial.coeff quot j =
+      CPolynomial.coeff Q (j + 1) + f * CPolynomial.coeff quot (j + 1) := by
+    simpa [quot] using divByLinearY_quot_recurrence (Q := Q) (f := f) (j := j)
+  have hpoly : (toPoly quot).coeff j =
+      (toPoly Q).coeff (j + 1) + f.toPoly * (toPoly quot).coeff (j + 1) := by
+    rw [CBivariate.toPoly_coeff, CBivariate.toPoly_coeff, CBivariate.toPoly_coeff]
+    simpa [CPolynomial.toPoly_add, CPolynomial.toPoly_mul] using
+      congrArg CPolynomial.toPoly hraw
+  rw [eq_sub_iff_add_eq]
+  simpa [quot, mul_comm] using hpoly.symm
+
+-- Step 2-4: main correctness theorem
 theorem divByLinearY_spec [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     let quot := (divByLinearY Q f).1
     let rem := (divByLinearY Q f).2
     toPoly Q = toPoly quot * (Polynomial.X - Polynomial.C (f.toPoly)) +
         Polynomial.C (rem.toPoly) := by
-  sorry
+  dsimp
+  apply Polynomial.ext
+  intro n
+  cases n with
+  | zero =>
+    simp only [Polynomial.coeff_add, Polynomial.mul_coeff_zero, Polynomial.coeff_C,
+      Polynomial.coeff_X_zero, sub_eq_add_neg, add_comm]
+    simpa [sub_eq_add_neg, add_comm] using
+      divByLinearY_coeff_zero Q f
+  | succ j =>
+    simp only [Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_mul_X_sub_C]
+    simpa using divByLinearY_coeff_succ Q f j
 
 -- Follows from divByLinearY_rem_eq_eval + isLinearYFactor_iff:
 -- isLinearYFactor Q f = true ↔ evalYPoly f Q = 0, and rem = evalYPoly f Q

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -80,6 +80,60 @@ def divByLinearY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     let quotArr : CPolynomial.Raw (CPolynomial R) := coeffs.reverse
     (⟨quotArr.trim, CPolynomial.Raw.Trim.isCanonical_trim quotArr⟩, rem)
 
+/-
+Proof strategy for divByLinearY_spec (approach A — via Mathlib division theorem):
+
+Step 1: Prove `divByLinearY_rem_eq_eval`: the remainder of synthetic division
+equals `evalYPoly f Q`. Both compute Σ aⱼ fʲ (Horner's method = synthetic
+division remainder). This is an induction on the fold, showing the running
+accumulator `b` satisfies `b = Σ_{j≥k} a_j * f^{j-k}` after processing
+coefficient k.
+
+Step 2: Combine `divByLinearY_rem_eq_eval` with `evalYPoly_toPoly` to get
+  `rem.toPoly = (toPoly Q).eval (f.toPoly)`
+which is also
+  `rem.toPoly = ((toPoly Q) %ₘ (X - C f.toPoly)).coeff 0`  (by modByMonic_X_sub_C_eq_C_eval)
+
+Step 3: Use Mathlib's `modByMonic_add_div` to get
+  `toPoly Q = (X - C f.toPoly) * ((toPoly Q) /ₘ (X - C f.toPoly)) + C ((toPoly Q).eval f.toPoly)`
+
+Step 4: Subtract our decomposition from the Mathlib decomposition. This gives
+  `(toPoly quot - (toPoly Q) /ₘ (X - C f.toPoly)) * (X - C f.toPoly) = 0`
+Since `X - C f.toPoly` is monic (hence nonzero), and `R[X]` is an integral
+domain (assuming `IsDomain R`), the other factor is zero, proving
+  `toPoly quot = (toPoly Q) /ₘ (X - C f.toPoly)`
+and thus the spec.
+
+Note: Step 4 uses `IsDomain R` (or `IsDomain R[X]`). If we want to avoid that,
+the alternative is to show `degree (toPoly quot) < degree (X - C f.toPoly)` is
+impossible, so the factor must be zero by Mathlib's uniqueness of divByMonic.
+Alternatively, use `Polynomial.eq_of_dvd_of_degree_le_of_leadingCoeff` or
+`divByMonic_eq_of_lt_and_lt` if available.
+-/
+
+-- Step 1: remainder of synthetic division = evaluation at f
+theorem divByLinearY_rem_eq_eval [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    (divByLinearY Q f).2 = evalYPoly f Q := by
+  sorry
+
+-- Step 2–4: main correctness theorem
+theorem divByLinearY_spec [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    let quot := (divByLinearY Q f).1
+    let rem := (divByLinearY Q f).2
+    toPoly Q = toPoly quot * (Polynomial.X - Polynomial.C (f.toPoly)) +
+        Polynomial.C (rem.toPoly) := by
+  sorry
+
+-- Follows from divByLinearY_rem_eq_eval + isLinearYFactor_iff:
+-- isLinearYFactor Q f = true ↔ evalYPoly f Q = 0, and rem = evalYPoly f Q
+theorem divByLinearY_exact [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) (h : isLinearYFactor Q f = true) :
+    (divByLinearY Q f).2 = 0 := by
+  rw [divByLinearY_rem_eq_eval]
+  exact (isLinearYFactor_iff Q f).mp h
+
 end CBivariate
 
 end CompPoly

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -14,10 +14,19 @@ import Mathlib.Algebra.Polynomial.Degree.Operations
 /-!
 # Factorisation of Computable Bivariate Polynomials
 
-Defines `evalYPoly` (substitute Y ↦ f(X)), `isLinearYFactor` (check
-divisibility by Y - f(X)), and `divByLinearY` (synthetic division in Y).
-These operations support the Roth-Ruckenstein root-finding step in
-Guruswami–Sudan interpolation.
+Defines `evalYPoly` (substitute `Y ↦ f(X)`), `isLinearYFactor` (test
+divisibility by `Y - f(X)`), and `divByLinearY` (synthetic division of a
+bivariate polynomial by the monic linear factor `Y - f(X)`).
+
+`divByLinearY` is the computable factor theorem for the nested representation
+`CBivariate R = CPolynomial (CPolynomial R)`: given a root `f(X)`, it deflates
+`Q` by `Y - f(X)` over an arbitrary commutative ring (no field required). It is
+the degree-one special case of monic Euclidean division; division by an
+arbitrary monic divisor in `Y` is available generically through
+`CPolynomial.divByMonic` / `CPolynomial.modByMonic` over the coefficient ring
+`CPolynomial R` (see `CPolynomial.modByMonic_add_mul_divByMonic`). These are
+general-purpose primitives — root deflation, multiplicity, and Euclidean
+reduction all build on them, independently of any particular decoding algorithm.
 -/
 
 namespace CompPoly
@@ -31,8 +40,7 @@ def evalYPoly [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
   Q.val.eval f
 
 /-- Decide whether `Y - f(X)` divides `Q`, i.e. whether `Q(X, f(X)) = 0`. By the
-factor theorem this is exactly the divisibility test used in the Roth–Ruckenstein
-root-finding step. -/
+factor theorem this is exactly the test for `f(X)` being a `Y`-root of `Q`. -/
 def isLinearYFactor [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) : Bool :=
   evalYPoly f Q == 0

--- a/CompPoly/Bivariate/FactorMonic.lean
+++ b/CompPoly/Bivariate/FactorMonic.lean
@@ -7,79 +7,23 @@ import CompPoly.Bivariate.Factor
 import CompPoly.Univariate.DivisionCorrectness
 
 /-!
-# Bridge: synthetic linear division vs. general monic division (WORK IN PROGRESS)
+# Bridge: synthetic linear division equals general monic division
 
-This file states — but does **not** yet prove — that the bespoke synthetic
-division `divByLinearY Q f` (Horner) coincides with general monic Euclidean
-division of `Q` by the linear factor `Y - f`, using the now-`CommRing`-general
-`CPolynomial.divByMonic` / `CPolynomial.modByMonic` at the coefficient ring
-`CPolynomial R` (recall `CBivariate R = CPolynomial (CPolynomial R)`).
+Proves that the bespoke synthetic division `divByLinearY Q f` (Horner) coincides
+with general monic Euclidean division of `Q` by the linear factor `Y - f`, using
+the `CommRing`-general `CPolynomial.divByMonic` / `CPolynomial.modByMonic` at the
+coefficient ring `CPolynomial R` (recall `CBivariate R = CPolynomial (CPolynomial R)`).
 
-The two sorried theorems below are the handoff target. Once proved, the root
-API (`evalYPoly`, `isLinearYFactor`, `divByLinearY_exact`, the remainder/
-evaluation identity) can be re-expressed on top of `divByMonic`, and the
-question of whether to retire `divByLinearY` reduces to a pure benchmark.
+`divByLinearY_eq_divByMonic` shows the quotient equals `(divByLinearY Q f).1` and
+the remainder equals `CPolynomial.C (divByLinearY Q f).2`, so `divByLinearY` is a
+verified fast path for division by `Y - f`.
 
-This module is intentionally **not** registered in `CompPoly.lean` (it contains
-`sorry`); build it directly with
-`lake build CompPoly.Bivariate.FactorMonic`.
-
-## Why it is nontrivial
-
-There are two *different* `toPoly` bridges in play, and the proof has to cross
-between them:
-
-* `CBivariate.toPoly : CBivariate R → R[X][Y]` — used by `divByLinearY_spec`
-  (coefficients are genuine Mathlib `R[X]`).
-* `CPolynomial.toPoly : CPolynomial (CPolynomial R) → (CPolynomial R)[Y]` — used
-  by `divByMonic_toPoly_eq_divByMonic` (coefficients are the *computable*
-  `CPolynomial R`).
-
-They are related by mapping the coefficient ring through the ring isomorphism
-`CPolynomial.ringEquiv : CPolynomial R ≃+* R[X]` coefficientwise; see
-`CBivariate.toPoly_eq_map` and the pattern in `CBivariate.evalYPoly_toPoly`.
-
-## Recommended proof strategy
-
-Prefer the *uniqueness of monic division* route, staying at the
-`CPolynomial.toPoly` level (avoids one of the two bridges):
-
-1. `linearYDivisor_monic`: show `Y - f` is monic. Working at `CPolynomial.toPoly`
-   (into `(CPolynomial R)[Y]`), its image is `Polynomial.X - Polynomial.C f`
-   (coefficient `f : CPolynomial R`, *not* `f.toPoly`), monic of degree `1`
-   (`Polynomial.monic_X_sub_C`). `CPolynomial.monic` ↔ `.toPoly.Monic` is
-   `CPolynomial.monic_toPoly_iff`; combine with `CPolynomial.toPoly_sub`,
-   `CPolynomial.X_toPoly`, `CPolynomial.C_toPoly`.
-2. Establish the ring-level Euclidean identity in `CBivariate R`:
-   `Q = linearYDivisor f * (divByLinearY Q f).1 + CPolynomial.C (divByLinearY Q f).2`.
-   The cleanest source is the coefficient-level facts already proved in
-   `Factor.lean` — `divByLinearY_quot_recurrence` and `divByLinearY_rem_formula`
-   — fed through `CPolynomial.eq_iff_coeff`; alternatively recover it from
-   `divByLinearY_spec` by injectivity of `CBivariate.toPoly`.
-3. Apply `CPolynomial.toPoly` to that identity and use
-   `Polynomial.div_modByMonic_unique` (the remainder `C (divByLinearY Q f).2`
-   has `Y`-degree `0 < 1`, so `degree (C rem).toPoly < degree (Y - f).toPoly`)
-   to identify the quotient with `Q.toPoly /ₘ (Y-f).toPoly` and the remainder
-   with `Q.toPoly %ₘ (Y-f).toPoly`.
-4. Rewrite those with `CPolynomial.divByMonic_toPoly_eq_divByMonic` /
-   `CPolynomial.modByMonic_toPoly_eq_modByMonic`, then conclude the
-   `CBivariate`-level equalities by `CPolynomial.eq_iff_coeff` +
-   `CPolynomial.coeff_toPoly` (the same injectivity trick used in
-   `CPolynomial.modByMonic_add_mul_divByMonic`).
-
-## Useful lemmas
-
-`CPolynomial.divByMonic_toPoly_eq_divByMonic`,
-`CPolynomial.modByMonic_toPoly_eq_modByMonic`,
-`CPolynomial.modByMonic_add_mul_divByMonic`, `CPolynomial.monic_toPoly_iff`,
-`CPolynomial.eq_iff_coeff`, `CPolynomial.coeff_toPoly`,
-`Polynomial.div_modByMonic_unique`, `Polynomial.monic_X_sub_C`,
-`CPolynomial.toPoly_sub`, `CPolynomial.X_toPoly`, `CPolynomial.C_toPoly`,
-`CBivariate.divByLinearY_spec`, `CBivariate.divByLinearY_rem_eq_eval`,
-`CBivariate.divByLinearY_quot_recurrence`, `CBivariate.divByLinearY_rem_formula`,
-`CBivariate.toPoly_eq_map`.
-
-## Done = no `sorry`; the file builds; the two theorems hold.
+The proof works in the outer polynomial ring `(CPolynomial R)[Y]` (the image of
+`CPolynomial.toPoly`): it rewrites the divisor as `X - C f`
+(`linearYDivisor_toPoly`), establishes the Euclidean identity by transporting
+`divByLinearY_spec` across the coefficient ring-equiv
+(`divByLinearY_euclid_toPoly`), and concludes via
+`Polynomial.div_modByMonic_unique`.
 -/
 
 namespace CompPoly
@@ -95,22 +39,82 @@ def linearYDivisor [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
   -- `CPolynomial.X` at this nested type is `Y`; it is defeq to `CBivariate.X`.
   (CPolynomial.X : CPolynomial (CPolynomial R)) - CPolynomial.C f
 
-/-- TODO (aleph): the linear divisor `Y - f` is monic. -/
+/-- `toPoly` sends the linear divisor `Y - f` to `X - C f` in `(CPolynomial R)[Y]`. -/
+theorem linearYDivisor_toPoly [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (f : CPolynomial R) :
+    CPolynomial.toPoly (linearYDivisor f) = Polynomial.X - Polynomial.C f := by
+  simpa [linearYDivisor, CPolynomial.X_toPoly, CPolynomial.C_toPoly] using
+    (CPolynomial.toPoly_sub (p := (CPolynomial.X : CPolynomial (CPolynomial R)))
+      (q := CPolynomial.C f))
+
+/-- The linear divisor `Y - f` is monic. -/
 theorem linearYDivisor_monic [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (f : CPolynomial R) :
     CPolynomial.monic (linearYDivisor f) = true := by
-  sorry
+  have hpoly := linearYDivisor_toPoly (R := R) f
+  have hmonic : (CPolynomial.toPoly (linearYDivisor f)).Monic := by
+    rw [hpoly]
+    exact Polynomial.monic_X_sub_C f
+  exact (CPolynomial.monic_toPoly_iff (linearYDivisor f)).2 hmonic
 
-/-- TODO (aleph): the bespoke synthetic division `divByLinearY` agrees with
-general monic division by `Y - f`. The quotient matches `divByMonic`, and the
-constant-in-`Y` remainder `C (divByLinearY Q f).2` matches `modByMonic`. -/
-theorem divByLinearY_eq_divByMonic
+/-- Euclidean identity for `divByLinearY` in the outer ring `(CPolynomial R)[Y]`:
+`C rem + (Y - f) * quot = Q` after `toPoly`. Transports `divByLinearY_spec`
+across the coefficient ring-equiv. -/
+theorem divByLinearY_euclid_toPoly
     [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    (CPolynomial.C (divByLinearY Q f).2).toPoly
+        + CPolynomial.toPoly (linearYDivisor f) * CPolynomial.toPoly ((divByLinearY Q f).1)
+      = CPolynomial.toPoly Q := by
+  let e := (CPolynomial.ringEquiv (R := R)).toRingHom
+  apply Polynomial.map_injective e (CPolynomial.ringEquiv (R := R)).injective
+  rw [Polynomial.map_add, Polynomial.map_mul, CPolynomial.C_toPoly,
+    linearYDivisor_toPoly (R := R) f]
+  simp only [Polynomial.map_C, Polynomial.map_sub, Polynomial.map_X]
+  simpa [e, CBivariate.toPoly_eq_map, mul_comm, add_comm, add_left_comm, add_assoc] using
+    (divByLinearY_spec Q f).symm
+
+/-- The bespoke synthetic division `divByLinearY` agrees with general monic
+division by `Y - f`: the quotient matches `divByMonic`, and the constant-in-`Y`
+remainder `C (divByLinearY Q f).2` matches `modByMonic`. -/
+theorem divByLinearY_eq_divByMonic [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (Q : CBivariate R) (f : CPolynomial R) :
     CPolynomial.divByMonic Q (linearYDivisor f) = (divByLinearY Q f).1
       ∧ CPolynomial.modByMonic Q (linearYDivisor f)
           = CPolynomial.C (divByLinearY Q f).2 := by
-  sorry
+  let g := linearYDivisor f
+  let q := (divByLinearY Q f).1
+  let r := (divByLinearY Q f).2
+  have hg : CPolynomial.monic g := by
+    simpa [g] using linearYDivisor_monic (R := R) f
+  have hg_toPoly : (CPolynomial.toPoly g).Monic :=
+    (CPolynomial.monic_toPoly_iff g).1 hg
+  have he : (CPolynomial.C r).toPoly + CPolynomial.toPoly g * CPolynomial.toPoly q
+      = CPolynomial.toPoly Q := by
+    simpa [g, q, r] using divByLinearY_euclid_toPoly (R := R) Q f
+  have hdeg : ((CPolynomial.C r).toPoly).degree < (CPolynomial.toPoly g).degree := by
+    rw [CPolynomial.C_toPoly, linearYDivisor_toPoly (R := R) f]
+    by_cases hr : r = 0 <;> simp [hr, Polynomial.degree_X_sub_C]
+  have huniq := Polynomial.div_modByMonic_unique
+      (f := CPolynomial.toPoly Q) (g := CPolynomial.toPoly g)
+      (q := CPolynomial.toPoly q) (r := (CPolynomial.C r).toPoly)
+      hg_toPoly ⟨he, hdeg⟩
+  have hdiv : CPolynomial.toPoly (CPolynomial.divByMonic Q g) = CPolynomial.toPoly q := by
+    rw [CPolynomial.divByMonic_toPoly_eq_divByMonic Q g hg]
+    exact huniq.1
+  have hmod : CPolynomial.toPoly (CPolynomial.modByMonic Q g)
+      = CPolynomial.toPoly (CPolynomial.C r) := by
+    rw [CPolynomial.modByMonic_toPoly_eq_modByMonic Q g hg]
+    exact huniq.2
+  constructor
+  · apply CPolynomial.eq_iff_coeff.2
+    intro i
+    have hi := congrArg (fun p : Polynomial (CPolynomial R) => p.coeff i) hdiv
+    simpa only [CPolynomial.coeff_toPoly, g, q] using hi
+  · apply CPolynomial.eq_iff_coeff.2
+    intro i
+    have hi := congrArg (fun p : Polynomial (CPolynomial R) => p.coeff i) hmod
+    simpa only [CPolynomial.coeff_toPoly, g, r] using hi
 
 end CBivariate
 

--- a/CompPoly/Bivariate/FactorMonic.lean
+++ b/CompPoly/Bivariate/FactorMonic.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+import CompPoly.Bivariate.Factor
+import CompPoly.Univariate.DivisionCorrectness
+
+/-!
+# Bridge: synthetic linear division vs. general monic division (WORK IN PROGRESS)
+
+This file states — but does **not** yet prove — that the bespoke synthetic
+division `divByLinearY Q f` (Horner) coincides with general monic Euclidean
+division of `Q` by the linear factor `Y - f`, using the now-`CommRing`-general
+`CPolynomial.divByMonic` / `CPolynomial.modByMonic` at the coefficient ring
+`CPolynomial R` (recall `CBivariate R = CPolynomial (CPolynomial R)`).
+
+The two sorried theorems below are the handoff target. Once proved, the root
+API (`evalYPoly`, `isLinearYFactor`, `divByLinearY_exact`, the remainder/
+evaluation identity) can be re-expressed on top of `divByMonic`, and the
+question of whether to retire `divByLinearY` reduces to a pure benchmark.
+
+This module is intentionally **not** registered in `CompPoly.lean` (it contains
+`sorry`); build it directly with
+`lake build CompPoly.Bivariate.FactorMonic`.
+
+## Why it is nontrivial
+
+There are two *different* `toPoly` bridges in play, and the proof has to cross
+between them:
+
+* `CBivariate.toPoly : CBivariate R → R[X][Y]` — used by `divByLinearY_spec`
+  (coefficients are genuine Mathlib `R[X]`).
+* `CPolynomial.toPoly : CPolynomial (CPolynomial R) → (CPolynomial R)[Y]` — used
+  by `divByMonic_toPoly_eq_divByMonic` (coefficients are the *computable*
+  `CPolynomial R`).
+
+They are related by mapping the coefficient ring through the ring isomorphism
+`CPolynomial.ringEquiv : CPolynomial R ≃+* R[X]` coefficientwise; see
+`CBivariate.toPoly_eq_map` and the pattern in `CBivariate.evalYPoly_toPoly`.
+
+## Recommended proof strategy
+
+Prefer the *uniqueness of monic division* route, staying at the
+`CPolynomial.toPoly` level (avoids one of the two bridges):
+
+1. `linearYDivisor_monic`: show `Y - f` is monic. Working at `CPolynomial.toPoly`
+   (into `(CPolynomial R)[Y]`), its image is `Polynomial.X - Polynomial.C f`
+   (coefficient `f : CPolynomial R`, *not* `f.toPoly`), monic of degree `1`
+   (`Polynomial.monic_X_sub_C`). `CPolynomial.monic` ↔ `.toPoly.Monic` is
+   `CPolynomial.monic_toPoly_iff`; combine with `CPolynomial.toPoly_sub`,
+   `CPolynomial.X_toPoly`, `CPolynomial.C_toPoly`.
+2. Establish the ring-level Euclidean identity in `CBivariate R`:
+   `Q = linearYDivisor f * (divByLinearY Q f).1 + CPolynomial.C (divByLinearY Q f).2`.
+   The cleanest source is the coefficient-level facts already proved in
+   `Factor.lean` — `divByLinearY_quot_recurrence` and `divByLinearY_rem_formula`
+   — fed through `CPolynomial.eq_iff_coeff`; alternatively recover it from
+   `divByLinearY_spec` by injectivity of `CBivariate.toPoly`.
+3. Apply `CPolynomial.toPoly` to that identity and use
+   `Polynomial.div_modByMonic_unique` (the remainder `C (divByLinearY Q f).2`
+   has `Y`-degree `0 < 1`, so `degree (C rem).toPoly < degree (Y - f).toPoly`)
+   to identify the quotient with `Q.toPoly /ₘ (Y-f).toPoly` and the remainder
+   with `Q.toPoly %ₘ (Y-f).toPoly`.
+4. Rewrite those with `CPolynomial.divByMonic_toPoly_eq_divByMonic` /
+   `CPolynomial.modByMonic_toPoly_eq_modByMonic`, then conclude the
+   `CBivariate`-level equalities by `CPolynomial.eq_iff_coeff` +
+   `CPolynomial.coeff_toPoly` (the same injectivity trick used in
+   `CPolynomial.modByMonic_add_mul_divByMonic`).
+
+## Useful lemmas
+
+`CPolynomial.divByMonic_toPoly_eq_divByMonic`,
+`CPolynomial.modByMonic_toPoly_eq_modByMonic`,
+`CPolynomial.modByMonic_add_mul_divByMonic`, `CPolynomial.monic_toPoly_iff`,
+`CPolynomial.eq_iff_coeff`, `CPolynomial.coeff_toPoly`,
+`Polynomial.div_modByMonic_unique`, `Polynomial.monic_X_sub_C`,
+`CPolynomial.toPoly_sub`, `CPolynomial.X_toPoly`, `CPolynomial.C_toPoly`,
+`CBivariate.divByLinearY_spec`, `CBivariate.divByLinearY_rem_eq_eval`,
+`CBivariate.divByLinearY_quot_recurrence`, `CBivariate.divByLinearY_rem_formula`,
+`CBivariate.toPoly_eq_map`.
+
+## Done = no `sorry`; the file builds; the two theorems hold.
+-/
+
+namespace CompPoly
+
+namespace CBivariate
+
+variable {R : Type*}
+
+/-- The linear monic divisor `Y - f`, as a bivariate polynomial
+(`CBivariate R = CPolynomial (CPolynomial R)`). -/
+def linearYDivisor [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (f : CPolynomial R) : CBivariate R :=
+  -- `CPolynomial.X` at this nested type is `Y`; it is defeq to `CBivariate.X`.
+  (CPolynomial.X : CPolynomial (CPolynomial R)) - CPolynomial.C f
+
+/-- TODO (aleph): the linear divisor `Y - f` is monic. -/
+theorem linearYDivisor_monic [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (f : CPolynomial R) :
+    CPolynomial.monic (linearYDivisor f) = true := by
+  sorry
+
+/-- TODO (aleph): the bespoke synthetic division `divByLinearY` agrees with
+general monic division by `Y - f`. The quotient matches `divByMonic`, and the
+constant-in-`Y` remainder `C (divByLinearY Q f).2` matches `modByMonic`. -/
+theorem divByLinearY_eq_divByMonic
+    [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (Q : CBivariate R) (f : CPolynomial R) :
+    CPolynomial.divByMonic Q (linearYDivisor f) = (divByLinearY Q f).1
+      ∧ CPolynomial.modByMonic Q (linearYDivisor f)
+          = CPolynomial.C (divByLinearY Q f).2 := by
+  sorry
+
+end CBivariate
+
+end CompPoly

--- a/CompPoly/Univariate/Basic.lean
+++ b/CompPoly/Univariate/Basic.lean
@@ -783,12 +783,14 @@ lemma leadingCoeff_ne_zero [Zero R] [BEq R] [LawfulBEq R] {p : CPolynomial R} (h
 section Division
 
 /-- Quotient of `p` by a monic polynomial `q`. Matches Mathlib's `Polynomial.divByMonic`. -/
-def divByMonic [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomial R :=
+def divByMonic [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] (p q : CPolynomial R) :
+    CPolynomial R :=
   ⟨Raw.divByMonic p.val q.val,
    Trim.isCanonical_of_trim_eq (Raw.divByMonic_canonical p.val q.val)⟩
 
 /-- Remainder of `p` modulo a monic polynomial `q`. Matches Mathlib's `Polynomial.modByMonic`. -/
-def modByMonic [Field R] [BEq R] [LawfulBEq R] (p q : CPolynomial R) : CPolynomial R :=
+def modByMonic [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R] (p q : CPolynomial R) :
+    CPolynomial R :=
   ⟨Raw.modByMonic p.val q.val,
    Trim.isCanonical_of_trim_eq
      (Raw.modByMonic_canonical (Trim.trim_eq_of_isCanonical p.property) q.val)⟩

--- a/CompPoly/Univariate/DivisionCorrectness.lean
+++ b/CompPoly/Univariate/DivisionCorrectness.lean
@@ -492,7 +492,7 @@ theorem modByMonic_toPoly_eq_modByMonic (p q : CPolynomial R)
 /-- Euclidean division identity for a monic divisor, stated directly on
 `CPolynomial`: `p.modByMonic q + q * p.divByMonic q = p` whenever `q` is monic.
 
-This holds over an arbitrary commutative ring — no field is required — so it
+This holds over an arbitrary commutative ring, so it
 instantiates at nested coefficient rings, e.g. `CBivariate R =
 CPolynomial (CPolynomial R)`, giving Euclidean division by any monic divisor in
 the outer variable. -/

--- a/CompPoly/Univariate/DivisionCorrectness.lean
+++ b/CompPoly/Univariate/DivisionCorrectness.lean
@@ -316,6 +316,11 @@ private lemma toPoly_mulLow_natDegree_le (M : MulLowContext R) (k : Nat)
   have hnot : ¬i < k := by omega
   simp [hnot]
 
+end Division
+
+section
+variable [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+
 private lemma raw_toPoly_natDegree_lt_size_of_trim_eq (p : Raw R)
     (htrim : p.trim = p) (hpos : 0 < p.size) :
     p.toPoly.natDegree < p.size := by
@@ -482,6 +487,29 @@ theorem modByMonic_toPoly_eq_modByMonic (p q : CPolynomial R)
     (hmonic : q.monic) :
     (p.modByMonic q).toPoly = p.toPoly %ₘ q.toPoly :=
   (raw_divModByMonicAux_toPoly_eq p q ((monic_toPoly_iff q).mp hmonic)).2
+
+/-- Euclidean division identity for a monic divisor, stated directly on
+`CPolynomial`: `p.modByMonic q + q * p.divByMonic q = p` whenever `q` is monic.
+
+This holds over an arbitrary commutative ring — no field is required — so it
+instantiates at nested coefficient rings, e.g. `CBivariate R =
+CPolynomial (CPolynomial R)`, giving Euclidean division by any monic divisor in
+the outer variable. -/
+theorem modByMonic_add_mul_divByMonic (p q : CPolynomial R) (hmonic : q.monic) :
+    p.modByMonic q + q * p.divByMonic q = p := by
+  have hpoly : (p.modByMonic q + q * p.divByMonic q).toPoly = p.toPoly := by
+    rw [toPoly_add, toPoly_mul, divByMonic_toPoly_eq_divByMonic p q hmonic,
+      modByMonic_toPoly_eq_modByMonic p q hmonic]
+    exact Polynomial.modByMonic_add_div p.toPoly q.toPoly
+  apply CPolynomial.eq_iff_coeff.2
+  intro i
+  rw [CPolynomial.coeff_toPoly, CPolynomial.coeff_toPoly]
+  exact congrArg (fun r : R[X] => r.coeff i) hpoly
+
+end
+
+section Division
+variable [Field R] [BEq R] [LawfulBEq R]
 
 /-- Any nonzero polynomial scaled by the inverse of its leading
 coefficient is monic. -/

--- a/CompPoly/Univariate/DivisionCorrectness.lean
+++ b/CompPoly/Univariate/DivisionCorrectness.lean
@@ -321,13 +321,14 @@ end Division
 section
 variable [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
 
+omit [Nontrivial R] in
 private lemma raw_toPoly_natDegree_lt_size_of_trim_eq (p : Raw R)
     (htrim : p.trim = p) (hpos : 0 < p.size) :
     p.toPoly.natDegree < p.size := by
   simpa [htrim] using Raw.toPoly_natDegree_lt_trim_size_of_pos (R := R) p (by
     simpa [htrim] using hpos)
 
-omit [BEq R] [LawfulBEq R] in
+omit [BEq R] [LawfulBEq R] [Nontrivial R] in
 private lemma toImpl_size_le_of_degree_lt (f : R[X]) (n : Nat)
     (hdeg : f.degree < (n : WithBot Nat)) : f.toImpl.size ≤ n := by
   rcases Raw.toImpl_elim f with ⟨_hzero, himpl⟩ | ⟨hnz, himpl⟩
@@ -339,7 +340,7 @@ private lemma toImpl_size_le_of_degree_lt (f : R[X]) (n : Nat)
     simp [himpl]
     omega
 
-omit [LawfulBEq R] in
+omit [LawfulBEq R] [Nontrivial R] in
 private lemma raw_coeff_last_eq_leadingCoeff_of_trim_eq (q : Raw R)
     (htrim : q.trim = q) (hpos : 0 < q.size) :
     q.coeff (q.size - 1) = q.leadingCoeff := by
@@ -395,7 +396,7 @@ private lemma div_step_size_lt (p q : Raw R)
   change p'.size < p.size
   omega
 
-omit [BEq R] [LawfulBEq R] in
+omit [BEq R] [LawfulBEq R] [Nontrivial R] in
 private lemma raw_toPoly_degree_lt_of_size_lt (p q : Raw R)
     (hsize : p.size < q.size)
     (hqdegree : q.toPoly.degree = ((q.size - 1 : Nat) : WithBot Nat)) :

--- a/CompPoly/Univariate/Raw/Division.lean
+++ b/CompPoly/Univariate/Raw/Division.lean
@@ -22,7 +22,7 @@ section Division
 variable [BEq R]
 
 /-- Division with remainder by a monic polynomial using polynomial long division. -/
-def divModByMonicAux [Field R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
+def divModByMonicAux [CommRing R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
     CPolynomial.Raw R × CPolynomial.Raw R :=
   go p.size p q
 where
@@ -39,12 +39,12 @@ where
         ⟨e + C p.leadingCoeff * X^k, f⟩
 
 /-- Division of `p : CPolynomial.Raw R` by a monic `q : CPolynomial.Raw R`. -/
-def divByMonic [Field R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
+def divByMonic [CommRing R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
     CPolynomial.Raw R :=
   (divModByMonicAux p q).1
 
 /-- Modulus of `p : CPolynomial.Raw R` by a monic `q : CPolynomial.Raw R`. -/
-def modByMonic [Field R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
+def modByMonic [CommRing R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
     CPolynomial.Raw R :=
   (divModByMonicAux p q).2
 

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -1114,7 +1114,10 @@ end Ring
 
 section DivisionTheorems
 
-variable [Field R] [BEq R]
+variable [BEq R]
+
+section
+variable [CommRing R] [Nontrivial R]
 
 lemma coeff_mul_X_pow [LawfulBEq R] (p : CPolynomial.Raw R) (n i : ℕ) :
     (p * X ^ n).coeff i =
@@ -1165,6 +1168,11 @@ lemma coeff_C_mul_X_pow [LawfulBEq R] (scale : R) (p : CPolynomial.Raw R) (n i :
   rw [C_mul_eq_smul_trim, Trim.coeff_eq_coeff, smul_coeff, coeff_mul_X_pow]
   split_ifs <;> simp
 
+end
+
+section
+variable [Field R]
+
 lemma subScaledShift_eq_sub_C_mul_X_pow [LawfulBEq R]
     (p q : CPolynomial.Raw R) (scale : R) (shift : ℕ)
     (hsize : shift + q.size ≤ p.size) :
@@ -1205,6 +1213,11 @@ theorem modByMonicRemainderOnly_eq_modByMonic [LawfulBEq R]
     (p q : CPolynomial.Raw R) :
     modByMonicRemainderOnly p q = modByMonic p q := by
   exact modByMonicRemainderOnly_go_eq_divModByMonicAux_go_snd p.size p q
+
+end
+
+section
+variable [CommRing R]
 
 /-- The quotient produced by the monic long-division recursion is canonical regardless of input:
 each non-base step accumulates via `Raw.add` (which trims), and the base case returns `0`. -/
@@ -1252,6 +1265,11 @@ theorem divByMonic_canonical [LawfulBEq R] (p q : CPolynomial.Raw R) :
 theorem modByMonic_canonical [LawfulBEq R] {p : CPolynomial.Raw R} (hp : p.trim = p)
     (q : CPolynomial.Raw R) : (modByMonic p q).trim = modByMonic p q :=
   divModByMonicAux_go_snd_canonical p.size p q hp
+
+end
+
+section
+variable [Field R]
 
 /-- `subScaledShift` ends with `.trim`, so its result is canonical. -/
 theorem subScaledShift_is_trimmed [LawfulBEq R]
@@ -1307,6 +1325,8 @@ theorem mod_canonical [LawfulBEq R] (p q : CPolynomial.Raw R) :
   unfold mod
   apply modByMonic_canonical
   exact mul_is_trimmed _ _
+
+end
 
 end DivisionTheorems
 

--- a/bench/CompPolyBench/Bivariate/Factor.lean
+++ b/bench/CompPolyBench/Bivariate/Factor.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+
+import CompPolyBench.Common
+import CompPoly.Bivariate.Factor
+import CompPoly.Univariate.DivisionCorrectness
+import CompPoly.Fields.BN254
+
+/-!
+# Bivariate Linear-Division Benchmarks
+
+Compares two ways to divide a bivariate polynomial `Q` by the linear factor
+`Y - f` in the `Y` variable:
+
+* `divByLinearY` — the bespoke synthetic (Horner) division specialised to a monic
+  linear divisor; and
+* `CPolynomial.divByMonic` — general monic long division (now `CommRing`-general)
+  applied to the divisor `Y - f`.
+
+Measured across three fields of different word sizes (KoalaBear 31-bit,
+Goldilocks 64-bit, BN254 254-bit) and three `Y`-degree sizes (`< 8`, `< 16`,
+`< 32`), to show both that the Horner speedup is field-independent and that it
+*grows* with the `Y`-degree (the generic divider does a full polynomial multiply
+per step, whose cost balloons as the quotient's `X`-degree grows).
+
+Both methods produce the same quotient — verified by an identical checksum within
+each (field, size) group. The divisor's constant term is perturbed per iteration
+so the division is genuinely recomputed (not hoisted) each measured call.
+-/
+
+open CompPoly
+
+namespace CompPolyBench
+
+/-- Benchmark group metadata for bivariate linear division (3 fields × 3 sizes). -/
+def factorGroupInfos : List BenchGroupInfo := [
+  ⟨"bivariate-divlinear-koalabear-y8", "Bivariate division by Y - f (KoalaBear, yDeg<8)"⟩,
+  ⟨"bivariate-divlinear-koalabear-y16", "Bivariate division by Y - f (KoalaBear, yDeg<16)"⟩,
+  ⟨"bivariate-divlinear-koalabear-y32", "Bivariate division by Y - f (KoalaBear, yDeg<32)"⟩,
+  ⟨"bivariate-divlinear-goldilocks-y8", "Bivariate division by Y - f (Goldilocks, yDeg<8)"⟩,
+  ⟨"bivariate-divlinear-goldilocks-y16", "Bivariate division by Y - f (Goldilocks, yDeg<16)"⟩,
+  ⟨"bivariate-divlinear-goldilocks-y32", "Bivariate division by Y - f (Goldilocks, yDeg<32)"⟩,
+  ⟨"bivariate-divlinear-bn254-y8", "Bivariate division by Y - f (BN254, yDeg<8)"⟩,
+  ⟨"bivariate-divlinear-bn254-y16", "Bivariate division by Y - f (BN254, yDeg<16)"⟩,
+  ⟨"bivariate-divlinear-bn254-y32", "Bivariate division by Y - f (BN254, yDeg<32)"⟩
+]
+
+/-- Input-shape label for a given coefficient count (`xDegree < 8`, so
+`yDegree < terms / 8`). -/
+private def factorInputShape (terms : Nat) : String :=
+  s!"xDegree<8, yDegree<{terms / 8}, divisor Y - f with deg f < 8"
+
+/-- Build a bivariate polynomial from generated coefficients (xDegree < 8). -/
+private def buildCBivariate {R : Type*}
+    [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (terms : Array R) : CBivariate R :=
+  Id.run do
+    let mut p : CBivariate R := 0
+    for i in [0:terms.size] do
+      p := p + CBivariate.monomialXY (i % 8) (i / 8) (terms.getD i 0)
+    pure p
+
+/-- Build a univariate polynomial from generated coefficients. -/
+private def buildCPolynomial {R : Type*}
+    [Semiring R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (terms : Array R) : CPolynomial R :=
+  Id.run do
+    let mut p : CPolynomial R := 0
+    for i in [0:terms.size] do
+      p := p + CPolynomial.monomial i (terms.getD i 0)
+    pure p
+
+/-- The linear divisor `Y - f`, built at the underlying `CPolynomial (CPolynomial R)`. -/
+private def linearDivisor {R : Type*}
+    [CommRing R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (f : CPolynomial R) : CBivariate R :=
+  (CPolynomial.X : CPolynomial (CPolynomial R)) - CPolynomial.C f
+
+/-- Run the `divByLinearY` vs `divByMonic` comparison over a prime `ZMod` field at
+one `Y`-degree size (`terms` coefficients, `yDegree < terms / 8`). -/
+private def runFactorZMod (modulus : Nat) [Fact (Nat.Prime modulus)]
+    (key fieldName fieldTitle nameSuffix yLabel : String) (terms : Nat)
+    (largeHorner mediumHorner smallHorner largeMonic mediumMonic smallMonic : Nat)
+    (preset : BenchPreset) (gen : StdGen) :
+    IO (BenchGroup × StdGen) := do
+  let (qTerms, gen) := (zmodArray modulus terms false).run gen
+  let (fTerms, gen) := (zmodArray modulus 8 false).run gen
+  let (perturb, gen) := (zmodArray modulus 64 false).run gen
+  let q := buildCBivariate qTerms
+  let f := buildCPolynomial fTerms
+  let warmup := warmupIterations preset
+  let measured := measuredIterations preset
+  let hornerMeasured := preset.selectNat largeHorner mediumHorner smallHorner
+  let monicMeasured := preset.selectNat largeMonic mediumMonic smallMonic
+  let checksumIterations := groupChecksumIterations measured [hornerMeasured, monicMeasured]
+  let shape := factorInputShape terms
+  let fAt (i : Nat) : CPolynomial (ZMod modulus) :=
+    f + CPolynomial.C (perturb.getD (i % perturb.size) 0)
+  let checksumBiv (p : CBivariate (ZMod modulus)) : Nat :=
+    checksumCPolynomial (checksumCPolynomial checksumZMod) p
+  let horner ← runTimed
+    ("bivariate-deflate-horner-" ++ yLabel ++ nameSuffix) "CBivariate" "divByLinearY" fieldName
+    shape preset warmup hornerMeasured
+    (fun i ↦ (CBivariate.divByLinearY q (fAt i)).1)
+    checksumBiv (checksumIterations := checksumIterations)
+  let monic ← runTimed
+    ("bivariate-deflate-divbymonic-" ++ yLabel ++ nameSuffix) "CBivariate" "divByMonic" fieldName
+    shape preset warmup monicMeasured
+    (fun i ↦ (CPolynomial.divByMonic q (linearDivisor (fAt i)) : CBivariate (ZMod modulus)))
+    checksumBiv (checksumIterations := checksumIterations)
+  pure ({
+    groupKey := key,
+    title := "Bivariate division by Y - f (" ++ fieldTitle ++ ", " ++ yLabel ++ ")",
+    records := #[horner, monic] }, gen)
+
+/-- Run the KoalaBear comparison at one `Y`-degree size. -/
+private def runFactorKoalaBear (key yLabel : String) (terms : Nat)
+    (largeHorner mediumHorner smallHorner largeMonic mediumMonic smallMonic : Nat)
+    (preset : BenchPreset) (gen : StdGen) :
+    IO (BenchGroup × StdGen) := do
+  let (qTerms, gen) := (koalaBearArray terms false).run gen
+  let (fTerms, gen) := (koalaBearArray 8 false).run gen
+  let (perturb, gen) := (koalaBearArray 64 false).run gen
+  let q := buildCBivariate qTerms
+  let f := buildCPolynomial fTerms
+  let warmup := warmupIterations preset
+  let measured := measuredIterations preset
+  let hornerMeasured := preset.selectNat largeHorner mediumHorner smallHorner
+  let monicMeasured := preset.selectNat largeMonic mediumMonic smallMonic
+  let checksumIterations := groupChecksumIterations measured [hornerMeasured, monicMeasured]
+  let shape := factorInputShape terms
+  let fAt (i : Nat) : CPolynomial KoalaBear.Field :=
+    f + CPolynomial.C (perturb.getD (i % perturb.size) 0)
+  let checksumBiv (p : CBivariate KoalaBear.Field) : Nat :=
+    checksumCPolynomial (checksumCPolynomial checksumKoalaBear) p
+  let horner ← runTimed
+    ("bivariate-deflate-horner-" ++ yLabel) "CBivariate" "divByLinearY" "KoalaBear.Field"
+    shape preset warmup hornerMeasured
+    (fun i ↦ (CBivariate.divByLinearY q (fAt i)).1)
+    checksumBiv (checksumIterations := checksumIterations)
+  let monic ← runTimed
+    ("bivariate-deflate-divbymonic-" ++ yLabel) "CBivariate" "divByMonic" "KoalaBear.Field"
+    shape preset warmup monicMeasured
+    (fun i ↦ (CPolynomial.divByMonic q (linearDivisor (fAt i)) : CBivariate KoalaBear.Field))
+    checksumBiv (checksumIterations := checksumIterations)
+  pure ({
+    groupKey := key,
+    title := "Bivariate division by Y - f (KoalaBear, " ++ yLabel ++ ")",
+    records := #[horner, monic] }, gen)
+
+/-- Runnable bivariate linear-division benchmark tasks (3 fields × 3 `Y`-sizes). -/
+def factorTasks : List BenchTask := [
+  BenchTask.fromGroupRunner
+    ⟨"bivariate-divlinear-koalabear-y8", "Bivariate division by Y - f (KoalaBear, yDeg<8)"⟩
+    (runFactorKoalaBear "bivariate-divlinear-koalabear-y8" "y8" 64 800 120 10 350 50 8),
+  BenchTask.fromGroupRunner
+    ⟨"bivariate-divlinear-koalabear-y16", "Bivariate division by Y - f (KoalaBear, yDeg<16)"⟩
+    (runFactorKoalaBear "bivariate-divlinear-koalabear-y16" "y16" 128 250 40 5 100 15 4),
+  BenchTask.fromGroupRunner
+    ⟨"bivariate-divlinear-koalabear-y32", "Bivariate division by Y - f (KoalaBear, yDeg<32)"⟩
+    (runFactorKoalaBear "bivariate-divlinear-koalabear-y32" "y32" 256 60 10 3 20 4 2),
+  BenchTask.fromGroupRunner
+    ⟨"bivariate-divlinear-goldilocks-y8", "Bivariate division by Y - f (Goldilocks, yDeg<8)"⟩
+    (runFactorZMod Goldilocks.fieldSize "bivariate-divlinear-goldilocks-y8" "Goldilocks.Field"
+      "Goldilocks" "-goldilocks" "y8" 64 300 45 8 200 30 6),
+  BenchTask.fromGroupRunner
+    ⟨"bivariate-divlinear-goldilocks-y16", "Bivariate division by Y - f (Goldilocks, yDeg<16)"⟩
+    (runFactorZMod Goldilocks.fieldSize "bivariate-divlinear-goldilocks-y16" "Goldilocks.Field"
+      "Goldilocks" "-goldilocks" "y16" 128 120 20 5 50 10 4),
+  BenchTask.fromGroupRunner
+    ⟨"bivariate-divlinear-goldilocks-y32", "Bivariate division by Y - f (Goldilocks, yDeg<32)"⟩
+    (runFactorZMod Goldilocks.fieldSize "bivariate-divlinear-goldilocks-y32" "Goldilocks.Field"
+      "Goldilocks" "-goldilocks" "y32" 256 30 6 3 13 3 2),
+  BenchTask.fromGroupRunner
+    ⟨"bivariate-divlinear-bn254-y8", "Bivariate division by Y - f (BN254, yDeg<8)"⟩
+    (runFactorZMod BN254.scalarFieldSize "bivariate-divlinear-bn254-y8" "BN254.ScalarField"
+      "BN254" "-bn254" "y8" 64 250 40 6 150 25 5),
+  BenchTask.fromGroupRunner
+    ⟨"bivariate-divlinear-bn254-y16", "Bivariate division by Y - f (BN254, yDeg<16)"⟩
+    (runFactorZMod BN254.scalarFieldSize "bivariate-divlinear-bn254-y16" "BN254.ScalarField"
+      "BN254" "-bn254" "y16" 128 60 12 4 40 8 3),
+  BenchTask.fromGroupRunner
+    ⟨"bivariate-divlinear-bn254-y32", "Bivariate division by Y - f (BN254, yDeg<32)"⟩
+    (runFactorZMod BN254.scalarFieldSize "bivariate-divlinear-bn254-y32" "BN254.ScalarField"
+      "BN254" "-bn254" "y32" 256 15 4 2 10 3 2)
+]
+
+end CompPolyBench

--- a/bench/CompPolyBench/Bivariate/Factor.lean
+++ b/bench/CompPolyBench/Bivariate/Factor.lean
@@ -15,20 +15,14 @@ import CompPoly.Fields.BN254
 Compares two ways to divide a bivariate polynomial `Q` by the linear factor
 `Y - f` in the `Y` variable:
 
-* `divByLinearY`: the bespoke synthetic (Horner) division specialised to a monic
-  linear divisor; and
-* `CPolynomial.divByMonic`: general monic long division (now `CommRing`-general)
-  applied to the divisor `Y - f`.
+* `divByLinearY`: synthetic (Horner) division specialised to a monic linear
+  divisor;
+* `CPolynomial.divByMonic`: general monic long division applied to `Y - f`.
 
-Measured across three fields of different word sizes (KoalaBear 31-bit,
-Goldilocks 64-bit, BN254 254-bit) and three `Y`-degree sizes (`< 8`, `< 16`,
-`< 32`), to show both that the Horner speedup is field-independent and that it
-*grows* with the `Y`-degree (the generic divider does a full polynomial multiply
-per step, whose cost balloons as the quotient's `X`-degree grows).
-
-Both methods produce the same quotient, verified by an identical checksum within
-each (field, size) group. The divisor's constant term is perturbed per iteration
-so the division is genuinely recomputed (not hoisted) each measured call.
+Measured over KoalaBear, Goldilocks, and BN254, at `Y`-degrees `< 8`, `< 16`,
+and `< 32`. Both methods produce the same quotient, verified by an identical
+checksum within each (field, size) group. The divisor's constant term is
+perturbed per iteration so each measured call recomputes the division.
 -/
 
 open CompPoly

--- a/bench/CompPolyBench/Bivariate/Factor.lean
+++ b/bench/CompPolyBench/Bivariate/Factor.lean
@@ -15,9 +15,9 @@ import CompPoly.Fields.BN254
 Compares two ways to divide a bivariate polynomial `Q` by the linear factor
 `Y - f` in the `Y` variable:
 
-* `divByLinearY` — the bespoke synthetic (Horner) division specialised to a monic
+* `divByLinearY`: the bespoke synthetic (Horner) division specialised to a monic
   linear divisor; and
-* `CPolynomial.divByMonic` — general monic long division (now `CommRing`-general)
+* `CPolynomial.divByMonic`: general monic long division (now `CommRing`-general)
   applied to the divisor `Y - f`.
 
 Measured across three fields of different word sizes (KoalaBear 31-bit,
@@ -26,7 +26,7 @@ Goldilocks 64-bit, BN254 254-bit) and three `Y`-degree sizes (`< 8`, `< 16`,
 *grows* with the `Y`-degree (the generic divider does a full polynomial multiply
 per step, whose cost balloons as the quotient's `X`-degree grows).
 
-Both methods produce the same quotient — verified by an identical checksum within
+Both methods produce the same quotient, verified by an identical checksum within
 each (field, size) group. The divisor's constant term is perturbed per iteration
 so the division is genuinely recomputed (not hoisted) each measured call.
 -/

--- a/bench/CompPolyBench/Setup.lean
+++ b/bench/CompPolyBench/Setup.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 
 import CompPolyBench.Bivariate.Basic
+import CompPolyBench.Bivariate.Factor
 import CompPolyBench.Fields.Binary.AdditiveNTT.Impl
 import CompPolyBench.Multilinear.Basic
 import CompPolyBench.Multivariate.CMvPolynomial
@@ -20,7 +21,8 @@ namespace CompPolyBench
 
 /-- Runnable benchmark registry. -/
 def allTasks : List BenchTask :=
-  univariateTasks ++ multivariateTasks ++ multilinearTasks ++ bivariateTasks ++ additiveNttTasks
+  univariateTasks ++ multivariateTasks ++ multilinearTasks ++ bivariateTasks ++ factorTasks ++
+    additiveNttTasks
 
 /-- Metadata for every benchmark group accepted by the command-line selector. -/
 def allGroupInfos : List BenchGroupInfo :=

--- a/tests/CompPolyTests.lean
+++ b/tests/CompPolyTests.lean
@@ -6,6 +6,7 @@ Authors: Valerii Huhnin
 
 import CompPolyTests.Bivariate.Basic
 import CompPolyTests.Bivariate.Degree
+import CompPolyTests.Bivariate.Factor
 import CompPolyTests.Bivariate.Multiplicity
 import CompPolyTests.Bivariate.WeightedDegree
 import CompPolyTests.Data.MvPolynomial.Notation

--- a/tests/CompPolyTests/Bivariate/Factor.lean
+++ b/tests/CompPolyTests/Bivariate/Factor.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2025 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+import CompPoly.Bivariate.Factor
+
+/-!
+  # Bivariate Factorisation Tests
+
+  Lightweight regressions for `evalYPoly`, `isLinearYFactor`, and `divByLinearY`
+  over `ℚ`: the synthetic-division specification, the remainder/evaluation
+  identity, exactness, and the degenerate `0` / constant cases.
+-/
+
+namespace CompPoly
+namespace CBivariate
+
+-- Synthetic division identity `Q = quot * (Y - f) + rem` holds over `ℚ`.
+example (Q : CBivariate ℚ) (f : CPolynomial ℚ) :
+    toPoly Q =
+      toPoly (divByLinearY Q f).1 * (Polynomial.X - Polynomial.C f.toPoly)
+        + Polynomial.C ((divByLinearY Q f).2).toPoly := by
+  simpa using divByLinearY_spec (R := ℚ) Q f
+
+-- The remainder of synthetic division is the substitution `Q(X, f(X))`.
+example (Q : CBivariate ℚ) (f : CPolynomial ℚ) :
+    (divByLinearY Q f).2 = evalYPoly f Q :=
+  divByLinearY_rem_eq_eval Q f
+
+-- When `Y - f` divides `Q`, the division is exact.
+example (Q : CBivariate ℚ) (f : CPolynomial ℚ) (h : isLinearYFactor Q f = true) :
+    (divByLinearY Q f).2 = 0 :=
+  divByLinearY_exact Q f h
+
+-- `isLinearYFactor` matches the proposition `Q(X, f(X)) = 0`.
+example (Q : CBivariate ℚ) (f : CPolynomial ℚ) :
+    isLinearYFactor Q f = true ↔ evalYPoly f Q = 0 :=
+  isLinearYFactor_iff Q f
+
+-- Degenerate cases: dividing `0` and a `Y`-constant.
+example (f : CPolynomial ℚ) : divByLinearY (0 : CBivariate ℚ) f = (0, 0) :=
+  divByLinearY_zero f
+
+example (a f : CPolynomial ℚ) :
+    divByLinearY (CPolynomial.C a : CBivariate ℚ) f = (0, a) :=
+  divByLinearY_const a f
+
+end CBivariate
+end CompPoly


### PR DESCRIPTION
This PR adds exact division by a linear factor and monic division over a Commutative Ring. Additionally, an equality proof of the two is added along with API, tests, and benchmarks. The division by a linear
  factor is implemented as synthetic (Horner) division and is significantly faster:

  | Field | `yDeg < 8` | `yDeg < 16` | `yDeg < 32` |
  |---|---:|---:|---:|
  | KoalaBear (31-bit)  | 7.5× | 18.6× | 61.4× |
  | Goldilocks (64-bit) | 4.7× |  9.7× | 22.3× |
  | BN254 (254-bit)     | 5.1× | 10.1× | 26.2× |

  Speedup of `divByLinearY` over `divByMonic` for dividing a bivariate `Q` by `Y − f` (medium preset, `xDegree < 8`). Both produce the same quotient (checksum-verified); the gap grows with the `Y`-degree.

  Measured on: AMD Ryzen 5 3400G (8 threads), 29 GiB RAM, Linux 7.0.10-arch1-1, Lean v4.30.0-rc2.

  ## Additions

  - **`CompPoly/Bivariate/Factor.lean`** — `evalYPoly`, `isLinearYFactor`, `divByLinearY` (synthetic/Horner division by `Y − f`), with correctness:
    - `divByLinearY_spec`: `Q = quot · (Y − f) + rem`, proved coefficient-wise over any commutative ring;
    - `divByLinearY_rem_eq_eval`: `rem = Q(X, f(X))` (factor/remainder theorem);
    - `isLinearYFactor_iff`, `divByLinearY_exact`.
  - **Monic Euclidean division generalised to any commutative ring** (`Univariate/Raw/Division.lean`, `Raw/Proofs.lean`, `Basic.lean`, `DivisionCorrectness.lean`), plus the identity
  `CPolynomial.modByMonic_add_mul_divByMonic`: `p.modByMonic q + q * p.divByMonic q = p` for monic `q`.
  - **`CompPoly/Bivariate/FactorMonic.lean`** — `divByLinearY_eq_divByMonic`: `divByLinearY` and `divByMonic` (dividing by `Y − f`) compute the same quotient and the same remainder.
  - **Benchmarks** (`bench/CompPolyBench/Bivariate/Factor.lean`) — `divByLinearY` vs `divByMonic` across KoalaBear / Goldilocks / BN254 at `Y`-degrees `< 8`, `< 16`, `< 32`.
  - **Tests** (`tests/CompPolyTests/Bivariate/Factor.lean`) and regenerated `CompPoly.lean`.

  All proofs are kernel-safe (no `native_decide`).

  The equality proofs in `FactorMonic.lean` were produced by the aleph-prover tool.
