### PR TITLE
feat(bivariate): Kronecker substitution and optimisations

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -3,6 +3,7 @@ import CompPoly.Bivariate.CMvEquiv
 import CompPoly.Bivariate.Deriv
 import CompPoly.Bivariate.Factor
 import CompPoly.Bivariate.FactorMonic
+import CompPoly.Bivariate.Kronecker
 import CompPoly.Bivariate.ToPoly
 import CompPoly.Data.Array.Lemmas
 import CompPoly.Data.Classes.DCast

--- a/CompPoly/Bivariate/Basic.lean
+++ b/CompPoly/Bivariate/Basic.lean
@@ -277,7 +277,7 @@ theorem coeff_monomialXY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [Deci
     · rw [if_neg hi, if_neg (fun h => hi h.1)]
   · rw [if_neg hj, CPolynomial.coeff_zero, if_neg (fun h => hj h.2)]
 
-/-- Coefficient of a `Y`-monomial `Y^m * c(X)` viewed bivariately. -/
+/-- Coefficient of `Y^m * c(X)` as a bivariate polynomial. -/
 theorem coeff_monomialY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (m : ℕ) (c : CPolynomial R) (i j : ℕ) :
     coeff (CPolynomial.monomial m c) i j = if j = m then CPolynomial.coeff c i else 0 := by

--- a/CompPoly/Bivariate/Basic.lean
+++ b/CompPoly/Bivariate/Basic.lean
@@ -233,6 +233,72 @@ def leadingCoeffX {R : Type*} [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] 
 
 end Operations
 
+section CoeffLemmas
+
+variable {R : Type*}
+
+/-- `CBivariate.coeff` as two composed `CPolynomial.coeff`. -/
+@[simp]
+theorem coeff_eq_coeff_coeff [Zero R] (f : CBivariate R) (i j : ℕ) :
+    coeff f i j = CPolynomial.coeff (CPolynomial.coeff f j) i := rfl
+
+/-- Bivariate coefficients are additive. -/
+theorem coeff_add [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (p q : CBivariate R) (i j : ℕ) :
+    coeff (p + q) i j = coeff p i j + coeff q i j := by
+  simp only [coeff_eq_coeff_coeff]
+  rw [show CPolynomial.coeff (p + q) j = CPolynomial.coeff p j + CPolynomial.coeff q j from
+    CPolynomial.coeff_add p q j, CPolynomial.coeff_add]
+
+/-- Bivariate coefficients distribute over finite sums. -/
+theorem coeff_finset_sum [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    {ι : Type*} [DecidableEq ι] (s : Finset ι) (f : ι → CBivariate R) (i j : ℕ) :
+    coeff (s.sum f) i j = s.sum (fun t => coeff (f t) i j) := by
+  induction s using Finset.induction with
+  | empty =>
+    rw [Finset.sum_empty, Finset.sum_empty, coeff_eq_coeff_coeff,
+      show CPolynomial.coeff (0 : CBivariate R) j = 0 from CPolynomial.coeff_zero j,
+      CPolynomial.coeff_zero]
+  | insert a s ha ih =>
+    simp only [Finset.sum_insert ha]
+    rw [coeff_add, ih]
+
+/-- Coefficient of a bivariate monomial `c * X^a * Y^b`. -/
+theorem coeff_monomialXY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (a b : ℕ) (c : R) (i j : ℕ) :
+    coeff (monomialXY a b c) i j = if i = a ∧ j = b then c else 0 := by
+  rw [coeff_eq_coeff_coeff]
+  unfold monomialXY
+  rw [CPolynomial.coeff_monomial]
+  by_cases hj : j = b
+  · rw [if_pos hj, CPolynomial.coeff_monomial]
+    by_cases hi : i = a
+    · rw [if_pos hi, if_pos ⟨hi, hj⟩]
+    · rw [if_neg hi, if_neg (fun h => hi h.1)]
+  · rw [if_neg hj, CPolynomial.coeff_zero, if_neg (fun h => hj h.2)]
+
+/-- Coefficient of a `Y`-monomial `Y^m * c(X)` viewed bivariately. -/
+theorem coeff_monomialY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (m : ℕ) (c : CPolynomial R) (i j : ℕ) :
+    coeff (CPolynomial.monomial m c) i j = if j = m then CPolynomial.coeff c i else 0 := by
+  rw [coeff_eq_coeff_coeff, CPolynomial.coeff_monomial]
+  by_cases hj : j = m
+  · rw [if_pos hj, if_pos hj]
+  · rw [if_neg hj, if_neg hj, CPolynomial.coeff_zero]
+
+/-- Two bivariate polynomials are equal iff all their coefficients agree. -/
+theorem eq_iff_coeff [Zero R] [BEq R] [LawfulBEq R] {p q : CBivariate R} :
+    p = q ↔ ∀ i j, coeff p i j = coeff q i j := by
+  constructor
+  · intro h i j; rw [h]
+  · intro h
+    refine CPolynomial.eq_iff_coeff.2 (fun j => ?_)
+    rw [CPolynomial.eq_iff_coeff]
+    intro i
+    exact h i j
+
+end CoeffLemmas
+
 section WeightedDegreeLemmas
 
 variable {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R]

--- a/CompPoly/Bivariate/Deriv.lean
+++ b/CompPoly/Bivariate/Deriv.lean
@@ -38,18 +38,6 @@ namespace CompPoly
 
 namespace CBivariate
 
-/-- `CBivariate.coeff` as two composed `CPolynomial.coeff`. -/
-@[simp]
-lemma coeff_eq_coeff_coeff [Zero R] (f : CBivariate R) (i j : ℕ) :
-    CBivariate.coeff f i j = CPolynomial.coeff (CPolynomial.coeff f j) i := rfl
-
-/-- Bivariate coefficient distributes over addition. -/
-lemma coeff_add [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    (f g : CBivariate R) (i j : ℕ) :
-    CBivariate.coeff (f + g) i j = CBivariate.coeff f i j + CBivariate.coeff g i j := by
-  simp only [coeff_eq_coeff_coeff]
-  erw [CPolynomial.coeff_add, CPolynomial.coeff_add]
-
 /-- Partial derivative with respect to X: differentiate each Y-coefficient in X. -/
 def partialDerivX [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (f : CBivariate R) : CBivariate R :=

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -1,0 +1,282 @@
+/-
+Copyright (c) 2025 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+
+import CompPoly.Bivariate.Basic
+import CompPoly.Univariate.ToPoly
+
+/-!
+# Kronecker substitution for bivariate polynomials
+
+Kronecker substitution (linearization) reduces a bivariate multiplication to a single
+univariate multiplication. With a stride `D` we substitute `X ↦ t`, `Y ↦ t^D`, packing
+`p : CBivariate R` into `kroneckerPack D p : CPolynomial R`. The coefficient of `X^i Y^j`
+lands at position `D * j + i`, so the packing is faithful whenever each monomial has
+X-degree `< D`.
+
+`kroneckerPack` is the evaluation of the ring homomorphism that fixes the X-coefficients
+and sends `Y` to `X^D`, hence it is multiplicative unconditionally. `kroneckerUnpack`
+recovers the bivariate coefficients via Euclidean division by `D`. The main result
+`kroneckerUnpack_mul` states that
+
+  `kroneckerUnpack D (kroneckerPack D p * kroneckerPack D q) = p * q`
+
+whenever `natDegreeX (p * q) < D`, i.e. the product fits in the stride. Once an NTT-based
+univariate multiplication lands, this turns bivariate multiplication into a single fast
+univariate multiplication.
+-/
+
+namespace CompPoly
+
+namespace CPolynomial
+
+variable {R : Type*}
+
+/-- A coefficient above the `natDegree` vanishes. -/
+theorem coeff_eq_zero_of_natDegree_lt [Zero R] [BEq R] [LawfulBEq R]
+    {p : CPolynomial R} {i : ℕ} (h : p.natDegree < i) : coeff p i = 0 := by
+  by_contra hc
+  exact absurd (le_natDegree_of_ne_zero hc) (Nat.not_le.2 h)
+
+/-- Coefficients of a polynomial shifted by `X ^ m`: a clean stride lemma used by
+Kronecker packing. -/
+theorem coeff_mul_X_pow [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (c : CPolynomial R) (m n : ℕ) :
+    coeff (c * X ^ m) n = if m ≤ n then coeff c (n - m) else 0 := by
+  induction m generalizing n with
+  | zero => simp [pow_zero]
+  | succ m ih =>
+    rw [pow_succ, ← mul_assoc]
+    cases n with
+    | zero => rw [coeff_mul_X_zero]; simp
+    | succ k =>
+      rw [coeff_mul_X_succ, ih]
+      by_cases h : m ≤ k
+      · rw [if_pos h, if_pos (Nat.succ_le_succ h), Nat.succ_sub_succ]
+      · rw [if_neg h, if_neg (fun hc => h (Nat.le_of_succ_le_succ hc))]
+
+end CPolynomial
+
+namespace CBivariate
+
+section Coeff
+
+variable {R : Type*}
+
+/-- Bivariate coefficients are additive. -/
+theorem coeff_add [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (p q : CBivariate R) (i j : ℕ) :
+    coeff (p + q) i j = coeff p i j + coeff q i j := by
+  show ((p + q).val.coeff j).coeff i = (p.val.coeff j).coeff i + (q.val.coeff j).coeff i
+  rw [show (p + q).val.coeff j = p.val.coeff j + q.val.coeff j from CPolynomial.coeff_add p q j]
+  exact CPolynomial.coeff_add _ _ i
+
+/-- Bivariate coefficients distribute over finite sums. -/
+theorem coeff_finset_sum [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    {ι : Type*} [DecidableEq ι] (s : Finset ι) (f : ι → CBivariate R) (i j : ℕ) :
+    coeff (s.sum f) i j = s.sum (fun t => coeff (f t) i j) := by
+  induction s using Finset.induction with
+  | empty =>
+    rw [Finset.sum_empty, Finset.sum_empty]
+    show ((0 : CBivariate R).val.coeff j).coeff i = 0
+    rw [show (0 : CBivariate R).val.coeff j = 0 from CPolynomial.coeff_zero j]
+    exact CPolynomial.coeff_zero i
+  | insert a s ha ih =>
+    simp only [Finset.sum_insert ha]
+    rw [coeff_add, ih]
+
+/-- Coefficient of a bivariate monomial `c * X^a * Y^b`. -/
+theorem coeff_monomialXY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (a b : ℕ) (c : R) (i j : ℕ) :
+    coeff (monomialXY a b c) i j = if i = a ∧ j = b then c else 0 := by
+  show (CPolynomial.coeff (monomialXY a b c) j).coeff i = if i = a ∧ j = b then c else 0
+  unfold monomialXY
+  rw [CPolynomial.coeff_monomial]
+  by_cases hj : j = b
+  · rw [if_pos hj, CPolynomial.coeff_monomial]
+    by_cases hi : i = a
+    · rw [if_pos hi, if_pos ⟨hi, hj⟩]
+    · rw [if_neg hi, if_neg (fun h => hi h.1)]
+  · rw [if_neg hj, CPolynomial.coeff_zero, if_neg (fun h => hj h.2)]
+
+/-- Two bivariate polynomials are equal iff all their coefficients agree. -/
+theorem eq_iff_coeff [Zero R] [BEq R] [LawfulBEq R] {p q : CBivariate R} :
+    p = q ↔ ∀ i j, coeff p i j = coeff q i j := by
+  constructor
+  · intro h i j; rw [h]
+  · intro h
+    refine CPolynomial.eq_iff_coeff.2 (fun j => ?_)
+    rw [CPolynomial.eq_iff_coeff]
+    intro i
+    exact h i j
+
+end Coeff
+
+section Pack
+
+variable {R : Type*}
+
+/-- Pack a bivariate polynomial into a univariate one by substituting `X ↦ t`, `Y ↦ t^D`.
+The coefficient of `X^i Y^j` (with `i < D`) lands at position `D * j + i`. -/
+def kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (D : ℕ) (p : CBivariate R) : CPolynomial R :=
+  CPolynomial.eval₂ (RingHom.id (CPolynomial R)) (CPolynomial.X ^ D) p
+
+/-- Unpack a univariate polynomial into a bivariate one: position `k` becomes the
+monomial `X^(k % D) Y^(k / D)`. -/
+def kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (D : ℕ) (P : CPolynomial R) : CBivariate R :=
+  (CPolynomial.support P).sum
+    (fun k => monomialXY (k % D) (k / D) (CPolynomial.coeff P k))
+
+/-- Packing is multiplicative: it is the evaluation of a ring homomorphism. -/
+theorem kroneckerPack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (D : ℕ) (p q : CBivariate R) :
+    kroneckerPack D (p * q) = kroneckerPack D p * kroneckerPack D q := by
+  unfold kroneckerPack
+  simp only [CPolynomial.eval₂_toPoly]
+  rw [show CPolynomial.toPoly (p * q) = CPolynomial.toPoly p * CPolynomial.toPoly q from
+    CPolynomial.toPoly_mul p q, Polynomial.eval₂_mul]
+
+/-- Packing coefficient lemma: when every X-degree is `< D`, the coefficient at position
+`n` of the packed polynomial is the bivariate coefficient at `(n % D, n / D)`. -/
+theorem coeff_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    {D : ℕ} (hD : 0 < D) (p : CBivariate R) (hp : natDegreeX p < D) (n : ℕ) :
+    CPolynomial.coeff (kroneckerPack D p) n = coeff p (n % D) (n / D) := by
+  have hsum : kroneckerPack D p
+      = (CPolynomial.support p).sum
+          (fun i => CPolynomial.coeff p i * CPolynomial.X ^ (D * i)) := by
+    unfold kroneckerPack
+    rw [CPolynomial.eval₂_eq_sum_support]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [RingHom.id_apply, ← pow_mul]
+  rw [hsum, CPolynomial.coeff_finset_sum]
+  rw [Finset.sum_eq_single (n / D)]
+  · rw [CPolynomial.coeff_mul_X_pow]
+    have hle : D * (n / D) ≤ n := Nat.mul_div_le n D
+    rw [if_pos hle]
+    have hsub : n - D * (n / D) = n % D := by
+      have := Nat.mod_add_div n D; omega
+    rw [hsub]
+    rfl
+  · intro i hi hine
+    rw [CPolynomial.coeff_mul_X_pow]
+    split_ifs with hle
+    · by_contra hc
+      have hdeg : n - D * i ≤ (CPolynomial.coeff p i).natDegree :=
+        CPolynomial.le_natDegree_of_ne_zero hc
+      have hsup : (CPolynomial.coeff p i).natDegree ≤ natDegreeX p := by
+        unfold natDegreeX
+        exact Finset.le_sup (f := fun n => (p.val.coeff n).natDegree) hi
+      have hlt : n - D * i < D := lt_of_le_of_lt (le_trans hdeg hsup) hp
+      apply hine
+      have h1 : i ≤ n / D := (Nat.le_div_iff_mul_le hD).2 (by rw [Nat.mul_comm]; exact hle)
+      have h2 : n / D < i + 1 :=
+        (Nat.div_lt_iff_lt_mul hD).2 (by rw [Nat.mul_comm, Nat.mul_succ]; omega)
+      omega
+    · rfl
+  · intro hns
+    have h0 : CPolynomial.coeff p (n / D) = 0 := by
+      by_contra hc
+      exact hns ((CPolynomial.mem_support_iff p (n / D)).2 hc)
+    rw [h0, zero_mul, CPolynomial.coeff_zero]
+
+end Pack
+
+section Unpack
+
+variable {R : Type*}
+
+/-- Unpacking coefficient lemma (above the stride): a bivariate coefficient with
+X-exponent `≥ D` is zero. -/
+theorem coeff_kroneckerUnpack_of_le [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R] {D : ℕ} (hD : 0 < D) (P : CPolynomial R) (i j : ℕ) (hi : D ≤ i) :
+    coeff (kroneckerUnpack D P) i j = 0 := by
+  unfold kroneckerUnpack
+  rw [coeff_finset_sum]
+  apply Finset.sum_eq_zero
+  intro k _
+  rw [coeff_monomialXY, if_neg]
+  rintro ⟨hik, _⟩
+  have : k % D < D := Nat.mod_lt _ hD
+  omega
+
+/-- Unpacking coefficient lemma (within the stride): for `i < D`, the bivariate coefficient
+at `(i, j)` of the unpacked polynomial is the univariate coefficient at `D * j + i`. -/
+theorem coeff_kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R] {D : ℕ} (hD : 0 < D) (P : CPolynomial R) (i j : ℕ) (hi : i < D) :
+    coeff (kroneckerUnpack D P) i j = CPolynomial.coeff P (D * j + i) := by
+  have hmod : (D * j + i) % D = i := by
+    rw [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hi]
+  have hdiv : (D * j + i) / D = j := by
+    rw [Nat.add_comm, Nat.add_mul_div_left i j hD, Nat.div_eq_of_lt hi, Nat.zero_add]
+  unfold kroneckerUnpack
+  rw [coeff_finset_sum]
+  rw [Finset.sum_eq_single (D * j + i)]
+  · rw [coeff_monomialXY, if_pos]
+    exact ⟨hmod.symm, hdiv.symm⟩
+  · intro k _ hkne
+    rw [coeff_monomialXY, if_neg]
+    rintro ⟨hik, hjk⟩
+    apply hkne
+    subst hik; subst hjk
+    have := Nat.mod_add_div k D
+    omega
+  · intro hns
+    rw [coeff_monomialXY, if_pos ⟨hmod.symm, hdiv.symm⟩]
+    by_contra hc
+    exact hns ((CPolynomial.mem_support_iff P (D * j + i)).2 hc)
+
+end Unpack
+
+section Correctness
+
+variable {R : Type*}
+
+/-- Round-trip: under the X-degree bound, unpacking recovers the packed polynomial. -/
+theorem kroneckerUnpack_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R] {D : ℕ} (hD : 0 < D) (p : CBivariate R) (hp : natDegreeX p < D) :
+    kroneckerUnpack D (kroneckerPack D p) = p := by
+  rw [eq_iff_coeff]
+  intro i j
+  by_cases hi : i < D
+  · rw [coeff_kroneckerUnpack hD _ i j hi, coeff_kroneckerPack hD p hp]
+    have hmod : (D * j + i) % D = i := by
+      rw [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hi]
+    have hdiv : (D * j + i) / D = j := by
+      rw [Nat.add_comm, Nat.add_mul_div_left i j hD, Nat.div_eq_of_lt hi, Nat.zero_add]
+    rw [hmod, hdiv]
+  · rw [coeff_kroneckerUnpack_of_le hD _ i j (Nat.le_of_not_lt hi)]
+    -- the bivariate coefficient at X-exponent `i ≥ D > natDegreeX p` vanishes
+    have hdeg : (CPolynomial.coeff p j).natDegree < i := by
+      by_cases hj : j ∈ CPolynomial.support p
+      · have : (CPolynomial.coeff p j).natDegree ≤ natDegreeX p := by
+          unfold natDegreeX
+          exact Finset.le_sup (f := fun n => (p.val.coeff n).natDegree) hj
+        omega
+      · have h0 : CPolynomial.coeff p j = 0 := by
+          by_contra hc
+          exact hj ((CPolynomial.mem_support_iff p j).2 hc)
+        rw [h0]
+        have hz : (0 : CPolynomial R).natDegree = 0 := rfl
+        omega
+    exact (CPolynomial.coeff_eq_zero_of_natDegree_lt hdeg).symm
+
+/-- **Kronecker substitution correctness.** When the product fits within the stride
+(`natDegreeX (p * q) < D`), bivariate multiplication equals one univariate multiplication
+followed by unpacking. -/
+theorem kroneckerUnpack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R] {D : ℕ} (hD : 0 < D) (p q : CBivariate R)
+    (hpq : natDegreeX (p * q) < D) :
+    kroneckerUnpack D (kroneckerPack D p * kroneckerPack D q) = p * q := by
+  rw [← kroneckerPack_mul]
+  exact kroneckerUnpack_kroneckerPack hD (p * q) hpq
+
+end Correctness
+
+end CBivariate
+
+end CompPoly

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 CompPoly. All rights reserved.
+Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dimitris Mitsios
 -/

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -88,59 +88,6 @@ end CPolynomial
 
 namespace CBivariate
 
-section Coeff
-
-variable {R : Type*}
-
-/-- Bivariate coefficients are additive. -/
-theorem coeff_add [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    (p q : CBivariate R) (i j : ℕ) :
-    coeff (p + q) i j = coeff p i j + coeff q i j := by
-  show ((p + q).val.coeff j).coeff i = (p.val.coeff j).coeff i + (q.val.coeff j).coeff i
-  rw [show (p + q).val.coeff j = p.val.coeff j + q.val.coeff j from CPolynomial.coeff_add p q j]
-  exact CPolynomial.coeff_add _ _ i
-
-/-- Bivariate coefficients distribute over finite sums. -/
-theorem coeff_finset_sum [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
-    {ι : Type*} [DecidableEq ι] (s : Finset ι) (f : ι → CBivariate R) (i j : ℕ) :
-    coeff (s.sum f) i j = s.sum (fun t => coeff (f t) i j) := by
-  induction s using Finset.induction with
-  | empty =>
-    rw [Finset.sum_empty, Finset.sum_empty]
-    show ((0 : CBivariate R).val.coeff j).coeff i = 0
-    rw [show (0 : CBivariate R).val.coeff j = 0 from CPolynomial.coeff_zero j]
-    exact CPolynomial.coeff_zero i
-  | insert a s ha ih =>
-    simp only [Finset.sum_insert ha]
-    rw [coeff_add, ih]
-
-/-- Coefficient of a bivariate monomial `c * X^a * Y^b`. -/
-theorem coeff_monomialXY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-    (a b : ℕ) (c : R) (i j : ℕ) :
-    coeff (monomialXY a b c) i j = if i = a ∧ j = b then c else 0 := by
-  show (CPolynomial.coeff (monomialXY a b c) j).coeff i = if i = a ∧ j = b then c else 0
-  unfold monomialXY
-  rw [CPolynomial.coeff_monomial]
-  by_cases hj : j = b
-  · rw [if_pos hj, CPolynomial.coeff_monomial]
-    by_cases hi : i = a
-    · rw [if_pos hi, if_pos ⟨hi, hj⟩]
-    · rw [if_neg hi, if_neg (fun h => hi h.1)]
-  · rw [if_neg hj, CPolynomial.coeff_zero, if_neg (fun h => hj h.2)]
-
-/-- Two bivariate polynomials are equal iff all their coefficients agree. -/
-theorem eq_iff_coeff [Zero R] [BEq R] [LawfulBEq R] {p q : CBivariate R} :
-    p = q ↔ ∀ i j, coeff p i j = coeff q i j := by
-  constructor
-  · intro h i j; rw [h]
-  · intro h
-    refine CPolynomial.eq_iff_coeff.2 (fun j => ?_)
-    rw [CPolynomial.eq_iff_coeff]
-    intro i
-    exact h i j
-
-end Coeff
-
 section Pack
 
 variable {R : Type*}
@@ -301,16 +248,6 @@ theorem coeff_window [Zero R] [BEq R] [LawfulBEq R] (D j : ℕ) (P : CPolynomial
   · rw [if_neg hiD, Nat.not_lt] at *
     rw [if_neg (by omega : ¬ i < min (D * j + D) P.val.size - D * j)]
     rfl
-
-/-- Coefficient of a `Y`-monomial `Y^m * c(X)` viewed bivariately. -/
-theorem coeff_monomialY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
-    (m : ℕ) (c : CPolynomial R) (i j : ℕ) :
-    coeff (CPolynomial.monomial m c) i j = if j = m then CPolynomial.coeff c i else 0 := by
-  show (CPolynomial.coeff (CPolynomial.monomial m c) j).coeff i = _
-  rw [CPolynomial.coeff_monomial]
-  by_cases hj : j = m
-  · rw [if_pos hj, if_pos hj]
-  · rw [if_neg hj, if_neg hj, CPolynomial.coeff_zero]
 
 /-- Efficient unpacking: assemble the X-columns `Y^j * window j` directly, avoiding the
 per-coefficient monomial sum of `kroneckerUnpack`. -/

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -6,6 +6,8 @@ Authors: Dimitris Mitsios
 
 import CompPoly.Bivariate.Basic
 import CompPoly.Univariate.ToPoly
+import CompPoly.Univariate.NTT.FastMul
+import CompPoly.Univariate.NTTFast.Correctness
 
 /-!
 # Kronecker substitution for bivariate polynomials
@@ -274,6 +276,44 @@ theorem kroneckerUnpack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R
     kroneckerUnpack D (kroneckerPack D p * kroneckerPack D q) = p * q := by
   rw [← kroneckerPack_mul]
   exact kroneckerUnpack_kroneckerPack hD (p * q) hpq
+
+/-- **Kronecker substitution backed by NTT multiplication.** Combines `kroneckerPack` /
+`kroneckerUnpack` with the NTT-accelerated `withFallback` univariate multiplication: when
+the product fits the stride (`natDegreeX (p * q) < D`), bivariate multiplication reduces to
+a single fast univariate multiplication.
+
+No domain-fit hypothesis is needed: `withFallback` selects a fitting NTT domain when one
+exists and otherwise falls back to schoolbook multiplication, so it is unconditionally equal
+to `*`. The only remaining hypothesis, `natDegreeX (p * q) < D`, is intrinsic to Kronecker
+packing, not to the multiplication backend. -/
+theorem kroneckerUnpack_withFallback [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (CPolynomial.NTT.FittingDomain R requiredLen))
+    {D : ℕ} (hD : 0 < D) (p q : CBivariate R) (hpq : natDegreeX (p * q) < D) :
+    kroneckerUnpack D
+        (CPolynomial.NTT.FastMul.withFallback bestDomainForLength?
+          (kroneckerPack D p) (kroneckerPack D q))
+      = p * q := by
+  rw [CPolynomial.NTT.FastMul.withFallback_eq_mul]
+  exact kroneckerUnpack_mul hD p q hpq
+
+/-- **Kronecker substitution backed by the recursive (NTTFast) multiplication.** As
+`kroneckerUnpack_withFallback`, but using the recursive radix-2/radix-4 NTT pipeline
+(`CPolynomial.NTTFast.withFallback`) as the univariate multiplication backend.
+
+No domain-fit hypothesis is needed: `withFallback` falls back to schoolbook multiplication
+when no NTT domain fits, so it is unconditionally equal to `*`. The only remaining
+hypothesis, `natDegreeX (p * q) < D`, is intrinsic to Kronecker packing. -/
+theorem kroneckerUnpack_withFallbackFast [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
+    (bestDomainForLength? : (requiredLen : Nat) →
+      Option (CPolynomial.NTT.FittingDomain R requiredLen))
+    {D : ℕ} (hD : 0 < D) (p q : CBivariate R) (hpq : natDegreeX (p * q) < D) :
+    kroneckerUnpack D
+        (CPolynomial.NTTFast.withFallback bestDomainForLength?
+          (kroneckerPack D p) (kroneckerPack D q))
+      = p * q := by
+  rw [CPolynomial.NTTFast.withFallback_eq_mul]
+  exact kroneckerUnpack_mul hD p q hpq
 
 end Correctness
 

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -88,6 +88,20 @@ end CPolynomial
 
 namespace CBivariate
 
+section Stride
+
+variable {D i j : ℕ}
+
+/-- For `i < D`, the packed position `D * j + i` has remainder `i`. -/
+private theorem stride_mod (hi : i < D) : (D * j + i) % D = i := by
+  rw [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hi]
+
+/-- For `i < D`, the packed position `D * j + i` has quotient `j`. -/
+private theorem stride_div (hD : 0 < D) (hi : i < D) : (D * j + i) / D = j := by
+  rw [Nat.add_comm, Nat.add_mul_div_left i j hD, Nat.div_eq_of_lt hi, Nat.zero_add]
+
+end Stride
+
 section Pack
 
 variable {R : Type*}
@@ -131,35 +145,26 @@ theorem kroneckerPack_eq_sum [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
 theorem coeff_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     {D : ℕ} (hD : 0 < D) (p : CBivariate R) (hp : natDegreeX p < D) (n : ℕ) :
     CPolynomial.coeff (kroneckerPack D p) n = coeff p (n % D) (n / D) := by
-  rw [kroneckerPack_eq_sum, CPolynomial.coeff_finset_sum]
-  rw [Finset.sum_eq_single (n / D)]
-  · rw [CPolynomial.coeff_mul_X_pow]
-    have hle : D * (n / D) ≤ n := Nat.mul_div_le n D
-    rw [if_pos hle]
-    have hsub : n - D * (n / D) = n % D := by
-      have := Nat.mod_add_div n D; omega
-    rw [hsub]
-    rfl
-  · intro i hi hine
+  rw [kroneckerPack_eq_sum, CPolynomial.coeff_finset_sum, Finset.sum_eq_single (n / D)]
+  · rw [CPolynomial.coeff_mul_X_pow, if_pos (Nat.mul_div_le n D)]
+    have hsub : n - D * (n / D) = n % D := by have := Nat.mod_add_div n D; omega
+    rw [hsub]; rfl
+  · -- every other column contributes nothing: its only reachable position exceeds its degree
+    intro i hi hine
     rw [CPolynomial.coeff_mul_X_pow]
     split_ifs with hle
-    · by_contra hc
-      have hdeg : n - D * i ≤ (CPolynomial.coeff p i).natDegree :=
-        CPolynomial.le_natDegree_of_ne_zero hc
-      have hsup : (CPolynomial.coeff p i).natDegree ≤ natDegreeX p := by
-        unfold natDegreeX
-        exact Finset.le_sup (f := fun n => (p.val.coeff n).natDegree) hi
-      have hlt : n - D * i < D := lt_of_le_of_lt (le_trans hdeg hsup) hp
-      apply hine
-      have h1 : i ≤ n / D := (Nat.le_div_iff_mul_le hD).2 (by rw [Nat.mul_comm]; exact hle)
-      have h2 : n / D < i + 1 :=
-        (Nat.div_lt_iff_lt_mul hD).2 (by rw [Nat.mul_comm, Nat.mul_succ]; omega)
-      omega
+    · refine CPolynomial.coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt (b := natDegreeX p) ?_ ?_)
+      · exact Finset.le_sup (f := fun m => (p.val.coeff m).natDegree) hi
+      · have hilt : i < n / D :=
+          lt_of_le_of_ne ((Nat.le_div_iff_mul_le hD).2 (by rw [Nat.mul_comm]; exact hle)) hine
+        have : D * i + D ≤ n := by
+          have := Nat.mul_le_mul_left D hilt; rw [Nat.mul_succ] at this
+          exact this.trans (Nat.mul_div_le n D)
+        omega
     · rfl
   · intro hns
     have h0 : CPolynomial.coeff p (n / D) = 0 := by
-      by_contra hc
-      exact hns ((CPolynomial.mem_support_iff p (n / D)).2 hc)
+      by_contra hc; exact hns ((CPolynomial.mem_support_iff p (n / D)).2 hc)
     rw [h0, zero_mul, CPolynomial.coeff_zero]
 
 /-- Efficient packing: sum of the Y-coefficients shifted by `X^(D·j)` using the cheap
@@ -202,15 +207,11 @@ at `(i, j)` of the unpacked polynomial is the univariate coefficient at `D * j +
 theorem coeff_kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     [DecidableEq R] {D : ℕ} (hD : 0 < D) (P : CPolynomial R) (i j : ℕ) (hi : i < D) :
     coeff (kroneckerUnpack D P) i j = CPolynomial.coeff P (D * j + i) := by
-  have hmod : (D * j + i) % D = i := by
-    rw [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hi]
-  have hdiv : (D * j + i) / D = j := by
-    rw [Nat.add_comm, Nat.add_mul_div_left i j hD, Nat.div_eq_of_lt hi, Nat.zero_add]
+  have hkey : i = (D * j + i) % D ∧ j = (D * j + i) / D :=
+    ⟨(stride_mod hi).symm, (stride_div hD hi).symm⟩
   unfold kroneckerUnpack
-  rw [coeff_finset_sum]
-  rw [Finset.sum_eq_single (D * j + i)]
-  · rw [coeff_monomialXY, if_pos]
-    exact ⟨hmod.symm, hdiv.symm⟩
+  rw [coeff_finset_sum, Finset.sum_eq_single (D * j + i)]
+  · rw [coeff_monomialXY, if_pos hkey]
   · intro k _ hkne
     rw [coeff_monomialXY, if_neg]
     rintro ⟨hik, hjk⟩
@@ -219,7 +220,7 @@ theorem coeff_kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     have := Nat.mod_add_div k D
     omega
   · intro hns
-    rw [coeff_monomialXY, if_pos ⟨hmod.symm, hdiv.symm⟩]
+    rw [coeff_monomialXY, if_pos hkey]
     by_contra hc
     exact hns ((CPolynomial.mem_support_iff P (D * j + i)).2 hc)
 
@@ -273,10 +274,8 @@ theorem kroneckerUnpackFast_eq [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     · rw [if_neg hjr]
       rw [Finset.mem_range, Nat.not_lt] at hjr
       refine (CPolynomial.coeff_eq_zero_of_natDegree_lt ?_).symm
-      have hdm := Nat.div_add_mod P.natDegree D
-      have hmd := Nat.mod_lt P.natDegree hD
-      have hmul : D * (P.natDegree / D + 1) ≤ D * j := Nat.mul_le_mul_left D hjr
-      have : D * (P.natDegree / D + 1) = D * (P.natDegree / D) + D := by ring
+      have : P.natDegree < D * j := by
+        rw [Nat.mul_comm]; exact (Nat.div_lt_iff_lt_mul hD).1 hjr
       omega
   · rw [if_neg hiD, coeff_kroneckerUnpack_of_le hD _ i j (Nat.le_of_not_lt hiD)]
     by_cases hjr : j ∈ Finset.range (P.natDegree / D + 1) <;> simp [hjr]
@@ -294,26 +293,17 @@ theorem kroneckerUnpack_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontri
   rw [eq_iff_coeff]
   intro i j
   by_cases hi : i < D
-  · rw [coeff_kroneckerUnpack hD _ i j hi, coeff_kroneckerPack hD p hp]
-    have hmod : (D * j + i) % D = i := by
-      rw [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hi]
-    have hdiv : (D * j + i) / D = j := by
-      rw [Nat.add_comm, Nat.add_mul_div_left i j hD, Nat.div_eq_of_lt hi, Nat.zero_add]
-    rw [hmod, hdiv]
-  · rw [coeff_kroneckerUnpack_of_le hD _ i j (Nat.le_of_not_lt hi)]
-    -- the bivariate coefficient at X-exponent `i ≥ D > natDegreeX p` vanishes
+  · rw [coeff_kroneckerUnpack hD _ i j hi, coeff_kroneckerPack hD p hp,
+      stride_mod hi, stride_div hD hi]
+  · -- the bivariate coefficient at X-exponent `i ≥ D > natDegreeX p` vanishes
+    rw [coeff_kroneckerUnpack_of_le hD _ i j (Nat.le_of_not_lt hi)]
     have hdeg : (CPolynomial.coeff p j).natDegree < i := by
       by_cases hj : j ∈ CPolynomial.support p
-      · have : (CPolynomial.coeff p j).natDegree ≤ natDegreeX p := by
-          unfold natDegreeX
-          exact Finset.le_sup (f := fun n => (p.val.coeff n).natDegree) hj
-        omega
+      · exact lt_of_le_of_lt (Finset.le_sup (f := fun n => (p.val.coeff n).natDegree) hj)
+          (lt_of_lt_of_le hp (Nat.le_of_not_lt hi))
       · have h0 : CPolynomial.coeff p j = 0 := by
-          by_contra hc
-          exact hj ((CPolynomial.mem_support_iff p j).2 hc)
-        rw [h0]
-        have hz : (0 : CPolynomial R).natDegree = 0 := rfl
-        omega
+          by_contra hc; exact hj ((CPolynomial.mem_support_iff p j).2 hc)
+        rw [h0]; show 0 < i; omega
     exact (CPolynomial.coeff_eq_zero_of_natDegree_lt hdeg).symm
 
 /-- **Kronecker substitution correctness.** When the product fits within the stride

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -12,22 +12,51 @@ import CompPoly.Univariate.NTTFast.Correctness
 /-!
 # Kronecker substitution for bivariate polynomials
 
-Kronecker substitution (linearization) reduces a bivariate multiplication to a single
-univariate multiplication. With a stride `D` we substitute `X ↦ t`, `Y ↦ t^D`, packing
-`p : CBivariate R` into `kroneckerPack D p : CPolynomial R`. The coefficient of `X^i Y^j`
-lands at position `D * j + i`, so the packing is faithful whenever each monomial has
-X-degree `< D`.
+Kronecker substitution turns one bivariate multiplication into one univariate
+multiplication. Fix a stride `D` and substitute `X ↦ t`, `Y ↦ t ^ D`. This sends a
+bivariate polynomial `p : CBivariate R` to a univariate polynomial
+`kroneckerPack D p : CPolynomial R` in which the coefficient of `X ^ i Y ^ j` is placed at
+position `D * j + i`.
 
-`kroneckerPack` is the evaluation of the ring homomorphism that fixes the X-coefficients
-and sends `Y` to `X^D`, hence it is multiplicative unconditionally. `kroneckerUnpack`
-recovers the bivariate coefficients via Euclidean division by `D`. The main result
-`kroneckerUnpack_mul` states that
+To multiply `p` and `q`: pack both, multiply the two univariate polynomials once, then
+unpack the result. The middle step is an ordinary univariate multiplication, so any fast
+univariate multiplication gives a fast bivariate multiplication. The NTT versions are
+`kroneckerUnpack_withFallback` and `kroneckerUnpack_withFallbackFast`.
 
-  `kroneckerUnpack D (kroneckerPack D p * kroneckerPack D q) = p * q`
+## Why it is correct
 
-whenever `natDegreeX (p * q) < D`, i.e. the product fits in the stride. Once an NTT-based
-univariate multiplication lands, this turns bivariate multiplication into a single fast
-univariate multiplication.
+Two separate facts are involved, and the proofs keep them apart.
+
+Packing keeps each `X`-coefficient and sends `Y` to `X ^ D`. This is a ring homomorphism,
+so `kroneckerPack D (p * q) = kroneckerPack D p * kroneckerPack D q` holds for every `p`
+and `q` with no extra condition (`kroneckerPack_mul`): multiplying in the packed form is
+always the same as packing the product.
+
+Recovering a bivariate polynomial from a packed one is where a condition appears. Packing
+is not injective in general, because the position `D * j + i` determines `i` and `j` only
+when `i < D`. If some `X`-exponent reaches `D`, two different monomials can be placed on
+the same position and can no longer be told apart. Unpacking inverts packing exactly when
+every `X`-exponent stays below `D`, that is when `natDegreeX p < D`
+(`kroneckerUnpack_kroneckerPack`).
+
+For a product the stride must therefore exceed the `X`-degree of `p * q`. The main result
+`kroneckerUnpack_mul` assumes `natDegreeX (p * q) < D`. Since
+`natDegreeX (p * q) ≤ natDegreeX p + natDegreeX q`, it is enough in practice to choose `D`
+greater than `natDegreeX p + natDegreeX q`.
+
+## Two versions of pack and unpack
+
+`kroneckerPack` and `kroneckerUnpack` are written so the proofs above stay short: packing
+is one evaluation and unpacking is one sum over coefficients. Run directly they are slow,
+because the evaluation recomputes powers of `X ^ D`. `kroneckerPackFast` and
+`kroneckerUnpackFast` compute the same polynomials in time linear in the output by shifting
+and slicing coefficient arrays, and are proved equal to the plain versions
+(`kroneckerPackFast_eq`, `kroneckerUnpackFast_eq`), so every correctness result carries
+over to them (`kroneckerUnpackFast_mul`).
+
+The NTT versions multiply through `withFallback`, which uses an NTT domain when one fits
+and otherwise multiplies the ordinary way. It is always equal to `*`, so those results need
+no extra assumption about the domain beyond the stride condition above.
 -/
 
 namespace CompPoly
@@ -36,14 +65,13 @@ namespace CPolynomial
 
 variable {R : Type*}
 
-/-- A coefficient above the `natDegree` vanishes. -/
+/-- A coefficient past the degree is zero. -/
 theorem coeff_eq_zero_of_natDegree_lt [Zero R] [BEq R] [LawfulBEq R]
     {p : CPolynomial R} {i : ℕ} (h : p.natDegree < i) : coeff p i = 0 := by
   by_contra hc
   exact absurd (le_natDegree_of_ne_zero hc) (Nat.not_le.2 h)
 
-/-- Coefficients of a polynomial shifted by `X ^ m`: a clean stride lemma used by
-Kronecker packing. -/
+/-- Coefficient of `c * X ^ m`. -/
 theorem coeff_mul_X_pow [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (c : CPolynomial R) (m n : ℕ) :
     coeff (c * X ^ m) n = if m ≤ n then coeff c (n - m) else 0 := by
@@ -59,12 +87,11 @@ theorem coeff_mul_X_pow [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
       · rw [if_pos h, if_pos (Nat.succ_le_succ h), Nat.succ_sub_succ]
       · rw [if_neg h, if_neg (fun hc => h (Nat.le_of_succ_le_succ hc))]
 
-/-- Efficient multiplication by `X ^ m`: prepends `m` zero coefficients (a true shift,
-`O(size)`), unlike the generic convolution `p * X ^ m`. -/
+/-- Multiplication by `X ^ m`, implemented as a coefficient shift. -/
 def shiftPow [Zero R] [BEq R] [LawfulBEq R] (m : ℕ) (p : CPolynomial R) : CPolynomial R :=
   ⟨(p.val.mulPowX m).trim, CPolynomial.Raw.Trim.isCanonical_trim _⟩
 
-/-- Coefficient of an efficient shift: `X ^ m` shifts coefficients up by `m`. -/
+/-- Coefficient of `shiftPow m p`. -/
 theorem coeff_shiftPow [Zero R] [BEq R] [LawfulBEq R] (m : ℕ) (p : CPolynomial R) (n : ℕ) :
     coeff (shiftPow m p) n = if m ≤ n then coeff p (n - m) else 0 := by
   show ((p.val.mulPowX m).trim).coeff n = _
@@ -77,7 +104,7 @@ theorem coeff_shiftPow [Zero R] [BEq R] [LawfulBEq R] (m : ℕ) (p : CPolynomial
   · rw [if_neg h, Array.getElem?_append_left (by simpa using Nat.lt_of_not_le h)]
     simp [Nat.lt_of_not_le h]
 
-/-- The efficient shift agrees with multiplication by `X ^ m`. -/
+/-- `shiftPow m p = p * X ^ m`. -/
 theorem shiftPow_eq_mul_X_pow [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (m : ℕ) (p : CPolynomial R) : shiftPow m p = p * X ^ m := by
   rw [eq_iff_coeff]
@@ -92,11 +119,11 @@ section Stride
 
 variable {D i j : ℕ}
 
-/-- For `i < D`, the packed position `D * j + i` has remainder `i`. -/
+/-- The remainder of the packed position `D * j + i` is `i`. -/
 private theorem stride_mod (hi : i < D) : (D * j + i) % D = i := by
   rw [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hi]
 
-/-- For `i < D`, the packed position `D * j + i` has quotient `j`. -/
+/-- The quotient of the packed position `D * j + i` is `j`. -/
 private theorem stride_div (hD : 0 < D) (hi : i < D) : (D * j + i) / D = j := by
   rw [Nat.add_comm, Nat.add_mul_div_left i j hD, Nat.div_eq_of_lt hi, Nat.zero_add]
 
@@ -106,20 +133,18 @@ section Pack
 
 variable {R : Type*}
 
-/-- Pack a bivariate polynomial into a univariate one by substituting `X ↦ t`, `Y ↦ t^D`.
-The coefficient of `X^i Y^j` (with `i < D`) lands at position `D * j + i`. -/
+/-- Pack a bivariate polynomial into a univariate one with stride `D`. -/
 def kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (D : ℕ) (p : CBivariate R) : CPolynomial R :=
   CPolynomial.eval₂ (RingHom.id (CPolynomial R)) (CPolynomial.X ^ D) p
 
-/-- Unpack a univariate polynomial into a bivariate one: position `k` becomes the
-monomial `X^(k % D) Y^(k / D)`. -/
+/-- Unpack a univariate polynomial into a bivariate one with stride `D`. -/
 def kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (D : ℕ) (P : CPolynomial R) : CBivariate R :=
   (CPolynomial.support P).sum
     (fun k => monomialXY (k % D) (k / D) (CPolynomial.coeff P k))
 
-/-- Packing is multiplicative: it is the evaluation of a ring homomorphism. -/
+/-- Packing is multiplicative. -/
 theorem kroneckerPack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (D : ℕ) (p q : CBivariate R) :
     kroneckerPack D (p * q) = kroneckerPack D p * kroneckerPack D q := by
@@ -128,7 +153,7 @@ theorem kroneckerPack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
   rw [show CPolynomial.toPoly (p * q) = CPolynomial.toPoly p * CPolynomial.toPoly q from
     CPolynomial.toPoly_mul p q, Polynomial.eval₂_mul]
 
-/-- Packing as an explicit sum of shifted Y-coefficients: `p = Σ_j c_j(X) · X^(D·j)`. -/
+/-- Packing written as a sum of shifted `Y`-coefficients. -/
 theorem kroneckerPack_eq_sum [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (D : ℕ) (p : CBivariate R) :
     kroneckerPack D p
@@ -140,8 +165,7 @@ theorem kroneckerPack_eq_sum [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
   intro i _
   rw [RingHom.id_apply, ← pow_mul]
 
-/-- Packing coefficient lemma: when every X-degree is `< D`, the coefficient at position
-`n` of the packed polynomial is the bivariate coefficient at `(n % D, n / D)`. -/
+/-- Coefficient of the packed polynomial, when the `X`-degree is below the stride. -/
 theorem coeff_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     {D : ℕ} (hD : 0 < D) (p : CBivariate R) (hp : natDegreeX p < D) (n : ℕ) :
     CPolynomial.coeff (kroneckerPack D p) n = coeff p (n % D) (n / D) := by
@@ -149,8 +173,7 @@ theorem coeff_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
   · rw [CPolynomial.coeff_mul_X_pow, if_pos (Nat.mul_div_le n D)]
     have hsub : n - D * (n / D) = n % D := by have := Nat.mod_add_div n D; omega
     rw [hsub]; rfl
-  · -- every other column contributes nothing: its only reachable position exceeds its degree
-    intro i hi hine
+  · intro i hi hine
     rw [CPolynomial.coeff_mul_X_pow]
     split_ifs with hle
     · refine CPolynomial.coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt (b := natDegreeX p) ?_ ?_)
@@ -167,14 +190,13 @@ theorem coeff_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
       by_contra hc; exact hns ((CPolynomial.mem_support_iff p (n / D)).2 hc)
     rw [h0, zero_mul, CPolynomial.coeff_zero]
 
-/-- Efficient packing: sum of the Y-coefficients shifted by `X^(D·j)` using the cheap
-`CPolynomial.shiftPow` rather than the power-recomputing `eval₂` of `kroneckerPack`. -/
+/-- Efficient packing, linear in the output. -/
 def kroneckerPackFast [Semiring R] [BEq R] [LawfulBEq R]
     (D : ℕ) (p : CBivariate R) : CPolynomial R :=
   (CPolynomial.support p).sum
     (fun j => CPolynomial.shiftPow (D * j) (CPolynomial.coeff p j))
 
-/-- The efficient packing equals the verified `kroneckerPack` (unconditionally). -/
+/-- `kroneckerPackFast` equals `kroneckerPack`. -/
 theorem kroneckerPackFast_eq [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (D : ℕ) (p : CBivariate R) : kroneckerPackFast D p = kroneckerPack D p := by
   rw [kroneckerPackFast, kroneckerPack_eq_sum]
@@ -188,8 +210,7 @@ section Unpack
 
 variable {R : Type*}
 
-/-- Unpacking coefficient lemma (above the stride): a bivariate coefficient with
-X-exponent `≥ D` is zero. -/
+/-- Unpacked coefficients with `X`-exponent at least `D` are zero. -/
 theorem coeff_kroneckerUnpack_of_le [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     [DecidableEq R] {D : ℕ} (hD : 0 < D) (P : CPolynomial R) (i j : ℕ) (hi : D ≤ i) :
     coeff (kroneckerUnpack D P) i j = 0 := by
@@ -202,8 +223,7 @@ theorem coeff_kroneckerUnpack_of_le [Semiring R] [BEq R] [LawfulBEq R] [Nontrivi
   have : k % D < D := Nat.mod_lt _ hD
   omega
 
-/-- Unpacking coefficient lemma (within the stride): for `i < D`, the bivariate coefficient
-at `(i, j)` of the unpacked polynomial is the univariate coefficient at `D * j + i`. -/
+/-- Unpacked coefficient at `(i, j)` with `i < D`. -/
 theorem coeff_kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     [DecidableEq R] {D : ℕ} (hD : 0 < D) (P : CPolynomial R) (i j : ℕ) (hi : i < D) :
     coeff (kroneckerUnpack D P) i j = CPolynomial.coeff P (D * j + i) := by
@@ -224,13 +244,12 @@ theorem coeff_kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     by_contra hc
     exact hns ((CPolynomial.mem_support_iff P (D * j + i)).2 hc)
 
-/-- The `j`-th X-column of a packed polynomial: the length-`D` window
-`P[D*j .. D*j+D)` as a univariate polynomial in `X`. -/
+/-- The length-`D` slice of `P` holding column `j`. -/
 def window [Zero R] [BEq R] [LawfulBEq R] (D j : ℕ) (P : CPolynomial R) : CPolynomial R :=
   ⟨CPolynomial.Raw.trim (P.val.extract (D * j) (D * j + D)),
     CPolynomial.Raw.Trim.isCanonical_trim _⟩
 
-/-- Coefficient of a column window: position `i < D` reads off `P` at `D * j + i`. -/
+/-- Coefficient of a column slice. -/
 theorem coeff_window [Zero R] [BEq R] [LawfulBEq R] (D j : ℕ) (P : CPolynomial R) (i : ℕ) :
     CPolynomial.coeff (window D j P) i =
       if i < D then CPolynomial.coeff P (D * j + i) else 0 := by
@@ -250,14 +269,13 @@ theorem coeff_window [Zero R] [BEq R] [LawfulBEq R] (D j : ℕ) (P : CPolynomial
     rw [if_neg (by omega : ¬ i < min (D * j + D) P.val.size - D * j)]
     rfl
 
-/-- Efficient unpacking: assemble the X-columns `Y^j * window j` directly, avoiding the
-per-coefficient monomial sum of `kroneckerUnpack`. -/
+/-- Efficient unpacking, assembling columns directly. -/
 def kroneckerUnpackFast [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (D : ℕ) (P : CPolynomial R) : CBivariate R :=
   (Finset.range (P.natDegree / D + 1)).sum
     (fun j => CPolynomial.monomial j (window D j P))
 
-/-- The efficient unpacking equals the verified `kroneckerUnpack`. -/
+/-- `kroneckerUnpackFast` equals `kroneckerUnpack`. -/
 theorem kroneckerUnpackFast_eq [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     {D : ℕ} (hD : 0 < D) (P : CPolynomial R) :
     kroneckerUnpackFast D P = kroneckerUnpack D P := by
@@ -286,7 +304,7 @@ section Correctness
 
 variable {R : Type*}
 
-/-- Round-trip: under the X-degree bound, unpacking recovers the packed polynomial. -/
+/-- Unpacking recovers a packed polynomial when its `X`-degree is below the stride. -/
 theorem kroneckerUnpack_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     [DecidableEq R] {D : ℕ} (hD : 0 < D) (p : CBivariate R) (hp : natDegreeX p < D) :
     kroneckerUnpack D (kroneckerPack D p) = p := by
@@ -295,8 +313,7 @@ theorem kroneckerUnpack_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontri
   by_cases hi : i < D
   · rw [coeff_kroneckerUnpack hD _ i j hi, coeff_kroneckerPack hD p hp,
       stride_mod hi, stride_div hD hi]
-  · -- the bivariate coefficient at X-exponent `i ≥ D > natDegreeX p` vanishes
-    rw [coeff_kroneckerUnpack_of_le hD _ i j (Nat.le_of_not_lt hi)]
+  · rw [coeff_kroneckerUnpack_of_le hD _ i j (Nat.le_of_not_lt hi)]
     have hdeg : (CPolynomial.coeff p j).natDegree < i := by
       by_cases hj : j ∈ CPolynomial.support p
       · exact lt_of_le_of_lt (Finset.le_sup (f := fun n => (p.val.coeff n).natDegree) hj)
@@ -306,9 +323,8 @@ theorem kroneckerUnpack_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontri
         rw [h0]; show 0 < i; omega
     exact (CPolynomial.coeff_eq_zero_of_natDegree_lt hdeg).symm
 
-/-- **Kronecker substitution correctness.** When the product fits within the stride
-(`natDegreeX (p * q) < D`), bivariate multiplication equals one univariate multiplication
-followed by unpacking. -/
+/-- Bivariate multiplication as pack, univariate multiply, unpack, when the product fits
+the stride. -/
 theorem kroneckerUnpack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     [DecidableEq R] {D : ℕ} (hD : 0 < D) (p q : CBivariate R)
     (hpq : natDegreeX (p * q) < D) :
@@ -316,9 +332,7 @@ theorem kroneckerUnpack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R
   rw [← kroneckerPack_mul]
   exact kroneckerUnpack_kroneckerPack hD (p * q) hpq
 
-/-- **Correctness of the efficient pipeline.** The fast `kroneckerPackFast` /
-`kroneckerUnpackFast` (used by the benchmark) compute the same bivariate product as the
-verified spec, under the same stride condition `natDegreeX (p * q) < D`. -/
+/-- `kroneckerUnpack_mul` for the efficient `kroneckerPackFast` / `kroneckerUnpackFast`. -/
 theorem kroneckerUnpackFast_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     [DecidableEq R] {D : ℕ} (hD : 0 < D) (p q : CBivariate R)
     (hpq : natDegreeX (p * q) < D) :
@@ -326,15 +340,7 @@ theorem kroneckerUnpackFast_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivi
   rw [kroneckerPackFast_eq, kroneckerPackFast_eq, kroneckerUnpackFast_eq hD]
   exact kroneckerUnpack_mul hD p q hpq
 
-/-- **Kronecker substitution backed by NTT multiplication.** Combines `kroneckerPack` /
-`kroneckerUnpack` with the NTT-accelerated `withFallback` univariate multiplication: when
-the product fits the stride (`natDegreeX (p * q) < D`), bivariate multiplication reduces to
-a single fast univariate multiplication.
-
-No domain-fit hypothesis is needed: `withFallback` selects a fitting NTT domain when one
-exists and otherwise falls back to schoolbook multiplication, so it is unconditionally equal
-to `*`. The only remaining hypothesis, `natDegreeX (p * q) < D`, is intrinsic to Kronecker
-packing, not to the multiplication backend. -/
+/-- Bivariate multiplication using the NTT (`withFallback`) as the univariate backend. -/
 theorem kroneckerUnpack_withFallback [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
     (bestDomainForLength? : (requiredLen : Nat) →
       Option (CPolynomial.NTT.FittingDomain R requiredLen))
@@ -346,13 +352,8 @@ theorem kroneckerUnpack_withFallback [Field R] [BEq R] [LawfulBEq R] [DecidableE
   rw [CPolynomial.NTT.FastMul.withFallback_eq_mul]
   exact kroneckerUnpack_mul hD p q hpq
 
-/-- **Kronecker substitution backed by the recursive (NTTFast) multiplication.** As
-`kroneckerUnpack_withFallback`, but using the recursive radix-2/radix-4 NTT pipeline
-(`CPolynomial.NTTFast.withFallback`) as the univariate multiplication backend.
-
-No domain-fit hypothesis is needed: `withFallback` falls back to schoolbook multiplication
-when no NTT domain fits, so it is unconditionally equal to `*`. The only remaining
-hypothesis, `natDegreeX (p * q) < D`, is intrinsic to Kronecker packing. -/
+/-- Bivariate multiplication using the recursive NTT (`NTTFast.withFallback`) as the
+univariate backend. -/
 theorem kroneckerUnpack_withFallbackFast [Field R] [BEq R] [LawfulBEq R] [DecidableEq R]
     (bestDomainForLength? : (requiredLen : Nat) →
       Option (CPolynomial.NTT.FittingDomain R requiredLen))

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -169,7 +169,7 @@ theorem coeff_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
 
 /-- Efficient packing: sum of the Y-coefficients shifted by `X^(D·j)` using the cheap
 `CPolynomial.shiftPow` rather than the power-recomputing `eval₂` of `kroneckerPack`. -/
-def kroneckerPackFast [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+def kroneckerPackFast [Semiring R] [BEq R] [LawfulBEq R]
     (D : ℕ) (p : CBivariate R) : CPolynomial R :=
   (CPolynomial.support p).sum
     (fun j => CPolynomial.shiftPow (D * j) (CPolynomial.coeff p j))

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -12,51 +12,31 @@ import CompPoly.Univariate.NTTFast.Correctness
 /-!
 # Kronecker substitution for bivariate polynomials
 
-Kronecker substitution turns one bivariate multiplication into one univariate
-multiplication. Fix a stride `D` and substitute `X ↦ t`, `Y ↦ t ^ D`. This sends a
-bivariate polynomial `p : CBivariate R` to a univariate polynomial
-`kroneckerPack D p : CPolynomial R` in which the coefficient of `X ^ i Y ^ j` is placed at
-position `D * j + i`.
+Kronecker substitution turns a bivariate multiplication into a univariate multiplication by
+fixing a gap `D` and substituting `X ↦ t`, `Y ↦ t ^ D`. This sends a bivariate
+polynomial `p : CBivariate R` to a univariate polynomial `kroneckerPack D p : CPolynomial R`
+in which the coefficient of `X ^ i Y ^ j` is placed at position `D * j + i`.
 
-To multiply `p` and `q`: pack both, multiply the two univariate polynomials once, then
-unpack the result. The middle step is an ordinary univariate multiplication, so any fast
-univariate multiplication gives a fast bivariate multiplication. The NTT versions are
-`kroneckerUnpack_withFallback` and `kroneckerUnpack_withFallbackFast`.
+Packing is a ring homomorphism, so the packed product equals the product of the packed
+operands for any `p` and `q`; the only condition is recovering the answer afterwards. The
+position `D * j + i` determines `i` and `j` only when `i < D`, so packing can be reversed
+exactly on polynomials with `natDegreeX < D`. Recovering a product `p * q` therefore needs
+`natDegreeX (p * q) < D`, and since `natDegreeX (p * q) ≤ natDegreeX p + natDegreeX q`, it is
+enough to choose `D` greater than `natDegreeX p + natDegreeX q`.
 
-## Why it is correct
+Kronecker substitution is not itself an optimisation; it lets a fast univariate
+multiplication carry out the bivariate one. The NTT versions multiply through `withFallback`,
+which uses an NTT domain when one fits and otherwise multiplies the ordinary way, so it is
+always equal to `*` and adds no assumption about the domain beyond the gap condition above.
 
-Two separate facts are involved, and the proofs keep them apart.
+## Main results
 
-Packing keeps each `X`-coefficient and sends `Y` to `X ^ D`. This is a ring homomorphism,
-so `kroneckerPack D (p * q) = kroneckerPack D p * kroneckerPack D q` holds for every `p`
-and `q` with no extra condition (`kroneckerPack_mul`): multiplying in the packed form is
-always the same as packing the product.
-
-Recovering a bivariate polynomial from a packed one is where a condition appears. Packing
-is not injective in general, because the position `D * j + i` determines `i` and `j` only
-when `i < D`. If some `X`-exponent reaches `D`, two different monomials can be placed on
-the same position and can no longer be told apart. Unpacking inverts packing exactly when
-every `X`-exponent stays below `D`, that is when `natDegreeX p < D`
-(`kroneckerUnpack_kroneckerPack`).
-
-For a product the stride must therefore exceed the `X`-degree of `p * q`. The main result
-`kroneckerUnpack_mul` assumes `natDegreeX (p * q) < D`. Since
-`natDegreeX (p * q) ≤ natDegreeX p + natDegreeX q`, it is enough in practice to choose `D`
-greater than `natDegreeX p + natDegreeX q`.
-
-## Two versions of pack and unpack
-
-`kroneckerPack` and `kroneckerUnpack` are written so the proofs above stay short: packing
-is one evaluation and unpacking is one sum over coefficients. Run directly they are slow,
-because the evaluation recomputes powers of `X ^ D`. `kroneckerPackFast` and
-`kroneckerUnpackFast` compute the same polynomials in time linear in the output by shifting
-and slicing coefficient arrays, and are proved equal to the plain versions
-(`kroneckerPackFast_eq`, `kroneckerUnpackFast_eq`), so every correctness result carries
-over to them (`kroneckerUnpackFast_mul`).
-
-The NTT versions multiply through `withFallback`, which uses an NTT domain when one fits
-and otherwise multiplies the ordinary way. It is always equal to `*`, so those results need
-no extra assumption about the domain beyond the stride condition above.
+* `kroneckerPack` / `kroneckerUnpack` — the substitution and its inverse.
+* `kroneckerPack_mul` — packing is multiplicative.
+* `kroneckerUnpack_mul` — bivariate multiplication as pack, multiply, unpack.
+* `kroneckerPackFast` / `kroneckerUnpackFast` — linear-time versions, proved equal to the above.
+* `kroneckerUnpack_withFallback` / `kroneckerUnpack_withFallbackFast` — multiplication backed by
+  the classic and recursive NTT.
 -/
 
 namespace CompPoly
@@ -115,30 +95,30 @@ end CPolynomial
 
 namespace CBivariate
 
-section Stride
+section Gap
 
 variable {D i j : ℕ}
 
 /-- The remainder of the packed position `D * j + i` is `i`. -/
-private theorem stride_mod (hi : i < D) : (D * j + i) % D = i := by
+private theorem gap_mod (hi : i < D) : (D * j + i) % D = i := by
   rw [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hi]
 
 /-- The quotient of the packed position `D * j + i` is `j`. -/
-private theorem stride_div (hD : 0 < D) (hi : i < D) : (D * j + i) / D = j := by
+private theorem gap_div (hD : 0 < D) (hi : i < D) : (D * j + i) / D = j := by
   rw [Nat.add_comm, Nat.add_mul_div_left i j hD, Nat.div_eq_of_lt hi, Nat.zero_add]
 
-end Stride
+end Gap
 
 section Pack
 
 variable {R : Type*}
 
-/-- Pack a bivariate polynomial into a univariate one with stride `D`. -/
+/-- Pack a bivariate polynomial into a univariate one with gap `D`. -/
 def kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (D : ℕ) (p : CBivariate R) : CPolynomial R :=
   CPolynomial.eval₂ (RingHom.id (CPolynomial R)) (CPolynomial.X ^ D) p
 
-/-- Unpack a univariate polynomial into a bivariate one with stride `D`. -/
+/-- Unpack a univariate polynomial into a bivariate one with gap `D`. -/
 def kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
     (D : ℕ) (P : CPolynomial R) : CBivariate R :=
   (CPolynomial.support P).sum
@@ -165,7 +145,7 @@ theorem kroneckerPack_eq_sum [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
   intro i _
   rw [RingHom.id_apply, ← pow_mul]
 
-/-- Coefficient of the packed polynomial, when the `X`-degree is below the stride. -/
+/-- Coefficient of the packed polynomial, when the `X`-degree is below the gap. -/
 theorem coeff_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     {D : ℕ} (hD : 0 < D) (p : CBivariate R) (hp : natDegreeX p < D) (n : ℕ) :
     CPolynomial.coeff (kroneckerPack D p) n = coeff p (n % D) (n / D) := by
@@ -228,7 +208,7 @@ theorem coeff_kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     [DecidableEq R] {D : ℕ} (hD : 0 < D) (P : CPolynomial R) (i j : ℕ) (hi : i < D) :
     coeff (kroneckerUnpack D P) i j = CPolynomial.coeff P (D * j + i) := by
   have hkey : i = (D * j + i) % D ∧ j = (D * j + i) / D :=
-    ⟨(stride_mod hi).symm, (stride_div hD hi).symm⟩
+    ⟨(gap_mod hi).symm, (gap_div hD hi).symm⟩
   unfold kroneckerUnpack
   rw [coeff_finset_sum, Finset.sum_eq_single (D * j + i)]
   · rw [coeff_monomialXY, if_pos hkey]
@@ -304,7 +284,7 @@ section Correctness
 
 variable {R : Type*}
 
-/-- Unpacking recovers a packed polynomial when its `X`-degree is below the stride. -/
+/-- Unpacking recovers a packed polynomial when its `X`-degree is below the gap. -/
 theorem kroneckerUnpack_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     [DecidableEq R] {D : ℕ} (hD : 0 < D) (p : CBivariate R) (hp : natDegreeX p < D) :
     kroneckerUnpack D (kroneckerPack D p) = p := by
@@ -312,7 +292,7 @@ theorem kroneckerUnpack_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontri
   intro i j
   by_cases hi : i < D
   · rw [coeff_kroneckerUnpack hD _ i j hi, coeff_kroneckerPack hD p hp,
-      stride_mod hi, stride_div hD hi]
+      gap_mod hi, gap_div hD hi]
   · rw [coeff_kroneckerUnpack_of_le hD _ i j (Nat.le_of_not_lt hi)]
     have hdeg : (CPolynomial.coeff p j).natDegree < i := by
       by_cases hj : j ∈ CPolynomial.support p
@@ -324,7 +304,7 @@ theorem kroneckerUnpack_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontri
     exact (CPolynomial.coeff_eq_zero_of_natDegree_lt hdeg).symm
 
 /-- Bivariate multiplication as pack, univariate multiply, unpack, when the product fits
-the stride. -/
+the gap. -/
 theorem kroneckerUnpack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     [DecidableEq R] {D : ℕ} (hD : 0 < D) (p q : CBivariate R)
     (hpq : natDegreeX (p * q) < D) :

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -59,6 +59,31 @@ theorem coeff_mul_X_pow [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
       · rw [if_pos h, if_pos (Nat.succ_le_succ h), Nat.succ_sub_succ]
       · rw [if_neg h, if_neg (fun hc => h (Nat.le_of_succ_le_succ hc))]
 
+/-- Efficient multiplication by `X ^ m`: prepends `m` zero coefficients (a true shift,
+`O(size)`), unlike the generic convolution `p * X ^ m`. -/
+def shiftPow [Zero R] [BEq R] [LawfulBEq R] (m : ℕ) (p : CPolynomial R) : CPolynomial R :=
+  ⟨(p.val.mulPowX m).trim, CPolynomial.Raw.Trim.isCanonical_trim _⟩
+
+/-- Coefficient of an efficient shift: `X ^ m` shifts coefficients up by `m`. -/
+theorem coeff_shiftPow [Zero R] [BEq R] [LawfulBEq R] (m : ℕ) (p : CPolynomial R) (n : ℕ) :
+    coeff (shiftPow m p) n = if m ≤ n then coeff p (n - m) else 0 := by
+  show ((p.val.mulPowX m).trim).coeff n = _
+  rw [CPolynomial.Raw.Trim.coeff_eq_coeff]
+  simp only [CPolynomial.Raw.mulPowX, CPolynomial.Raw.coeff, CPolynomial.Raw.mk,
+    Array.getD_eq_getD_getElem?]
+  by_cases h : m ≤ n
+  · rw [if_pos h, Array.getElem?_append_right (by simpa using h)]
+    simp
+  · rw [if_neg h, Array.getElem?_append_left (by simpa using Nat.lt_of_not_le h)]
+    simp [Nat.lt_of_not_le h]
+
+/-- The efficient shift agrees with multiplication by `X ^ m`. -/
+theorem shiftPow_eq_mul_X_pow [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (m : ℕ) (p : CPolynomial R) : shiftPow m p = p * X ^ m := by
+  rw [eq_iff_coeff]
+  intro n
+  rw [coeff_shiftPow, coeff_mul_X_pow]
+
 end CPolynomial
 
 namespace CBivariate
@@ -142,20 +167,24 @@ theorem kroneckerPack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
   rw [show CPolynomial.toPoly (p * q) = CPolynomial.toPoly p * CPolynomial.toPoly q from
     CPolynomial.toPoly_mul p q, Polynomial.eval₂_mul]
 
+/-- Packing as an explicit sum of shifted Y-coefficients: `p = Σ_j c_j(X) · X^(D·j)`. -/
+theorem kroneckerPack_eq_sum [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (D : ℕ) (p : CBivariate R) :
+    kroneckerPack D p
+      = (CPolynomial.support p).sum
+          (fun i => CPolynomial.coeff p i * CPolynomial.X ^ (D * i)) := by
+  unfold kroneckerPack
+  rw [CPolynomial.eval₂_eq_sum_support]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [RingHom.id_apply, ← pow_mul]
+
 /-- Packing coefficient lemma: when every X-degree is `< D`, the coefficient at position
 `n` of the packed polynomial is the bivariate coefficient at `(n % D, n / D)`. -/
 theorem coeff_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     {D : ℕ} (hD : 0 < D) (p : CBivariate R) (hp : natDegreeX p < D) (n : ℕ) :
     CPolynomial.coeff (kroneckerPack D p) n = coeff p (n % D) (n / D) := by
-  have hsum : kroneckerPack D p
-      = (CPolynomial.support p).sum
-          (fun i => CPolynomial.coeff p i * CPolynomial.X ^ (D * i)) := by
-    unfold kroneckerPack
-    rw [CPolynomial.eval₂_eq_sum_support]
-    apply Finset.sum_congr rfl
-    intro i _
-    rw [RingHom.id_apply, ← pow_mul]
-  rw [hsum, CPolynomial.coeff_finset_sum]
+  rw [kroneckerPack_eq_sum, CPolynomial.coeff_finset_sum]
   rw [Finset.sum_eq_single (n / D)]
   · rw [CPolynomial.coeff_mul_X_pow]
     have hle : D * (n / D) ≤ n := Nat.mul_div_le n D
@@ -185,6 +214,21 @@ theorem coeff_kroneckerPack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
       by_contra hc
       exact hns ((CPolynomial.mem_support_iff p (n / D)).2 hc)
     rw [h0, zero_mul, CPolynomial.coeff_zero]
+
+/-- Efficient packing: sum of the Y-coefficients shifted by `X^(D·j)` using the cheap
+`CPolynomial.shiftPow` rather than the power-recomputing `eval₂` of `kroneckerPack`. -/
+def kroneckerPackFast [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (D : ℕ) (p : CBivariate R) : CPolynomial R :=
+  (CPolynomial.support p).sum
+    (fun j => CPolynomial.shiftPow (D * j) (CPolynomial.coeff p j))
+
+/-- The efficient packing equals the verified `kroneckerPack` (unconditionally). -/
+theorem kroneckerPackFast_eq [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    (D : ℕ) (p : CBivariate R) : kroneckerPackFast D p = kroneckerPack D p := by
+  rw [kroneckerPackFast, kroneckerPack_eq_sum]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [CPolynomial.shiftPow_eq_mul_X_pow]
 
 end Pack
 
@@ -232,6 +276,74 @@ theorem coeff_kroneckerUnpack [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     by_contra hc
     exact hns ((CPolynomial.mem_support_iff P (D * j + i)).2 hc)
 
+/-- The `j`-th X-column of a packed polynomial: the length-`D` window
+`P[D*j .. D*j+D)` as a univariate polynomial in `X`. -/
+def window [Zero R] [BEq R] [LawfulBEq R] (D j : ℕ) (P : CPolynomial R) : CPolynomial R :=
+  ⟨CPolynomial.Raw.trim (P.val.extract (D * j) (D * j + D)),
+    CPolynomial.Raw.Trim.isCanonical_trim _⟩
+
+/-- Coefficient of a column window: position `i < D` reads off `P` at `D * j + i`. -/
+theorem coeff_window [Zero R] [BEq R] [LawfulBEq R] (D j : ℕ) (P : CPolynomial R) (i : ℕ) :
+    CPolynomial.coeff (window D j P) i =
+      if i < D then CPolynomial.coeff P (D * j + i) else 0 := by
+  have hcoe : CPolynomial.coeff P (D * j + i) = (P.val[D * j + i]?).getD 0 := by
+    rw [CPolynomial.coeff, CPolynomial.Raw.coeff, Array.getD_eq_getD_getElem?]
+  show CPolynomial.Raw.coeff (CPolynomial.Raw.trim (P.val.extract (D * j) (D * j + D))) i = _
+  rw [CPolynomial.Raw.Trim.coeff_eq_coeff, CPolynomial.Raw.coeff,
+    Array.getD_eq_getD_getElem?, Array.getElem?_extract]
+  by_cases hiD : i < D
+  · rw [if_pos hiD, hcoe]
+    by_cases hb : i < min (D * j + D) P.val.size - D * j
+    · rw [if_pos hb]
+    · rw [if_neg hb, Nat.not_lt] at *
+      have hsz : P.val.size ≤ D * j + i := by omega
+      rw [Array.getElem?_eq_none hsz]
+  · rw [if_neg hiD, Nat.not_lt] at *
+    rw [if_neg (by omega : ¬ i < min (D * j + D) P.val.size - D * j)]
+    rfl
+
+/-- Coefficient of a `Y`-monomial `Y^m * c(X)` viewed bivariately. -/
+theorem coeff_monomialY [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (m : ℕ) (c : CPolynomial R) (i j : ℕ) :
+    coeff (CPolynomial.monomial m c) i j = if j = m then CPolynomial.coeff c i else 0 := by
+  show (CPolynomial.coeff (CPolynomial.monomial m c) j).coeff i = _
+  rw [CPolynomial.coeff_monomial]
+  by_cases hj : j = m
+  · rw [if_pos hj, if_pos hj]
+  · rw [if_neg hj, if_neg hj, CPolynomial.coeff_zero]
+
+/-- Efficient unpacking: assemble the X-columns `Y^j * window j` directly, avoiding the
+per-coefficient monomial sum of `kroneckerUnpack`. -/
+def kroneckerUnpackFast [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    (D : ℕ) (P : CPolynomial R) : CBivariate R :=
+  (Finset.range (P.natDegree / D + 1)).sum
+    (fun j => CPolynomial.monomial j (window D j P))
+
+/-- The efficient unpacking equals the verified `kroneckerUnpack`. -/
+theorem kroneckerUnpackFast_eq [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
+    {D : ℕ} (hD : 0 < D) (P : CPolynomial R) :
+    kroneckerUnpackFast D P = kroneckerUnpack D P := by
+  rw [eq_iff_coeff]
+  intro i j
+  rw [kroneckerUnpackFast, coeff_finset_sum]
+  simp only [coeff_monomialY]
+  rw [Finset.sum_ite_eq (Finset.range (P.natDegree / D + 1)) j
+    (fun j' => CPolynomial.coeff (window D j' P) i), coeff_window]
+  by_cases hiD : i < D
+  · rw [if_pos hiD, coeff_kroneckerUnpack hD _ i j hiD]
+    by_cases hjr : j ∈ Finset.range (P.natDegree / D + 1)
+    · rw [if_pos hjr]
+    · rw [if_neg hjr]
+      rw [Finset.mem_range, Nat.not_lt] at hjr
+      refine (CPolynomial.coeff_eq_zero_of_natDegree_lt ?_).symm
+      have hdm := Nat.div_add_mod P.natDegree D
+      have hmd := Nat.mod_lt P.natDegree hD
+      have hmul : D * (P.natDegree / D + 1) ≤ D * j := Nat.mul_le_mul_left D hjr
+      have : D * (P.natDegree / D + 1) = D * (P.natDegree / D) + D := by ring
+      omega
+  · rw [if_neg hiD, coeff_kroneckerUnpack_of_le hD _ i j (Nat.le_of_not_lt hiD)]
+    by_cases hjr : j ∈ Finset.range (P.natDegree / D + 1) <;> simp [hjr]
+
 end Unpack
 
 section Correctness
@@ -276,6 +388,16 @@ theorem kroneckerUnpack_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R
     kroneckerUnpack D (kroneckerPack D p * kroneckerPack D q) = p * q := by
   rw [← kroneckerPack_mul]
   exact kroneckerUnpack_kroneckerPack hD (p * q) hpq
+
+/-- **Correctness of the efficient pipeline.** The fast `kroneckerPackFast` /
+`kroneckerUnpackFast` (used by the benchmark) compute the same bivariate product as the
+verified spec, under the same stride condition `natDegreeX (p * q) < D`. -/
+theorem kroneckerUnpackFast_mul [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
+    [DecidableEq R] {D : ℕ} (hD : 0 < D) (p q : CBivariate R)
+    (hpq : natDegreeX (p * q) < D) :
+    kroneckerUnpackFast D (kroneckerPackFast D p * kroneckerPackFast D q) = p * q := by
+  rw [kroneckerPackFast_eq, kroneckerPackFast_eq, kroneckerUnpackFast_eq hD]
+  exact kroneckerUnpack_mul hD p q hpq
 
 /-- **Kronecker substitution backed by NTT multiplication.** Combines `kroneckerPack` /
 `kroneckerUnpack` with the NTT-accelerated `withFallback` univariate multiplication: when

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -17,10 +17,11 @@ fixing a gap `D` and substituting `X ↦ t`, `Y ↦ t ^ D`. This sends a bivaria
 polynomial `p : CBivariate R` to a univariate polynomial `kroneckerPack D p : CPolynomial R`
 in which the coefficient of `X ^ i Y ^ j` is placed at position `D * j + i`.
 
-Packing is a ring homomorphism, so the packed product equals the product of the packed
-operands for any `p` and `q`; the only condition is recovering the answer afterwards. The
-position `D * j + i` determines `i` and `j` only when `i < D`, so packing can be reversed
-exactly on polynomials with `natDegreeX < D`. Recovering a product `p * q` therefore needs
+Packing is a ring homomorphism, so for any `p` and `q` the packed product equals the
+product of the packed operands, with no condition on degrees. A condition is needed only to
+unpack the result. The position `D * j + i` determines `i` and `j` only when `i < D`, so
+packing can be reversed exactly on polynomials with `natDegreeX < D`. Recovering a product
+`p * q` therefore needs
 `natDegreeX (p * q) < D`, and since `natDegreeX (p * q) ≤ natDegreeX p + natDegreeX q`, it is
 enough to choose `D` greater than `natDegreeX p + natDegreeX q`.
 

--- a/CompPoly/Bivariate/README.md
+++ b/CompPoly/Bivariate/README.md
@@ -12,6 +12,7 @@ Formally verified computable bivariate polynomials for [CompPoly](../../README.m
 
 - **Basic.lean** — Type definition, constructors (`CC`, `C_X`, `Y`, `monomialXY`), operations (`coeff`, `evalX`, `evalY`, `evalEval`, `natDegreeX`, `natDegreeY`, `totalDegree`, `natWeightedDegree`, `leadingCoeffY`, `leadingCoeffX`, `swap`, `support`).
 - **ToPoly.lean** — Conversion to/from Mathlib's `R[X][Y]` via `toPoly` and `ofPoly`, with round-trip theorems, ring equivalence, and correctness lemmas for coefficients, evaluation, support, and degree APIs.
+- **Kronecker.lean** — Kronecker substitution (`kroneckerPack`, `kroneckerUnpack`) reducing bivariate multiplication to one univariate multiplication, with multiplicativity of packing and round-trip correctness under an X-degree bound (`kroneckerUnpack_mul`).
 
 Mathlib-facing helper files for `R[X][Y]` live under `CompPoly/ToMathlib/Polynomial/`:
 - [`../ToMathlib/Polynomial/BivariateDegree.lean`](../ToMathlib/Polynomial/BivariateDegree.lean)

--- a/tests/CompPolyTests.lean
+++ b/tests/CompPolyTests.lean
@@ -7,6 +7,7 @@ Authors: Valerii Huhnin
 import CompPolyTests.Bivariate.Basic
 import CompPolyTests.Bivariate.Degree
 import CompPolyTests.Bivariate.Factor
+import CompPolyTests.Bivariate.Kronecker
 import CompPolyTests.Bivariate.Deriv
 import CompPolyTests.Bivariate.Multiplicity
 import CompPolyTests.Bivariate.WeightedDegree

--- a/tests/CompPolyTests/Bivariate/Kronecker.lean
+++ b/tests/CompPolyTests/Bivariate/Kronecker.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 CompPoly. All rights reserved.
+Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dimitris Mitsios
 -/

--- a/tests/CompPolyTests/Bivariate/Kronecker.lean
+++ b/tests/CompPolyTests/Bivariate/Kronecker.lean
@@ -9,10 +9,10 @@ import CompPolyTests.Bivariate.KroneckerCommon
 /-!
   # Kronecker substitution tests
 
-  Regressions for `kroneckerPack` / `kroneckerUnpack` packing coefficients and the
-  round-trip recovery under the X-degree bound, plus a small runtime smoke test that the
-  efficient and NTT-backed pipelines agree with schoolbook multiplication on compiled
-  KoalaBear data. The full timing sweep lives in `KroneckerBenchmark.lean`.
+  Packing coefficients and round-trip recovery for `kroneckerPack` / `kroneckerUnpack`,
+  followed by a runtime check that, on small KoalaBear data, each pipeline (schoolbook,
+  classic NTT, recursive NTT) returns the same product as direct multiplication. The full
+  timing comparison lives in `KroneckerBenchmark.lean`.
 -/
 
 namespace CompPoly
@@ -38,10 +38,7 @@ example :
   apply kroneckerUnpack_kroneckerPack (by norm_num)
   rw [natDegreeX_XY2]; omega
 
-/- Runtime smoke test: on small compiled KoalaBear operands, the Kronecker pipeline with
-each univariate backend (schoolbook, classic NTT, recursive NTTFast) agrees with direct
-schoolbook bivariate multiplication. Guards the compiled execution paths (array packing,
-`withFallback` domain selection) that the kernel-checked proofs do not exercise. -/
+/- Each pipeline must return the same product as direct multiplication on small data. -/
 #eval show IO Unit from do
   let n := 4
   let D := 2 * n
@@ -54,7 +51,7 @@ schoolbook bivariate multiplication. Guards the compiled execution paths (array 
   let fast := TestCommon.kronWith
     (CPolynomial.NTTFast.withFallback TestCommon.bestDomainForLength?) D p q
   unless (kron == expected) && (ntt == expected) && (fast == expected) do
-    throw <| IO.userError "Kronecker smoke test: a backend disagreed with schoolbook"
+    throw <| IO.userError "a Kronecker pipeline disagreed with direct multiplication"
 
 end CBivariate
 end CompPoly

--- a/tests/CompPolyTests/Bivariate/Kronecker.lean
+++ b/tests/CompPolyTests/Bivariate/Kronecker.lean
@@ -22,7 +22,7 @@ namespace CBivariate
 private theorem natDegreeX_XY2 : natDegreeX (monomialXY 1 2 (1 : ℚ)) = 1 := by
   rw [natDegreeX_eq_natWeightedDegree, natWeightedDegree_monomialXY (by norm_num) 1 0]
 
-/-- Packing `X Y^2` with stride `3` puts its coefficient at position `3 * 2 + 1 = 7`. -/
+/-- Packing `X Y^2` with gap `3` puts its coefficient at position `3 * 2 + 1 = 7`. -/
 example : CPolynomial.coeff (kroneckerPack 3 (monomialXY 1 2 (1 : ℚ))) 7 = 1 := by
   rw [coeff_kroneckerPack (by norm_num) _ (by rw [natDegreeX_XY2]; omega)]
   rw [coeff_monomialXY, if_pos (by decide)]
@@ -32,7 +32,7 @@ example : CPolynomial.coeff (kroneckerPack 3 (monomialXY 1 2 (1 : ℚ))) 5 = 0 :
   rw [coeff_kroneckerPack (by norm_num) _ (by rw [natDegreeX_XY2]; omega)]
   rw [coeff_monomialXY, if_neg (by decide)]
 
-/-- Round-trip: unpacking the packed monomial recovers it (stride `2 > natDegreeX = 1`). -/
+/-- Round-trip: unpacking the packed monomial recovers it (gap `2 > natDegreeX = 1`). -/
 example :
     kroneckerUnpack 2 (kroneckerPack 2 (monomialXY 1 2 (1 : ℚ))) = monomialXY 1 2 (1 : ℚ) := by
   apply kroneckerUnpack_kroneckerPack (by norm_num)

--- a/tests/CompPolyTests/Bivariate/Kronecker.lean
+++ b/tests/CompPolyTests/Bivariate/Kronecker.lean
@@ -4,12 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dimitris Mitsios
 -/
 import CompPoly.Bivariate.Kronecker
+import CompPolyTests.Bivariate.KroneckerCommon
 
 /-!
   # Kronecker substitution tests
 
   Regressions for `kroneckerPack` / `kroneckerUnpack` packing coefficients and the
-  round-trip recovery under the X-degree bound.
+  round-trip recovery under the X-degree bound, plus a small runtime smoke test that the
+  efficient and NTT-backed pipelines agree with schoolbook multiplication on compiled
+  KoalaBear data. The full timing sweep lives in `KroneckerBenchmark.lean`.
 -/
 
 namespace CompPoly
@@ -34,6 +37,24 @@ example :
     kroneckerUnpack 2 (kroneckerPack 2 (monomialXY 1 2 (1 : ℚ))) = monomialXY 1 2 (1 : ℚ) := by
   apply kroneckerUnpack_kroneckerPack (by norm_num)
   rw [natDegreeX_XY2]; omega
+
+/- Runtime smoke test: on small compiled KoalaBear operands, the Kronecker pipeline with
+each univariate backend (schoolbook, classic NTT, recursive NTTFast) agrees with direct
+schoolbook bivariate multiplication. Guards the compiled execution paths (array packing,
+`withFallback` domain selection) that the kernel-checked proofs do not exercise. -/
+#eval show IO Unit from do
+  let n := 4
+  let D := 2 * n
+  let p := TestCommon.mkBiv n n 41
+  let q := TestCommon.mkBiv n n 73
+  let expected := p * q
+  let kron := TestCommon.kronWith (· * ·) D p q
+  let ntt := TestCommon.kronWith
+    (CPolynomial.NTT.FastMul.withFallback TestCommon.bestDomainForLength?) D p q
+  let fast := TestCommon.kronWith
+    (CPolynomial.NTTFast.withFallback TestCommon.bestDomainForLength?) D p q
+  unless (kron == expected) && (ntt == expected) && (fast == expected) do
+    throw <| IO.userError "Kronecker smoke test: a backend disagreed with schoolbook"
 
 end CBivariate
 end CompPoly

--- a/tests/CompPolyTests/Bivariate/Kronecker.lean
+++ b/tests/CompPolyTests/Bivariate/Kronecker.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2025 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+import CompPoly.Bivariate.Kronecker
+
+/-!
+  # Kronecker substitution tests
+
+  Regressions for `kroneckerPack` / `kroneckerUnpack` packing coefficients and the
+  round-trip recovery under the X-degree bound.
+-/
+
+namespace CompPoly
+namespace CBivariate
+
+/-- The X-degree of the monomial `X Y^2` is `1`. -/
+private theorem natDegreeX_XY2 : natDegreeX (monomialXY 1 2 (1 : ℚ)) = 1 := by
+  rw [natDegreeX_eq_natWeightedDegree, natWeightedDegree_monomialXY (by norm_num) 1 0]
+
+/-- Packing `X Y^2` with stride `3` puts its coefficient at position `3 * 2 + 1 = 7`. -/
+example : CPolynomial.coeff (kroneckerPack 3 (monomialXY 1 2 (1 : ℚ))) 7 = 1 := by
+  rw [coeff_kroneckerPack (by norm_num) _ (by rw [natDegreeX_XY2]; omega)]
+  rw [coeff_monomialXY, if_pos (by decide)]
+
+/-- Positions that do not encode a monomial of `X Y^2` pack to `0`. -/
+example : CPolynomial.coeff (kroneckerPack 3 (monomialXY 1 2 (1 : ℚ))) 5 = 0 := by
+  rw [coeff_kroneckerPack (by norm_num) _ (by rw [natDegreeX_XY2]; omega)]
+  rw [coeff_monomialXY, if_neg (by decide)]
+
+/-- Round-trip: unpacking the packed monomial recovers it (stride `2 > natDegreeX = 1`). -/
+example :
+    kroneckerUnpack 2 (kroneckerPack 2 (monomialXY 1 2 (1 : ℚ))) = monomialXY 1 2 (1 : ℚ) := by
+  apply kroneckerUnpack_kroneckerPack (by norm_num)
+  rw [natDegreeX_XY2]; omega
+
+end CBivariate
+end CompPoly

--- a/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
+++ b/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
@@ -55,41 +55,15 @@ def mkCol (degX seed : Nat) : CPolynomial F :=
 def mkBiv (degY degX seed : Nat) : CBivariate F :=
   canon (Array.ofFn (fun j : Fin degY ↦ mkCol degX (seed + 7 * j.1 + 1)))
 
-/-!
-  ## Efficient packing for the benchmark
+/-- Kronecker pipeline parameterised by the univariate multiplication backend.
 
-  The verified `CBivariate.kroneckerPack` / `kroneckerUnpack` are defined for provability
-  (`eval₂` / sums of monomials) and are *not* efficient: `eval₂` recomputes powers and the
-  monomial products are not specialised to shifts, so packing alone is super-quadratic in
-  the degree. To benchmark the *multiplication* strategies we use these O(size) array-based
-  equivalents (coefficient `X^i Y^j` ↔ position `D * j + i`). An efficient *verified* pack
-  proven equal to the spec versions is future work.
--/
-
-/-- Efficient packing: place coefficient of `X^i Y^j` at position `D * j + i`.
-Assumes each X-degree is `< D` (true here, with `D = 2 * degX`). -/
-def packFast (D : Nat) (p : CBivariate F) : CPolynomial F := Id.run do
-  let cols := p.val
-  let mut arr : Array F := Array.replicate (D * cols.size + D) 0
-  for j in [0:cols.size] do
-    let col := cols[j]!.val
-    for i in [0:col.size] do
-      arr := arr.set! (D * j + i) col[i]!
-  return canon arr
-
-/-- Efficient unpacking: position `k` becomes coefficient of `X^(k % D) Y^(k / D)`. -/
-def unpackFast (D : Nat) (P : CPolynomial F) : CBivariate F := Id.run do
-  let arr := P.val
-  let numCols := (arr.size + D - 1) / D
-  let mut cols : Array (CPolynomial F) := #[]
-  for j in [0:numCols] do
-    cols := cols.push (canon (arr.extract (D * j) (min (D * j + D) arr.size)))
-  return canon cols
-
-/-- Kronecker pipeline parameterised by the univariate multiplication backend. -/
+Uses the verified efficient `kroneckerPackFast` / `kroneckerUnpackFast` from the library
+(both proven equal to the `kroneckerPack` / `kroneckerUnpack` spec; see
+`kroneckerUnpackFast_mul`). The slow spec versions, defined via `eval₂` for provability,
+recompute powers and are unsuitable for benchmarking. -/
 @[inline] def kronWith (mulU : CPolynomial F → CPolynomial F → CPolynomial F)
     (D : Nat) (p q : CBivariate F) : CBivariate F :=
-  unpackFast D (mulU (packFast D p) (packFast D q))
+  kroneckerUnpackFast D (mulU (kroneckerPackFast D p) (kroneckerPackFast D q))
 
 /-- Sweep of square sizes (`degX = degY = n`).
 

--- a/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
+++ b/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+
+import CompPoly.Bivariate.Kronecker
+import CompPoly.Univariate.NTT.KoalaBear
+
+/-!
+  # Bivariate Multiplication Benchmark
+
+  Manual benchmark comparing four strategies for bivariate multiplication over the
+  KoalaBear field:
+
+  1. **normal** — the schoolbook `CBivariate` product `p * q`;
+  2. **kron** — Kronecker substitution with schoolbook univariate multiplication;
+  3. **kron+NTT** — Kronecker with the classic NTT (`NTT.FastMul.withFallback`);
+  4. **kron+FastNTT** — Kronecker with the recursive NTT (`NTTFast.withFallback`).
+
+  All four results are checked for agreement at every size. Operands are square
+  (`degX = degY = n`) and the Kronecker stride is `D = 2 * n`, which always satisfies
+  `natDegreeX (p * q) < D`, so unpacking is faithful.
+
+  Not part of the aggregate `CompPolyTests` build; run manually, e.g.
+  `lake build CompPolyTests.Bivariate.KroneckerBenchmark`.
+-/
+
+namespace CompPoly
+namespace CBivariate
+namespace Benchmark
+
+open scoped CompPoly
+
+/-- KoalaBear field abbreviation. -/
+abbrev F := _root_.KoalaBear.Field
+
+/-- Best-fitting KoalaBear NTT domain for a required convolution length. -/
+def bestDomainForLength? (requiredLen : Nat) :
+    Option (CPolynomial.NTT.FittingDomain F requiredLen) :=
+  CPolynomial.NTT.bestDomainForLength? _root_.KoalaBear.twoAdicity
+    CPolynomial.NTT.KoalaBear.domainOfLogN (by intro _ _; rfl) requiredLen
+
+/-- Wrap a raw coefficient array as a canonical polynomial. -/
+def canon {α : Type} [Zero α] [BEq α] [LawfulBEq α]
+    (arr : CPolynomial.Raw α) : CPolynomial α :=
+  ⟨arr.trim, CPolynomial.Raw.Trim.isCanonical_trim arr⟩
+
+/-- Deterministic univariate column in `X` of length `degX`. -/
+def mkCol (degX seed : Nat) : CPolynomial F :=
+  canon (Array.ofFn (fun i : Fin degX ↦
+    (((i.1 + 1) * seed + i.1 * i.1 + 17 : Nat) : F)))
+
+/-- Deterministic bivariate polynomial with `degY` columns, each of X-length `degX`. -/
+def mkBiv (degY degX seed : Nat) : CBivariate F :=
+  canon (Array.ofFn (fun j : Fin degY ↦ mkCol degX (seed + 7 * j.1 + 1)))
+
+/-!
+  ## Efficient packing for the benchmark
+
+  The verified `CBivariate.kroneckerPack` / `kroneckerUnpack` are defined for provability
+  (`eval₂` / sums of monomials) and are *not* efficient: `eval₂` recomputes powers and the
+  monomial products are not specialised to shifts, so packing alone is super-quadratic in
+  the degree. To benchmark the *multiplication* strategies we use these O(size) array-based
+  equivalents (coefficient `X^i Y^j` ↔ position `D * j + i`). An efficient *verified* pack
+  proven equal to the spec versions is future work.
+-/
+
+/-- Efficient packing: place coefficient of `X^i Y^j` at position `D * j + i`.
+Assumes each X-degree is `< D` (true here, with `D = 2 * degX`). -/
+def packFast (D : Nat) (p : CBivariate F) : CPolynomial F := Id.run do
+  let cols := p.val
+  let mut arr : Array F := Array.replicate (D * cols.size + D) 0
+  for j in [0:cols.size] do
+    let col := cols[j]!.val
+    for i in [0:col.size] do
+      arr := arr.set! (D * j + i) col[i]!
+  return canon arr
+
+/-- Efficient unpacking: position `k` becomes coefficient of `X^(k % D) Y^(k / D)`. -/
+def unpackFast (D : Nat) (P : CPolynomial F) : CBivariate F := Id.run do
+  let arr := P.val
+  let numCols := (arr.size + D - 1) / D
+  let mut cols : Array (CPolynomial F) := #[]
+  for j in [0:numCols] do
+    cols := cols.push (canon (arr.extract (D * j) (min (D * j + D) arr.size)))
+  return canon cols
+
+/-- Kronecker pipeline parameterised by the univariate multiplication backend. -/
+@[inline] def kronWith (mulU : CPolynomial F → CPolynomial F → CPolynomial F)
+    (D : Nat) (p q : CBivariate F) : CBivariate F :=
+  unpackFast D (mulU (packFast D p) (packFast D q))
+
+/-- Sweep of square sizes (`degX = degY = n`).
+
+Kept modest because `#eval` runs in the interpreter; for larger sizes compile a native
+executable (see the note at the bottom of this file). The NTT crossover on the packed
+univariate operand (size `2 * n^2`) is already visible by `n = 16`–`32`. -/
+def benchSizes : Array Nat := #[4, 8, 12, 16, 24, 32]
+
+/-- Render an average millisecond count. -/
+def avgMsString (totalMs reps : Nat) : String :=
+  s!"{(Float.ofNat totalMs) / (Float.ofNat reps)}"
+
+/-- Number of repetitions to use for a given square size. -/
+def repeatsFor (n : Nat) : Nat :=
+  if n ≤ 8 then 10
+  else if n ≤ 16 then 4
+  else 1
+
+/-- Time repeated calls to a thunk and return the final result. -/
+def timeRepeated {α : Type} (reps : Nat) (f : Unit → α) : IO (Nat × α) := do
+  let actualReps := max reps 1
+  let start ← IO.monoMsNow
+  let mut last := f ()
+  for _ in [1:actualReps] do
+    last := f ()
+  let stop ← IO.monoMsNow
+  pure (stop - start, last)
+
+#eval show IO Unit from do
+  IO.println s!"sizes tested = {benchSizes.size}  (degX = degY = n, stride D = 2n)"
+  IO.println "n | reps | normal ms | kron ms | kron+NTT ms | kron+FastNTT ms"
+  IO.println "------------------------------------------------------------------"
+  for i in [0:benchSizes.size] do
+    let n := benchSizes[i]!
+    let reps := repeatsFor n
+    let D := 2 * n
+    let p := mkBiv n n (41 + 13 * i)
+    let q := mkBiv n n (73 + 17 * i)
+    let (normalMs, normalRes) ← timeRepeated reps (fun _ ↦ p * q)
+    let (kronMs, kronRes) ← timeRepeated reps (fun _ ↦ kronWith (· * ·) D p q)
+    let (nttMs, nttRes) ←
+      timeRepeated reps (fun _ ↦ kronWith (CPolynomial.NTT.FastMul.withFallback
+        bestDomainForLength?) D p q)
+    let (fastMs, fastRes) ←
+      timeRepeated reps (fun _ ↦ kronWith (CPolynomial.NTTFast.withFallback
+        bestDomainForLength?) D p q)
+    unless (kronRes == normalRes) && (nttRes == normalRes) && (fastRes == normalRes) do
+      throw <| IO.userError s!"benchmark mismatch at n = {n}"
+    let row :=
+      s!"{n} | {reps} | {avgMsString normalMs reps} | {avgMsString kronMs reps} | " ++
+      s!"{avgMsString nttMs reps} | {avgMsString fastMs reps}"
+    IO.println row
+
+end Benchmark
+end CBivariate
+end CompPoly
+
+/-
+  ## Running larger sizes
+
+  `#eval` runs in the interpreter, which dominates the absolute timings (the relative
+  comparison and crossover are still meaningful). For larger operands, compile natively:
+  turn the `#eval` body into `def main : IO Unit` and add a `lean_exe` target to the
+  lakefile, or run with `lake env lean --run` on a standalone copy. Native execution is
+  typically two to three orders of magnitude faster, pushing the practical sweep well past
+  `n = 32`.
+-/

--- a/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
+++ b/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
@@ -19,9 +19,9 @@ import CompPolyTests.Bivariate.KroneckerCommon
 
   All four results are checked for agreement at every size. Operands are square
   (`degX = degY = n`) and the Kronecker stride is `D = 2 * n`, which always satisfies
-  `natDegreeX (p * q) < D`, so unpacking is faithful. Shared fixtures (`mkBiv`,
-  `bestDomainForLength?`, `kronWith`) live in `KroneckerCommon.lean`; the agreement
-  smoke test lives in `Kronecker.lean`.
+  `natDegreeX (p * q) < D`, so unpacking is faithful. Shared data (`mkBiv`,
+  `bestDomainForLength?`, `kronWith`) lives in `KroneckerCommon.lean`; the agreement
+  check lives in `Kronecker.lean`.
 
   Not part of the aggregate `CompPolyTests` build; run manually, e.g.
   `lake build CompPolyTests.Bivariate.KroneckerBenchmark`.

--- a/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
+++ b/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dimitris Mitsios
 -/
 
-import CompPoly.Bivariate.Kronecker
-import CompPoly.Univariate.NTT.KoalaBear
+import CompPolyTests.Bivariate.KroneckerCommon
 
 /-!
   # Bivariate Multiplication Benchmark
@@ -20,7 +19,9 @@ import CompPoly.Univariate.NTT.KoalaBear
 
   All four results are checked for agreement at every size. Operands are square
   (`degX = degY = n`) and the Kronecker stride is `D = 2 * n`, which always satisfies
-  `natDegreeX (p * q) < D`, so unpacking is faithful.
+  `natDegreeX (p * q) < D`, so unpacking is faithful. Shared fixtures (`mkBiv`,
+  `bestDomainForLength?`, `kronWith`) live in `KroneckerCommon.lean`; the agreement
+  smoke test lives in `Kronecker.lean`.
 
   Not part of the aggregate `CompPolyTests` build; run manually, e.g.
   `lake build CompPolyTests.Bivariate.KroneckerBenchmark`.
@@ -30,40 +31,7 @@ namespace CompPoly
 namespace CBivariate
 namespace Benchmark
 
-open scoped CompPoly
-
-/-- KoalaBear field abbreviation. -/
-abbrev F := _root_.KoalaBear.Field
-
-/-- Best-fitting KoalaBear NTT domain for a required convolution length. -/
-def bestDomainForLength? (requiredLen : Nat) :
-    Option (CPolynomial.NTT.FittingDomain F requiredLen) :=
-  CPolynomial.NTT.bestDomainForLength? _root_.KoalaBear.twoAdicity
-    CPolynomial.NTT.KoalaBear.domainOfLogN (by intro _ _; rfl) requiredLen
-
-/-- Wrap a raw coefficient array as a canonical polynomial. -/
-def canon {α : Type} [Zero α] [BEq α] [LawfulBEq α]
-    (arr : CPolynomial.Raw α) : CPolynomial α :=
-  ⟨arr.trim, CPolynomial.Raw.Trim.isCanonical_trim arr⟩
-
-/-- Deterministic univariate column in `X` of length `degX`. -/
-def mkCol (degX seed : Nat) : CPolynomial F :=
-  canon (Array.ofFn (fun i : Fin degX ↦
-    (((i.1 + 1) * seed + i.1 * i.1 + 17 : Nat) : F)))
-
-/-- Deterministic bivariate polynomial with `degY` columns, each of X-length `degX`. -/
-def mkBiv (degY degX seed : Nat) : CBivariate F :=
-  canon (Array.ofFn (fun j : Fin degY ↦ mkCol degX (seed + 7 * j.1 + 1)))
-
-/-- Kronecker pipeline parameterised by the univariate multiplication backend.
-
-Uses the verified efficient `kroneckerPackFast` / `kroneckerUnpackFast` from the library
-(both proven equal to the `kroneckerPack` / `kroneckerUnpack` spec; see
-`kroneckerUnpackFast_mul`). The slow spec versions, defined via `eval₂` for provability,
-recompute powers and are unsuitable for benchmarking. -/
-@[inline] def kronWith (mulU : CPolynomial F → CPolynomial F → CPolynomial F)
-    (D : Nat) (p q : CBivariate F) : CBivariate F :=
-  kroneckerUnpackFast D (mulU (kroneckerPackFast D p) (kroneckerPackFast D q))
+open CBivariate.TestCommon
 
 /-- Sweep of square sizes (`degX = degY = n`).
 

--- a/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
+++ b/tests/CompPolyTests/Bivariate/KroneckerBenchmark.lean
@@ -18,7 +18,7 @@ import CompPolyTests.Bivariate.KroneckerCommon
   4. **kron+FastNTT** — Kronecker with the recursive NTT (`NTTFast.withFallback`).
 
   All four results are checked for agreement at every size. Operands are square
-  (`degX = degY = n`) and the Kronecker stride is `D = 2 * n`, which always satisfies
+  (`degX = degY = n`) and the Kronecker gap is `D = 2 * n`, which always satisfies
   `natDegreeX (p * q) < D`, so unpacking is faithful. Shared data (`mkBiv`,
   `bestDomainForLength?`, `kronWith`) lives in `KroneckerCommon.lean`; the agreement
   check lives in `Kronecker.lean`.
@@ -61,7 +61,7 @@ def timeRepeated {α : Type} (reps : Nat) (f : Unit → α) : IO (Nat × α) := 
   pure (stop - start, last)
 
 #eval show IO Unit from do
-  IO.println s!"sizes tested = {benchSizes.size}  (degX = degY = n, stride D = 2n)"
+  IO.println s!"sizes tested = {benchSizes.size}  (degX = degY = n, gap D = 2n)"
   IO.println "n | reps | normal ms | kron ms | kron+NTT ms | kron+FastNTT ms"
   IO.println "------------------------------------------------------------------"
   for i in [0:benchSizes.size] do

--- a/tests/CompPolyTests/Bivariate/KroneckerCommon.lean
+++ b/tests/CompPolyTests/Bivariate/KroneckerCommon.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dimitris Mitsios
+-/
+import CompPoly.Bivariate.Kronecker
+import CompPoly.Univariate.NTT.KoalaBear
+
+/-!
+  # Kronecker test helpers
+
+  Shared KoalaBear fixtures for the Kronecker smoke test and benchmark: deterministic
+  operand builders, the NTT domain selector, and the `kronWith` pipeline parameterised by
+  the univariate multiplication backend. Uses the verified efficient
+  `kroneckerPackFast` / `kroneckerUnpackFast`.
+-/
+
+namespace CompPoly
+namespace CBivariate
+namespace TestCommon
+
+/-- KoalaBear field abbreviation. -/
+abbrev F := _root_.KoalaBear.Field
+
+/-- Best-fitting KoalaBear NTT domain for a required convolution length. -/
+def bestDomainForLength? (requiredLen : Nat) :
+    Option (CPolynomial.NTT.FittingDomain F requiredLen) :=
+  CPolynomial.NTT.bestDomainForLength? _root_.KoalaBear.twoAdicity
+    CPolynomial.NTT.KoalaBear.domainOfLogN (by intro _ _; rfl) requiredLen
+
+/-- Wrap a raw coefficient array as a canonical polynomial. -/
+def canon {α : Type} [Zero α] [BEq α] [LawfulBEq α]
+    (arr : CPolynomial.Raw α) : CPolynomial α :=
+  ⟨arr.trim, CPolynomial.Raw.Trim.isCanonical_trim arr⟩
+
+/-- Deterministic univariate column in `X` of length `degX`. -/
+def mkCol (degX seed : Nat) : CPolynomial F :=
+  canon (Array.ofFn (fun i : Fin degX ↦
+    (((i.1 + 1) * seed + i.1 * i.1 + 17 : Nat) : F)))
+
+/-- Deterministic bivariate polynomial with `degY` columns, each of X-length `degX`. -/
+def mkBiv (degY degX seed : Nat) : CBivariate F :=
+  canon (Array.ofFn (fun j : Fin degY ↦ mkCol degX (seed + 7 * j.1 + 1)))
+
+/-- Kronecker pipeline parameterised by the univariate multiplication backend.
+
+Uses the verified efficient `kroneckerPackFast` / `kroneckerUnpackFast` (both proven equal
+to the `kroneckerPack` / `kroneckerUnpack` spec; see `kroneckerUnpackFast_mul`). -/
+@[inline] def kronWith (mulU : CPolynomial F → CPolynomial F → CPolynomial F)
+    (D : Nat) (p q : CBivariate F) : CBivariate F :=
+  kroneckerUnpackFast D (mulU (kroneckerPackFast D p) (kroneckerPackFast D q))
+
+end TestCommon
+end CBivariate
+end CompPoly

--- a/tests/CompPolyTests/Bivariate/KroneckerCommon.lean
+++ b/tests/CompPolyTests/Bivariate/KroneckerCommon.lean
@@ -9,10 +9,10 @@ import CompPoly.Univariate.NTT.KoalaBear
 /-!
   # Kronecker test helpers
 
-  Shared KoalaBear fixtures for the Kronecker smoke test and benchmark: deterministic
-  operand builders, the NTT domain selector, and the `kronWith` pipeline parameterised by
-  the univariate multiplication backend. Uses the verified efficient
-  `kroneckerPackFast` / `kroneckerUnpackFast`.
+  Shared KoalaBear data used by both the Kronecker test and the benchmark: deterministic
+  operand builders, the NTT domain selector, and the `kronWith` pipeline taking the
+  univariate multiplication as a parameter. Built on the efficient `kroneckerPackFast` /
+  `kroneckerUnpackFast`.
 -/
 
 namespace CompPoly


### PR DESCRIPTION
 This PR implements Kronecker substitution. The optimisation happens during multiplication of univariate polynomials via NTT-based univariate multiplication. 
  ## Benchmark

  KoalaBear field, operands `p` and `q` with equal degrees `degX = degY = n`. Times are
  measured through Lean's interpreter, so absolute values are inflated. (All methods produce the same result.)

  | n | normal (ms) | kron+schoolbook (ms) | kron+NTT (ms) | kron+FastNTT (ms) |
  |---|-------------|----------------------|---------------|-------------------|
  | 4 | 0.4 | 0.5 | 0.8 | 0.4 |
  | 8 | 2.4 | 8.2 | 3.8 | 1.9 |
  | 12 | 29.5 | 98 | 41 | 20.5 |
  | 16 | 93 | 339 | 50 | 28 |
  | 24 | 1911 | 6867 | 907 | 437 |
  | 32 | 5583 | 21208 | 1237 | 805 |

  Machine: AMD Ryzen 5 3400G (8 threads), 29 GiB RAM, Arch Linux (kernel 7.0.10), Lean 4.30.0-rc2.