### PR TITLE
feat: add KoalaBear extension and multilinear shift semantics

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -101,6 +101,7 @@ import CompPoly.Fields.Binary.Tower.TensorAlgebra
 import CompPoly.Fields.Goldilocks
 import CompPoly.Fields.KoalaBear
 import CompPoly.Fields.KoalaBear.Basic
+import CompPoly.Fields.KoalaBear.Ext5
 import CompPoly.Fields.KoalaBear.Fast
 import CompPoly.Fields.Mersenne
 import CompPoly.Fields.PrattCertificate
@@ -136,6 +137,8 @@ import CompPoly.Multilinear.Equiv
 import CompPoly.Multilinear.ManyEval
 import CompPoly.Multilinear.ManyEval.Basic
 import CompPoly.Multilinear.ManyEval.Correctness
+import CompPoly.Multilinear.Next
+import CompPoly.Multilinear.Semantics
 import CompPoly.Multilinear.TransformEquiv
 import CompPoly.Multivariate.CMvMonomial
 import CompPoly.Multivariate.CMvPolynomial

--- a/CompPoly/Fields/KoalaBear.lean
+++ b/CompPoly/Fields/KoalaBear.lean
@@ -1,10 +1,11 @@
 /-
 Copyright (c) 2026 CompPoly Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao, Valerii Huhnin
+Authors: Quang Dao, Valerii Huhnin, Aristotle (Harmonic), Elias Judin
 -/
 
 import CompPoly.Fields.KoalaBear.Basic
+import CompPoly.Fields.KoalaBear.Ext5
 import CompPoly.Fields.KoalaBear.Fast
 
 /-!

--- a/CompPoly/Fields/KoalaBear/Ext5.lean
+++ b/CompPoly/Fields/KoalaBear/Ext5.lean
@@ -1,0 +1,597 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aristotle (Harmonic), Elias Judin
+-/
+import CompPoly.Data.Polynomial.Frobenius
+import CompPoly.Fields.KoalaBear.Basic
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.LinearAlgebra.Basis.Basic
+import Mathlib.RingTheory.AdjoinRoot
+import Mathlib.Tactic.ComputeDegree
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Ring
+
+/-!
+# A degree-five extension of KoalaBear
+
+This module defines a degree-five extension of the KoalaBear base field:
+
+`F_{p^5} = F_p[X] / (X^5 + X^2 - 1)`.
+
+The quotient model is `AdjoinRoot ext5Poly`. Its canonical basis is the power
+basis of the adjoined root, reindexed by `Fin 5` in the order
+`1, X, X^2, X^3, X^4`.
+
+Irreducibility follows from Rabin's criterion in degree five. The finite
+computations use the coordinate model `V = F_p^5`, whose multiplication agrees
+with multiplication in the quotient.
+-/
+
+open Polynomial
+
+namespace KoalaBear.Ext5
+
+/-- The KoalaBear degree-5 extension polynomial `X^5 + X^2 - 1`. -/
+noncomputable def ext5Poly : Polynomial KoalaBear.Field := X ^ 5 + X ^ 2 - 1
+
+/-- The natural degree of `ext5Poly` is `5`. -/
+theorem ext5Poly_natDegree : ext5Poly.natDegree = 5 := by
+  unfold ext5Poly
+  compute_degree!
+
+/-- The extension polynomial is nonzero. -/
+theorem ext5Poly_ne_zero : ext5Poly ≠ 0 := by
+  intro h
+  have hdeg := ext5Poly_natDegree
+  rw [h] at hdeg
+  simp at hdeg
+
+private lemma exists_factor_le_two_of_reducible.{u} {R : Type u} [_root_.Field R]
+    (P : Polynomial R) (h_deg : P.natDegree = 5) (h_red : ¬ Irreducible P) :
+    ∃ q, Irreducible q ∧ q ∣ P ∧ q.natDegree ≤ 2 := by
+  have h_ne_zero : P ≠ 0 := by
+    intro h
+    rw [h, Polynomial.natDegree_zero] at h_deg
+    contradiction
+  have h_not_unit : ¬ IsUnit P := by
+    intro h_unit
+    have h0 : P.natDegree = 0 := Polynomial.natDegree_eq_zero_of_isUnit h_unit
+    omega
+  have h_exists_split : ∃ a b, P = a * b ∧ ¬ IsUnit a ∧ ¬ IsUnit b := by
+    rw [irreducible_iff, not_and_or, not_forall] at h_red
+    simp only [h_not_unit, not_false_eq_true] at h_red
+    push Not at h_red
+    simp only [IsEmpty.exists_iff, false_or] at h_red
+    rcases h_red with ⟨a, b, h_eq, h_non_units⟩
+    exact ⟨a, b, h_eq, h_non_units⟩
+  rcases h_exists_split with ⟨a, b, h_eq, ha_nu, hb_nu⟩
+  have h_a_ne_zero : a ≠ 0 := by
+    intro h_a_eq_0
+    rw [h_eq, h_a_eq_0] at h_deg
+    simp at h_deg
+  have h_b_ne_zero : b ≠ 0 := by
+    intro h_b_eq_0
+    rw [h_eq, h_b_eq_0] at h_deg
+    simp at h_deg
+  have h_deg_sum : a.natDegree + b.natDegree = 5 := by
+    rw [← h_deg, h_eq, Polynomial.natDegree_mul (hp := h_a_ne_zero) (hq := h_b_ne_zero)]
+  by_cases h_le : a.natDegree ≤ b.natDegree
+  · have h_deg_a : a.natDegree ≤ 2 := by omega
+    obtain ⟨q, hq_irr, hq_dvd_a⟩ :=
+      WfDvdMonoid.exists_irreducible_factor ha_nu h_a_ne_zero
+    refine ⟨q, hq_irr, dvd_trans hq_dvd_a (Dvd.intro b h_eq.symm), ?_⟩
+    exact le_trans (Polynomial.natDegree_le_of_dvd hq_dvd_a h_a_ne_zero) h_deg_a
+  · push Not at h_le
+    have h_deg_b : b.natDegree ≤ 2 := by omega
+    obtain ⟨q, hq_irr, hq_dvd_b⟩ :=
+      WfDvdMonoid.exists_irreducible_factor hb_nu h_b_ne_zero
+    refine ⟨q, hq_irr, dvd_trans hq_dvd_b (Dvd.intro_left a h_eq.symm), ?_⟩
+    exact le_trans (Polynomial.natDegree_le_of_dvd hq_dvd_b h_b_ne_zero) h_deg_b
+
+/-- Rabin irreducibility criterion, prime-degree-5 version.
+
+The absence of linear factors is expressed as `IsCoprime (X^q - X) P`. -/
+private lemma irreducible_of_rabin_5 (P : Polynomial KoalaBear.Field)
+    (h_deg : P.natDegree = 5)
+    (h_trace :
+      P ∣ ((X : Polynomial KoalaBear.Field) ^ ((Fintype.card KoalaBear.Field) ^ 5) - X))
+    (h_gcd :
+      IsCoprime
+        ((X : Polynomial KoalaBear.Field) ^ (Fintype.card KoalaBear.Field) - X) P) :
+    Irreducible P := by
+  have h_ringChar : ringChar KoalaBear.Field = KoalaBear.fieldSize := by
+    change ringChar (ZMod KoalaBear.fieldSize) = KoalaBear.fieldSize
+    exact ZMod.ringChar_zmod_n KoalaBear.fieldSize
+  letI : Fact (Nat.Prime (ringChar KoalaBear.Field)) :=
+    ⟨by rw [h_ringChar]; exact KoalaBear.is_prime⟩
+  by_contra h_red
+  rcases exists_factor_le_two_of_reducible P h_deg h_red with
+    ⟨q, hq_irr, hq_dvd_P, hq_deg_le⟩
+  have h_q_dvd_trace :
+      q ∣ ((X : Polynomial KoalaBear.Field) ^ ((Fintype.card KoalaBear.Field) ^ 5) - X) :=
+    dvd_trans hq_dvd_P h_trace
+  have h_deg_dvd_5 : q.natDegree ∣ 5 := by
+    exact (Polynomial.irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd (R := KoalaBear.Field)
+      (n := 5) (q := q) (hq_irr := hq_irr)).mp h_q_dvd_trace
+  have h_q_deg_eq_one : q.natDegree = 1 := by
+    rcases h_deg_dvd_5 with ⟨k, hk⟩
+    have h_q_deg_ne_zero : q.natDegree ≠ 0 := by
+      intro h0
+      rw [h0] at hk
+      omega
+    interval_cases q.natDegree <;> omega
+  have h_deg_dvd_1 : q.natDegree ∣ 1 := by
+    rw [h_q_deg_eq_one]
+  have h_q_dvd_check :
+      q ∣ ((X : Polynomial KoalaBear.Field) ^ (Fintype.card KoalaBear.Field) - X) := by
+    have h := (Polynomial.irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd
+      (R := KoalaBear.Field) (n := 1) (q := q) (hq_irr := hq_irr)).mpr h_deg_dvd_1
+    simpa using h
+  have h_q_unit : IsUnit q := h_gcd.isUnit_of_dvd' h_q_dvd_check hq_dvd_P
+  exact (irreducible_iff.mp hq_irr).1 h_q_unit
+
+/-!
+## Coordinate model of `F_p[X]/(ext5Poly)`
+
+`V = F_p^5` with multiplication induced by reduction modulo
+`X^5 + X^2 - 1`.
+-/
+
+/-- The coordinate model of `F_p[X]/(ext5Poly)`: coefficient tuples
+`(a₀, a₁, a₂, a₃, a₄)` representing `a₀ + a₁X + a₂X² + a₃X³ + a₄X⁴`. -/
+private abbrev V :=
+  KoalaBear.Field × KoalaBear.Field × KoalaBear.Field × KoalaBear.Field × KoalaBear.Field
+
+/-- Squaring in the coordinate model (product reduced modulo `X^5 = 1 - X^2`). -/
+private def vsq (v : V) : V :=
+  let a0 := v.1
+  let a1 := v.2.1
+  let a2 := v.2.2.1
+  let a3 := v.2.2.2.1
+  let a4 := v.2.2.2.2
+  ( a0 * a0 + (2 * a1 * a4 + 2 * a2 * a3) - a4 * a4
+  , 2 * a0 * a1 + (2 * a2 * a4 + a3 * a3)
+  , (2 * a0 * a2 + a1 * a1) - (2 * a1 * a4 + 2 * a2 * a3) +
+      2 * a3 * a4 + a4 * a4
+  , (2 * a0 * a3 + 2 * a1 * a2) - (2 * a2 * a4 + a3 * a3) + a4 * a4
+  , (2 * a0 * a4 + 2 * a1 * a3 + a2 * a2) - 2 * a3 * a4 )
+
+/-- Multiplication in the coordinate model (product reduced modulo `X^5 = 1 - X^2`). -/
+private def vmul (u v : V) : V :=
+  let a0 := u.1
+  let a1 := u.2.1
+  let a2 := u.2.2.1
+  let a3 := u.2.2.2.1
+  let a4 := u.2.2.2.2
+  let b0 := v.1
+  let b1 := v.2.1
+  let b2 := v.2.2.1
+  let b3 := v.2.2.2.1
+  let b4 := v.2.2.2.2
+  ( a0 * b0 + (a1 * b4 + a2 * b3 + a3 * b2 + a4 * b1) - a4 * b4
+  , a0 * b1 + a1 * b0 + (a2 * b4 + a3 * b3 + a4 * b2)
+  , (a0 * b2 + a1 * b1 + a2 * b0) -
+      (a1 * b4 + a2 * b3 + a3 * b2 + a4 * b1) +
+      (a3 * b4 + a4 * b3) + a4 * b4
+  , (a0 * b3 + a1 * b2 + a2 * b1 + a3 * b0) -
+      (a2 * b4 + a3 * b3 + a4 * b2) + a4 * b4
+  , (a0 * b4 + a1 * b3 + a2 * b2 + a3 * b1 + a4 * b0) -
+      (a3 * b4 + a4 * b3) )
+
+/-- Addition in the coordinate model. -/
+private def vadd (u v : V) : V :=
+  (u.1 + v.1, u.2.1 + v.2.1, u.2.2.1 + v.2.2.1,
+    u.2.2.2.1 + v.2.2.2.1, u.2.2.2.2 + v.2.2.2.2)
+
+/-- The scalar (constant) element `c` of the coordinate model. -/
+private def scal (c : KoalaBear.Field) : V := (c, 0, 0, 0, 0)
+
+/-- The unit `1` of the coordinate model. -/
+private def vone : V := (1, 0, 0, 0, 0)
+
+/-- The element `X` of the coordinate model. -/
+private def ve1 : V := (0, 1, 0, 0, 0)
+
+/-- Composition/substitution: `comp v w` evaluates the coefficient polynomial `v`
+at the element `w`, i.e. `Σ vᵢ wⁱ`. -/
+private def comp (v w : V) : V :=
+  vadd (scal v.1)
+    (vadd (vmul (scal v.2.1) w)
+      (vadd (vmul (scal v.2.2.1) (vmul w w))
+        (vadd (vmul (scal v.2.2.2.1) (vmul w (vmul w w)))
+          (vmul (scal v.2.2.2.2) (vmul (vmul w w) (vmul w w))))))
+
+/-- The interpretation `V → F_p[X]/(ext5Poly)`. -/
+private noncomputable def toA (v : V) : AdjoinRoot ext5Poly :=
+  AdjoinRoot.of ext5Poly v.1 +
+    AdjoinRoot.of ext5Poly v.2.1 * AdjoinRoot.root ext5Poly +
+    AdjoinRoot.of ext5Poly v.2.2.1 * AdjoinRoot.root ext5Poly ^ 2 +
+    AdjoinRoot.of ext5Poly v.2.2.2.1 * AdjoinRoot.root ext5Poly ^ 3 +
+    AdjoinRoot.of ext5Poly v.2.2.2.2 * AdjoinRoot.root ext5Poly ^ 4
+
+/-- The polynomial associated with a coordinate tuple. -/
+private noncomputable def vPoly (v : V) : Polynomial KoalaBear.Field :=
+  C v.1 + C v.2.1 * X + C v.2.2.1 * X ^ 2 + C v.2.2.2.1 * X ^ 3 + C v.2.2.2.2 * X ^ 4
+
+/-! ### Instances -/
+
+instance instNontrivialAdjoin : Nontrivial (AdjoinRoot ext5Poly) :=
+  AdjoinRoot.nontrivial ext5Poly (by
+    rw [degree_eq_natDegree ext5Poly_ne_zero, ext5Poly_natDegree]; decide)
+
+instance instCharPAdjoin : CharP (AdjoinRoot ext5Poly) KoalaBear.fieldSize := by
+  have h : Function.Injective (algebraMap KoalaBear.Field (AdjoinRoot ext5Poly)) :=
+    RingHom.injective _
+  exact charP_of_injective_algebraMap h KoalaBear.fieldSize
+
+/-! ### The defining relation and multiplication compatibility -/
+
+/-- The root satisfies the defining relation. -/
+private theorem root_rel :
+    (AdjoinRoot.root ext5Poly) ^ 5 + (AdjoinRoot.root ext5Poly) ^ 2 - 1 = 0 := by
+  have h0 : (AdjoinRoot.mk ext5Poly) ext5Poly = 0 := AdjoinRoot.mk_self
+  have hP : ext5Poly = X ^ 5 + X ^ 2 - 1 := rfl
+  rw [hP, map_sub, map_add, map_pow, map_pow, AdjoinRoot.mk_X, map_one] at h0
+  exact h0
+
+/-- Multiplication in the coordinate model agrees with the quotient ring. -/
+private theorem toA_mul (u v : V) : toA (vmul u v) = toA u * toA v := by
+  set r := AdjoinRoot.root ext5Poly with hrdef
+  have hself : r ^ 5 + r ^ 2 - 1 = 0 := root_rel
+  have hr5 : r ^ 5 = 1 - r ^ 2 := by linear_combination hself
+  have hr6 : r ^ 6 = r - r ^ 3 := by rw [pow_succ, hr5]; ring
+  have hr7 : r ^ 7 = r ^ 2 - r ^ 4 := by rw [pow_succ, hr6]; ring
+  have hr8 : r ^ 8 = r ^ 3 + r ^ 2 - 1 := by rw [pow_succ, hr7]; linear_combination -hself
+  simp only [toA, vmul, map_add, map_sub, map_mul]
+  ring_nf
+  rw [hr6, hr7, hr8, hr5]
+  ring
+
+/-- Addition in the coordinate model agrees with the quotient ring. -/
+private theorem toA_add (u v : V) : toA (vadd u v) = toA u + toA v := by
+  simp only [toA, vadd, map_add]
+  ring
+
+/-- The scalar element maps to the image of the scalar. -/
+private theorem toA_scal (c : KoalaBear.Field) :
+    toA (scal c) = AdjoinRoot.of ext5Poly c := by
+  simp only [toA, scal, map_zero, zero_mul, add_zero]
+
+/-- `ve1` maps to the root. -/
+private theorem toA_ve1 : toA ve1 = AdjoinRoot.root ext5Poly := by
+  simp only [toA, ve1, map_zero, map_one, zero_mul, zero_add, one_mul, add_zero]
+
+/-- `vone` maps to `1`. -/
+private theorem toA_vone : toA vone = 1 := by
+  simp only [toA, vone, map_zero, map_one, zero_mul, add_zero]
+
+/-- Squaring in the coordinate model agrees with the quotient ring. -/
+private theorem toA_sq (v : V) : toA (vsq v) = (toA v) ^ 2 := by
+  have heq : vsq v = vmul v v := by
+    simp only [vsq, vmul, Prod.mk.injEq]
+    refine ⟨by ring, by ring, by ring, by ring, by ring⟩
+  rw [heq, toA_mul, sq]
+
+/-- `comp` agrees with polynomial evaluation in the quotient ring. -/
+private theorem toA_comp (v w : V) :
+    toA (comp v w) =
+      AdjoinRoot.of ext5Poly v.1
+      + AdjoinRoot.of ext5Poly v.2.1 * toA w
+      + AdjoinRoot.of ext5Poly v.2.2.1 * (toA w) ^ 2
+      + AdjoinRoot.of ext5Poly v.2.2.2.1 * (toA w) ^ 3
+      + AdjoinRoot.of ext5Poly v.2.2.2.2 * (toA w) ^ 4 := by
+  simp only [comp, toA_add, toA_scal, toA_mul]
+  ring
+
+/-- `toA` factors through `AdjoinRoot.mk` of `vPoly`. -/
+private theorem toA_eq_mk (v : V) : toA v = AdjoinRoot.mk ext5Poly (vPoly v) := by
+  simp only [toA, vPoly, map_add, map_mul, map_pow, AdjoinRoot.mk_X]
+  rfl
+
+/-! ### The Frobenius power `root ^ p` -/
+
+/-- The explicit value of `X^p mod P`, `p = fieldSize`. -/
+private def cC : V := (1576402667, 1173144480, 1567662457, 1206866823, 2428146)
+
+/-- `root ^ (2 ^ k)` is the `k`-fold square of `X` in the coordinate model. -/
+private theorem pow2_correct (k : ℕ) :
+    (AdjoinRoot.root ext5Poly) ^ (2 ^ k) = toA (vsq^[k] ve1) := by
+  induction k with
+  | zero => simp [toA_ve1]
+  | succ n ih =>
+    rw [pow_succ 2 n, pow_mul, ih, Function.iterate_succ', Function.comp_apply, toA_sq]
+
+/-- The Frobenius image of the adjoined root is represented by `cC`. -/
+private theorem root_pow_fieldSize :
+    (AdjoinRoot.root ext5Poly) ^ KoalaBear.fieldSize = toA cC := by
+  set r := AdjoinRoot.root ext5Poly with hrdef
+  -- Use explicit intermediate tuples to keep each computation small.
+  have step : ∀ (k : ℕ) (L L' : V), vsq^[k] ve1 = L → vsq L = L' → vsq^[k+1] ve1 = L' := by
+    intro k L L' h hs; rw [Function.iterate_succ_apply', h, hs]
+  have s1 : vsq^[1] ve1 = (0,0,1,0,0) := by decide
+  have s2 := step 1 _ _ s1 (show vsq (0,0,1,0,0) = (0,0,0,0,1) by decide)
+  have s3 := step 2 _ _ s2 (show vsq (0,0,0,0,1) = (2130706432,0,1,1,0) by decide)
+  have s4 := step 3 _ _ s3 (show vsq (2130706432,0,1,1,0) = (3,1,2130706429,2130706430,1) by decide)
+  have s5 := step 4 _ _ s4
+    (show vsq (3,1,2130706429,2130706430,1) = (34,7,2130706379,2130706407,22) by decide)
+  have s6 := step 5 _ _ s5
+    (show vsq (34,7,2130706379,2130706407,22) =
+      (3788,2130705209,2130699034,2130706093,5192) by decide)
+  have s7 := step 6 _ _ s6
+    (show vsq (3788,2130705209,2130699034,2130706093,5192)
+        = (2110419817,2044717793,2107254785,119209392,98442673) by decide)
+  have s8 := step 7 _ _ s7
+    (show vsq (2110419817,2044717793,2107254785,119209392,98442673)
+        = (1962757147,1517752019,2034103327,1821522190,1486994651) by decide)
+  have s9 := step 8 _ _ s8
+    (show vsq (1962757147,1517752019,2034103327,1821522190,1486994651)
+        = (1769126182,159161379,1716678059,1359437718,1832431749) by decide)
+  have s10 := step 9 _ _ s9
+    (show vsq (1769126182,159161379,1716678059,1359437718,1832431749)
+        = (992533826,1049099903,1999262994,91642174,863970281) by decide)
+  have s11 := step 10 _ _ s10
+    (show vsq (992533826,1049099903,1999262994,91642174,863970281)
+        = (409320760,528924425,608828729,2124114134,475824548) by decide)
+  have s12 := step 11 _ _ s11
+    (show vsq (409320760,528924425,608828729,2124114134,475824548)
+        = (2111237692,396498471,1124300053,961203683,1585691692) by decide)
+  have s13 := step 12 _ _ s12
+    (show vsq (2111237692,396498471,1124300053,961203683,1585691692)
+        = (413260470,409516856,1431989188,1641019207,1704057837) by decide)
+  have s14 := step 13 _ _ s13
+    (show vsq (413260470,409516856,1431989188,1641019207,1704057837)
+        = (1108180128,308487541,156248939,2116951396,1974449295) by decide)
+  have s15 := step 14 _ _ s14
+    (show vsq (1108180128,308487541,156248939,2116951396,1974449295)
+        = (41990483,2006079421,1821017144,874368254,1995630240) by decide)
+  have s16 := step 15 _ _ s15
+    (show vsq (41990483,2006079421,1821017144,874368254,1995630240)
+        = (1566642517,395592644,2090964960,1639164963,985945876) by decide)
+  have s17 := step 16 _ _ s16
+    (show vsq (1566642517,395592644,2090964960,1639164963,985945876)
+        = (187322181,1526360033,1126590339,101840703,593878992) by decide)
+  have s18 := step 17 _ _ s17
+    (show vsq (187322181,1526360033,1126590339,101840703,593878992)
+        = (1436296730,309967013,1477441957,817455747,1777251330) by decide)
+  have s19 := step 18 _ _ s18
+    (show vsq (1436296730,309967013,1477441957,817455747,1777251330)
+        = (1185135385,1081768488,619543182,836527214,1154033604) by decide)
+  have s20 := step 19 _ _ s19
+    (show vsq (1185135385,1081768488,619543182,836527214,1154033604)
+        = (490029673,1131493085,1304097286,337236161,1481816257) by decide)
+  have s21 := step 20 _ _ s20
+    (show vsq (490029673,1131493085,1304097286,337236161,1481816257)
+        = (2021857567,854001862,1175881365,2053477554,391696094) by decide)
+  have s22 := step 21 _ _ s21
+    (show vsq (2021857567,854001862,1175881365,2053477554,391696094)
+        = (687510172,769974275,355032796,1909331372,942441006) by decide)
+  have s23 := step 22 _ _ s22
+    (show vsq (687510172,769974275,355032796,1909331372,942441006)
+        = (297794260,880422823,1923160268,1699843207,1741026385) by decide)
+  have s24 := step 23 _ _ s23
+    (show vsq (297794260,880422823,1923160268,1699843207,1741026385)
+        = (1245429030,2123323988,1997199567,840428791,934310696) by decide)
+  have s25 := step 24 _ _ s24
+    (show vsq (1245429030,2123323988,1997199567,840428791,934310696)
+        = (569013304,236098224,758792048,1272633629,2052091549) by decide)
+  have s26 := step 25 _ _ s25
+    (show vsq (569013304,236098224,758792048,1272633629,2052091549)
+        = (170464830,492509808,868271568,272443740,1531518663) by decide)
+  have s27 := step 26 _ _ s26
+    (show vsq (170464830,492509808,868271568,272443740,1531518663)
+        = (1874282980,1066852937,1433697031,1765783253,377756129) by decide)
+  have s28 := step 27 _ _ s27
+    (show vsq (1874282980,1066852937,1433697031,1765783253,377756129)
+        = (1830263855,1832006692,688110156,388686197,6993364) by decide)
+  have s29 := step 28 _ _ s28
+    (show vsq (1830263855,1832006692,688110156,388686197,6993364)
+        = (220557930,1557796740,232394723,1347875738,808949557) by decide)
+  have s30 := step 29 _ _ s29
+    (show vsq (220557930,1557796740,232394723,1347875738,808949557)
+        = (275177653,1039982331,1461735331,1496659274,1976841709) by decide)
+  -- Combine the nonzero binary digits of `fieldSize`.
+  have hCval :
+      vmul (vsq^[24] ve1) (vmul (vsq^[25] ve1) (vmul (vsq^[26] ve1)
+        (vmul (vsq^[27] ve1) (vmul (vsq^[28] ve1) (vmul (vsq^[29] ve1)
+          (vmul (vsq^[30] ve1) ve1)))))) = cC := by
+    rw [s24, s25, s26, s27, s28, s29, s30]; decide
+  rw [← hCval]
+  simp only [toA_mul, toA_ve1, ← pow2_correct]
+  have hpow : r ^ KoalaBear.fieldSize
+      = r ^ (2 ^ 24 + (2 ^ 25 + (2 ^ 26 + (2 ^ 27 + (2 ^ 28 + (2 ^ 29 + (2 ^ 30 + 1))))))) :=
+    congrArg (fun n ↦ r ^ n)
+      (by decide : KoalaBear.fieldSize
+          = 2 ^ 24 + (2 ^ 25 + (2 ^ 26 + (2 ^ 27 + (2 ^ 28 + (2 ^ 29 + (2 ^ 30 + 1)))))))
+  rw [hpow]
+  simp only [pow_add, pow_one, ← hrdef]
+
+/-- The Frobenius (`p`-power) of any coordinate element is `comp` with `cC`. -/
+private theorem frob_toA (v : V) :
+    (toA v) ^ KoalaBear.fieldSize = toA (comp v cC) := by
+  haveI : Fact (Nat.Prime KoalaBear.fieldSize) := ⟨KoalaBear.is_prime⟩
+  set r := AdjoinRoot.root ext5Poly with hrdef
+  have hofpow : ∀ c : KoalaBear.Field,
+      (AdjoinRoot.of ext5Poly c) ^ KoalaBear.fieldSize = AdjoinRoot.of ext5Poly c := by
+    intro c
+    rw [← map_pow, ZMod.pow_card]
+  have hrpow : r ^ KoalaBear.fieldSize = toA cC := root_pow_fieldSize
+  have hexpand :
+      (toA v) ^ KoalaBear.fieldSize
+        = (AdjoinRoot.of ext5Poly v.1) ^ KoalaBear.fieldSize
+          + (AdjoinRoot.of ext5Poly v.2.1) ^ KoalaBear.fieldSize
+              * (r ^ KoalaBear.fieldSize)
+          + (AdjoinRoot.of ext5Poly v.2.2.1) ^ KoalaBear.fieldSize
+              * (r ^ KoalaBear.fieldSize) ^ 2
+          + (AdjoinRoot.of ext5Poly v.2.2.2.1) ^ KoalaBear.fieldSize
+              * (r ^ KoalaBear.fieldSize) ^ 3
+          + (AdjoinRoot.of ext5Poly v.2.2.2.2) ^ KoalaBear.fieldSize
+              * (r ^ KoalaBear.fieldSize) ^ 4 := by
+    simp only [toA, ← hrdef]
+    rw [add_pow_char, add_pow_char, add_pow_char, add_pow_char,
+        mul_pow, mul_pow, mul_pow, mul_pow,
+        pow_right_comm r 2 KoalaBear.fieldSize, pow_right_comm r 3 KoalaBear.fieldSize,
+        pow_right_comm r 4 KoalaBear.fieldSize]
+  rw [hexpand, toA_comp]
+  simp only [hofpow, hrpow]
+
+/-! ### The trace certificate -/
+
+/-- The iterated Frobenius returns `X`. -/
+private theorem trace_root :
+    (AdjoinRoot.root ext5Poly) ^ (KoalaBear.fieldSize ^ 5) = AdjoinRoot.root ext5Poly := by
+  set r := AdjoinRoot.root ext5Poly with hrdef
+  set p := KoalaBear.fieldSize with hp
+  have e1 : r ^ (p ^ 1) = toA cC := by
+    rw [pow_one]; exact root_pow_fieldSize
+  have e2 : r ^ (p ^ 2) = toA (comp cC cC) := by
+    rw [show p ^ 2 = p ^ 1 * p by ring, pow_mul, e1, frob_toA]
+  have e3 : r ^ (p ^ 3) = toA (comp (comp cC cC) cC) := by
+    rw [show p ^ 3 = p ^ 2 * p by ring, pow_mul, e2, frob_toA]
+  have e4 : r ^ (p ^ 4) = toA (comp (comp (comp cC cC) cC) cC) := by
+    rw [show p ^ 4 = p ^ 3 * p by ring, pow_mul, e3, frob_toA]
+  have e5 : r ^ (p ^ 5) = toA (comp (comp (comp (comp cC cC) cC) cC) cC) := by
+    rw [show p ^ 5 = p ^ 4 * p by ring, pow_mul, e4, frob_toA]
+  have h2 : comp cC cC
+      = (361322221, 1970254932, 446925412, 2022674657, 1632465862) := by decide
+  have h3 : comp (361322221, 1970254932, 446925412, 2022674657, 1632465862) cC
+      = (866070051, 932157177, 618652440, 1443450085, 457078219) := by decide
+  have h4 : comp (866070051, 932157177, 618652440, 1443450085, 457078219) cC
+      = (1457617927, 185856276, 1628172557, 1719127734, 38734206) := by decide
+  have h5 : comp (1457617927, 185856276, 1628172557, 1719127734, 38734206) cC
+      = ve1 := by decide
+  rw [e5, h2, h3, h4, h5, toA_ve1]
+
+/-- Trace certificate: `ext5Poly ∣ X^(card^5) - X`. -/
+private theorem ext5Poly_trace :
+    ext5Poly ∣ ((X : Polynomial KoalaBear.Field) ^ ((Fintype.card KoalaBear.Field) ^ 5) - X) := by
+  have hcard : Fintype.card KoalaBear.Field = KoalaBear.fieldSize := ZMod.card _
+  rw [hcard]
+  rw [← AdjoinRoot.mk_eq_zero]
+  rw [map_sub, map_pow, AdjoinRoot.mk_X]
+  rw [trace_root, sub_self]
+
+/-! ### The no-linear-factor certificate -/
+
+/-- The reduced polynomial `cC(X) - X` as a coordinate tuple. -/
+private def gVec : V := (1576402667, 1173144479, 1567662457, 1206866823, 2428146)
+
+/-- The inverse of `gVec` modulo `ext5Poly`, in the coordinate model. -/
+private def hVec : V := (666019741, 1851614074, 1978360661, 214422949, 375508882)
+
+/-- `gVec` is a unit in the coordinate model with inverse `hVec`. -/
+private theorem gVec_mul_hVec : vmul gVec hVec = vone := by decide
+
+/-- `vPoly gVec = vPoly cC - X`. -/
+private theorem vPoly_gVec : vPoly gVec = vPoly cC - X := by
+  simp only [vPoly, gVec, cC]
+  rw [show (1173144479 : KoalaBear.Field) = 1173144480 - 1 by decide, map_sub, map_one]
+  ring
+
+/-- `ext5Poly ∣ X^p - vPoly cC`. -/
+private theorem dvd_X_pow_sub_cPoly :
+    ext5Poly ∣ ((X : Polynomial KoalaBear.Field) ^ KoalaBear.fieldSize - vPoly cC) := by
+  rw [← AdjoinRoot.mk_eq_zero, map_sub, map_pow, AdjoinRoot.mk_X, ← toA_eq_mk,
+    ← root_pow_fieldSize, sub_self]
+
+/-- `vPoly gVec` and `ext5Poly` are coprime. -/
+private theorem isCoprime_gPoly : IsCoprime (vPoly gVec) ext5Poly := by
+  -- `gVec` is a unit modulo `ext5Poly`.
+  have hunit : AdjoinRoot.mk ext5Poly (vPoly gVec * vPoly hVec) = 1 := by
+    rw [map_mul, ← toA_eq_mk, ← toA_eq_mk, ← toA_mul, gVec_mul_hVec, toA_vone]
+  have hdvd : ext5Poly ∣ (vPoly gVec * vPoly hVec - 1) := by
+    rw [← AdjoinRoot.mk_eq_zero, map_sub, hunit, map_one, sub_self]
+  obtain ⟨s, hs⟩ := hdvd
+  exact ⟨vPoly hVec, -s, by linear_combination hs⟩
+
+/-- No-linear-factor certificate as coprimality. -/
+private theorem ext5Poly_coprime :
+    IsCoprime
+      ((X : Polynomial KoalaBear.Field) ^ (Fintype.card KoalaBear.Field) - X) ext5Poly := by
+  have hcard : Fintype.card KoalaBear.Field = KoalaBear.fieldSize := ZMod.card _
+  rw [hcard]
+  obtain ⟨Qp, hQp⟩ := dvd_X_pow_sub_cPoly
+  -- Isolate the large power before normalization.
+  have key : ∀ y : Polynomial KoalaBear.Field, y - X = (vPoly cC - X) + (y - vPoly cC) :=
+    fun y ↦ by ring
+  have hsplit :
+      (X : Polynomial KoalaBear.Field) ^ KoalaBear.fieldSize - X
+        = vPoly gVec + ext5Poly * Qp := by
+    rw [vPoly_gVec, key ((X : Polynomial KoalaBear.Field) ^ KoalaBear.fieldSize), hQp]
+  rw [hsplit]
+  exact (isCoprime_gPoly).add_mul_left_left Qp
+
+/-- The extension polynomial is irreducible over the KoalaBear base field. -/
+theorem ext5Poly_irreducible : Irreducible ext5Poly := by
+  apply irreducible_of_rabin_5
+  · exact ext5Poly_natDegree
+  · exact ext5Poly_trace
+  · exact ext5Poly_coprime
+
+instance : Fact (Irreducible ext5Poly) := ⟨ext5Poly_irreducible⟩
+
+/-- The KoalaBear degree-5 extension field `F_p[X] / (X^5 + X^2 - 1)`. -/
+abbrev Field : Type := AdjoinRoot ext5Poly
+
+/-- The power basis of the adjoined root generating the extension field. -/
+noncomputable def powerBasis : PowerBasis KoalaBear.Field Field :=
+  AdjoinRoot.powerBasis ext5Poly_ne_zero
+
+/-- The power basis has dimension `5`. -/
+theorem powerBasis_dim : powerBasis.dim = 5 := by
+  unfold powerBasis
+  rw [AdjoinRoot.powerBasis_dim, ext5Poly_natDegree]
+
+/-- The canonical `Fin 5`-indexed basis `1, X, X^2, X^3, X^4`. -/
+noncomputable def basis : Module.Basis (Fin 5) KoalaBear.Field Field :=
+  powerBasis.basis.reindex (finCongr powerBasis_dim)
+
+/-- The `F_p`-linear equivalence from coordinate vectors to the extension field. -/
+noncomputable def embed : (Fin 5 → KoalaBear.Field) ≃ₗ[KoalaBear.Field] Field :=
+  basis.equivFun.symm
+
+/-- The `i`-th canonical basis vector is the `i`-th power of the adjoined root. -/
+theorem basis_apply (i : Fin 5) :
+    basis i = powerBasis.gen ^ (i : ℕ) := by
+  simp [basis, Module.Basis.reindex_apply, PowerBasis.basis_eq_pow]
+
+/-- Canonical coordinates in the basis `1, X, X², X³, X⁴`. -/
+noncomputable def coords : Field ≃ₗ[KoalaBear.Field] (Fin 5 → KoalaBear.Field) :=
+  basis.equivFun
+
+/-- `embed` sends coordinates to their linear combination in the canonical basis. -/
+theorem embed_apply (c : Fin 5 → KoalaBear.Field) :
+    embed c = ∑ i, c i • basis i := by
+  exact basis.equivFun_symm_apply c
+
+private theorem embed_eq_toA (c : Fin 5 → KoalaBear.Field) :
+    embed c = toA (c 0, c 1, c 2, c 3, c 4) := by
+  rw [embed_apply]
+  simp [basis_apply, Fin.sum_univ_succ, Algebra.smul_def, add_assoc, toA, powerBasis]
+
+/-- Executable multiplication in canonical coordinates, reduced by `X⁵ = 1 - X²`. -/
+def mulCoords (a b : Fin 5 → KoalaBear.Field) : Fin 5 → KoalaBear.Field :=
+  ![
+    a 0 * b 0 + (a 1 * b 4 + a 2 * b 3 + a 3 * b 2 + a 4 * b 1) - a 4 * b 4,
+    a 0 * b 1 + a 1 * b 0 + (a 2 * b 4 + a 3 * b 3 + a 4 * b 2),
+    (a 0 * b 2 + a 1 * b 1 + a 2 * b 0) -
+      (a 1 * b 4 + a 2 * b 3 + a 3 * b 2 + a 4 * b 1) +
+      (a 3 * b 4 + a 4 * b 3) + a 4 * b 4,
+    (a 0 * b 3 + a 1 * b 2 + a 2 * b 1 + a 3 * b 0) -
+      (a 2 * b 4 + a 3 * b 3 + a 4 * b 2) + a 4 * b 4,
+    (a 0 * b 4 + a 1 * b 3 + a 2 * b 2 + a 3 * b 1 + a 4 * b 0) -
+      (a 3 * b 4 + a 4 * b 3)
+  ]
+
+/-- Coordinate multiplication agrees with multiplication in the extension field. -/
+theorem embed_mulCoords (a b : Fin 5 → KoalaBear.Field) :
+    embed (mulCoords a b) = embed a * embed b := by
+  rw [embed_eq_toA, embed_eq_toA, embed_eq_toA]
+  simpa [mulCoords, vmul] using
+    toA_mul (a 0, a 1, a 2, a 3, a 4) (b 0, b 1, b 2, b 3, b 4)
+
+/-- The canonical coordinate embedding is bijective. -/
+theorem embed_bijective : Function.Bijective embed := embed.bijective
+
+end KoalaBear.Ext5

--- a/CompPoly/Fields/README.md
+++ b/CompPoly/Fields/README.md
@@ -15,6 +15,7 @@ This directory contains formally verified field infrastructure used in zero-know
 | **Goldilocks.lean** | \(2^{64} - 2^{32} + 1\) — Plonky2/3. |
 | **KoalaBear.lean** | Facade for KoalaBear modules, re-exporting the canonical field and fast native-word implementation. |
 | **KoalaBear/Basic.lean** | \(2^{31} - 2^{24} + 1\) — lean Ethereum spec. |
+| **KoalaBear/Ext5.lean** | Degree-five extension by \(X^5 + X^2 - 1\), with canonical coordinates and executable multiplication. |
 | **KoalaBear/Fast.lean** | Native `UInt32` Montgomery-residue operations for KoalaBear, with conversion and operation equivalence statements against `KoalaBear.Field`. |
 | **Mersenne.lean** | \(2^{31} - 1\) — Circle STARKs. |
 | **Secp256k1.lean** | Base and scalar fields for the Secp256k1 curve (used in Bitcoin/Ethereum). |

--- a/CompPoly/Multilinear/Equiv.lean
+++ b/CompPoly/Multilinear/Equiv.lean
@@ -1,9 +1,9 @@
 /-
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao, Chung Thai Nguyen
+Authors: Quang Dao, Chung Thai Nguyen, Aristotle (Harmonic), Elias Judin
 -/
-import CompPoly.Multilinear.Basic
+import CompPoly.Multilinear.TransformEquiv
 
 /-!
   # Equivalence between `CMlPolynomial` and multilinear polynomials in `MvPolynomial`
@@ -82,6 +82,21 @@ and coefficients `p[i]`.
 -/
 def toMvPolynomial (p : CMlPolynomial R n) : MvPolynomial (Fin n) R :=
   ∑ i : Fin (2 ^ n), MvPolynomial.monomial (monomialOfNat i) (a:=p[i])
+
+/-- Evaluating the associated multivariate polynomial agrees with coefficient evaluation. -/
+theorem eval_toMvPolynomial (p : CMlPolynomial R n) (x : Vector R n) :
+    MvPolynomial.eval (fun i ↦ x[i]) (toMvPolynomial p) = p.eval x := by
+  unfold toMvPolynomial eval
+  simp +decide [MvPolynomial.eval_monomial, Vector.dotProduct_eq_root_dotProduct]
+  refine Finset.sum_congr rfl fun i _ ↦ ?_
+  congr! 2
+  unfold monomialOfNat monomialBasis
+  simp +decide [Finset.prod_ite]
+  rw [Finset.prod_filter]
+  congr
+  ext j
+  simp +decide [Nat.getBit]
+  cases Nat.mod_two_eq_zero_or_one (i.val >>> j.val) <;> simp +decide [*, Nat.testBit]
 
 -- #check (toMvPolynomial (CMlPolynomial.mk 2 #v[(1: ℤ), 2, 3, 4]))
 
@@ -335,6 +350,154 @@ variable [CommRing R]
 recovering the monomial-basis representation. -/
 def toMvPolynomial (p : CMlPolynomialEval R n) : MvPolynomial (Fin n) R :=
   CMlPolynomial.toMvPolynomial (CMlPolynomial.lagrangeToMono n p)
+
+/-- The inverse of the finite-function encoder reads the corresponding
+little-endian bit. -/
+private theorem finFunctionFinEquiv_symm_apply_two (i : Fin (2 ^ n)) (j : Fin n) :
+    ((finFunctionFinEquiv.symm i) j).val = Nat.getBit j.val i.val := by
+  simp [finFunctionFinEquiv, Equiv.ofRightInverseOfCardLE, Nat.getBit,
+    Nat.shiftRight_eq_div_pow, Nat.and_one_is_mod]
+
+/-- The local factor used to expand a Boolean-lattice zeta transform against
+the multilinear Lagrange basis. -/
+private def basisChangeFactor (x : Vector R n) (j : Fin (2 ^ n))
+    (k : Fin n) (b : Fin 2) : R :=
+  if j.val.testBit k.val then
+    (b.val : R) * x[k]
+  else
+    (b.val : R) * x[k] + (1 - (b.val : R)) * (1 - x[k])
+
+private theorem sum_basisChangeFactor (x : Vector R n) (j : Fin (2 ^ n))
+    (k : Fin n) :
+    (∑ b : Fin 2, basisChangeFactor x j k b) =
+      if j.val.testBit k.val then x[k] else 1 := by
+  rw [Fin.sum_univ_two]
+  by_cases hj : j.val.testBit k.val <;> simp [basisChangeFactor, hj]
+
+private theorem submask_lagrange_eq_factor_prod
+    (x : Vector R n) (i j : Fin (2 ^ n)) :
+    (if i.val &&& j.val = j.val then (lagrangeBasis x).get i else 0) =
+      ∏ k : Fin n, basisChangeFactor x j k ((finFunctionFinEquiv.symm i) k) := by
+  by_cases hsub : i.val &&& j.val = j.val
+  · rw [if_pos hsub]
+    unfold lagrangeBasis
+    simp only [Vector.get_ofFn, BitVec.getLsb_eq_getElem, Fin.getElem_fin,
+      BitVec.getElem_ofFin]
+    apply Finset.prod_congr rfl
+    intro k _
+    have hdecode := finFunctionFinEquiv_symm_apply_two i k
+    by_cases hj : j.val.testBit k.val = true
+    · have hi : i.val.testBit k.val = true := by
+        have hbits := congrArg (fun m : ℕ ↦ m.testBit k.val) hsub
+        simpa [Nat.testBit_and, hj] using hbits
+      simp [Nat.getBit_eq_testBit, hi] at hdecode
+      simp [basisChangeFactor, hj, hi, hdecode]
+    · cases hi : i.val.testBit k.val <;>
+        simp [Nat.getBit_eq_testBit, hi] at hdecode <;>
+        simp [basisChangeFactor, hj, hdecode]
+  · rw [if_neg hsub]
+    obtain ⟨k, hj, hi⟩ :
+        ∃ k : Fin n, j.val.testBit k.val = true ∧ i.val.testBit k.val = false := by
+      by_contra h
+      apply hsub
+      apply Nat.eq_of_testBit_eq
+      intro k
+      rw [Nat.testBit_and]
+      by_cases hk : k < n
+      · let k' : Fin n := ⟨k, hk⟩
+        by_cases hj' : j.val.testBit k = true
+        · have hi' : i.val.testBit k ≠ false := by
+            intro hi'
+            exact h ⟨k', hj', hi'⟩
+          cases hibit : i.val.testBit k <;> simp_all
+        · cases hjbit : j.val.testBit k <;> simp_all
+      · have hnk : n ≤ k := Nat.le_of_not_gt hk
+        have hi' : i.val.testBit k = false :=
+          Nat.testBit_eq_false_of_lt
+            (lt_of_lt_of_le i.isLt (Nat.pow_le_pow_right two_pos hnk))
+        have hj' : j.val.testBit k = false :=
+          Nat.testBit_eq_false_of_lt
+            (lt_of_lt_of_le j.isLt (Nat.pow_le_pow_right two_pos hnk))
+        simp [hi', hj']
+    symm
+    apply Finset.prod_eq_zero (Finset.mem_univ k)
+    have hdecode := finFunctionFinEquiv_symm_apply_two i k
+    simp [Nat.getBit_eq_testBit, hi] at hdecode
+    simp [basisChangeFactor, hj, hdecode]
+
+private theorem submask_lagrange_sum (x : Vector R n) (j : Fin (2 ^ n)) :
+    (∑ i : Fin (2 ^ n),
+        if i.val &&& j.val = j.val then (lagrangeBasis x).get i else 0) =
+      (CMlPolynomial.monomialBasis x).get j := by
+  calc
+    _ = ∑ i : Fin (2 ^ n),
+        ∏ k : Fin n, basisChangeFactor x j k ((finFunctionFinEquiv.symm i) k) := by
+      exact Finset.sum_congr rfl fun i _ ↦ submask_lagrange_eq_factor_prod x i j
+    _ = ∑ y : Fin n → Fin 2, ∏ k : Fin n, basisChangeFactor x j k (y k) := by
+      symm
+      exact Fintype.sum_equiv finFunctionFinEquiv _ _ fun y ↦ by simp
+    _ = ∏ k : Fin n, ∑ b : Fin 2, basisChangeFactor x j k b := by
+      rw [Fintype.prod_sum]
+    _ = ∏ k : Fin n, if j.val.testBit k.val then x[k] else 1 := by
+      exact Finset.prod_congr rfl fun k _ ↦ sum_basisChangeFactor x j k
+    _ = (CMlPolynomial.monomialBasis x).get j := by
+      unfold CMlPolynomial.monomialBasis
+      simp only [Vector.get_ofFn, BitVec.getLsb_eq_getElem, Fin.getElem_fin,
+        BitVec.getElem_ofFin]
+
+/-- Changing monomial coefficients to Boolean-hypercube evaluations preserves
+evaluation at every point. -/
+theorem eval_monoToLagrange (p : CMlPolynomial R n) (x : Vector R n) :
+    (CMlPolynomial.monoToLagrange n p : CMlPolynomialEval R n).eval x = p.eval x := by
+  rw [CMlPolynomial.monoToLagrange_eq_monoToLagrangeSpec]
+  rw [eval, CMlPolynomial.eval, Vector.dotProduct_eq_root_dotProduct,
+    Vector.dotProduct_eq_root_dotProduct]
+  unfold _root_.dotProduct CMlPolynomial.monoToLagrangeSpec
+  simp only [Vector.get_ofFn]
+  calc
+    (∑ i : Fin (2 ^ n),
+        (∑ j : Fin (2 ^ n), if i.val &&& j.val = j.val then p.get j else 0) *
+          (lagrangeBasis x).get i) =
+        ∑ i : Fin (2 ^ n), ∑ j : Fin (2 ^ n),
+          p.get j *
+            (if i.val &&& j.val = j.val then (lagrangeBasis x).get i else 0) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro j _
+      by_cases hsub : i.val &&& j.val = j.val <;> simp [hsub]
+    _ = ∑ j : Fin (2 ^ n), ∑ i : Fin (2 ^ n),
+          p.get j *
+            (if i.val &&& j.val = j.val then (lagrangeBasis x).get i else 0) := by
+      rw [Finset.sum_comm]
+    _ = ∑ j : Fin (2 ^ n), p.get j *
+          (∑ i : Fin (2 ^ n),
+            if i.val &&& j.val = j.val then (lagrangeBasis x).get i else 0) := by
+      exact Finset.sum_congr rfl fun j _ ↦ (Finset.mul_sum _ _ _).symm
+    _ = ∑ j : Fin (2 ^ n), p.get j * (CMlPolynomial.monomialBasis x).get j := by
+      exact Finset.sum_congr rfl fun j _ ↦ by rw [submask_lagrange_sum]
+
+/-- Recovering monomial coefficients from a hypercube table preserves its
+multilinear-extension evaluation. -/
+theorem eval_lagrangeToMono (p : CMlPolynomialEval R n) (x : Vector R n) :
+    CMlPolynomial.eval (CMlPolynomial.lagrangeToMono n p) x =
+      CMlPolynomialEval.eval p x := by
+  have h := eval_monoToLagrange (CMlPolynomial.lagrangeToMono n p) x
+  have hinv :=
+    (CMlPolynomial.equivMonomialLagrangeRepr (R := R) (n := n)).apply_symm_apply p
+  have hinv' :
+      CMlPolynomial.monoToLagrange n (CMlPolynomial.lagrangeToMono n p) = p := by
+    simpa [CMlPolynomial.equivMonomialLagrangeRepr] using hinv
+  rw [hinv'] at h
+  exact h.symm
+
+/-- Evaluating the multivariate polynomial recovered from a hypercube table
+agrees with multilinear-extension evaluation. -/
+theorem eval_toMvPolynomial (p : CMlPolynomialEval R n) (x : Vector R n) :
+    MvPolynomial.eval (fun i ↦ x[i]) (toMvPolynomial p) = p.eval x := by
+  rw [toMvPolynomial, CMlPolynomial.eval_toMvPolynomial]
+  exact eval_lagrangeToMono p x
 
 /-- Converts a hypercube-evaluation representation to a Mathlib restricted-degree multivariate
 polynomial. -/

--- a/CompPoly/Multilinear/Next.lean
+++ b/CompPoly/Multilinear/Next.lean
@@ -1,0 +1,516 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aristotle (Harmonic), Elias Judin
+-/
+import CompPoly.Multilinear.Semantics
+
+/-!
+# The next kernel and shift identity
+
+This file defines the multilinear `nextHat` kernel on the Boolean hypercube
+and proves the shift identity `CompPoly.Multilinear.shift_eq_sum`.
+-/
+
+open scoped BigOperators
+
+namespace CompPoly.Multilinear
+
+open CompPoly
+
+variable {R : Type*} {n : Nat}
+
+/-- The terminal-successor map on hypercube indices. `nextIndex n i` is `i + 1`
+when that is still a valid index and is the terminal self-loop `i` at the
+all-ones point `i = 2^n - 1`. -/
+def nextIndex (n : Nat) (i : Fin (2 ^ n)) : Fin (2 ^ n) :=
+  if h : i.val + 1 < 2 ^ n then ⟨i.val + 1, h⟩ else i
+
+/-- The all-ones index, where `nextIndex` has its terminal self-loop. -/
+private def terminalIndex (n : ℕ) : Fin (2 ^ n) :=
+  ⟨2 ^ n - 1, by have := Nat.two_pow_pos n; omega⟩
+
+private theorem not_succ_lt_iff_eq_terminal (i : Fin (2 ^ n)) :
+    ¬ i.val + 1 < 2 ^ n ↔ i = terminalIndex n := by
+  constructor
+  · intro h
+    apply Fin.ext
+    simp only [terminalIndex]
+    omega
+  · rintro rfl
+    simp only [terminalIndex]
+    omega
+
+/-- Embed a prefix index with a zero low bit. -/
+private def evenIndex (i : Fin (2 ^ n)) : Fin (2 ^ (n + 1)) :=
+  ⟨2 * i.val, by
+    rw [pow_succ]
+    omega⟩
+
+/-- Embed a prefix index with a one low bit. -/
+private def oddIndex (i : Fin (2 ^ n)) : Fin (2 ^ (n + 1)) :=
+  ⟨2 * i.val + 1, by
+    rw [pow_succ, mul_comm]
+    omega⟩
+
+private theorem nextIndex_evenIndex (i : Fin (2 ^ n)) :
+    nextIndex (n + 1) (evenIndex i) = oddIndex i := by
+  unfold nextIndex
+  split
+  · apply Fin.ext
+    simp [evenIndex, oddIndex]
+  · rename_i h
+    exfalso
+    apply h
+    simpa [evenIndex, oddIndex] using (oddIndex i).isLt
+
+private theorem nextIndex_oddIndex (i : Fin (2 ^ n)) :
+    nextIndex (n + 1) (oddIndex i) =
+      if h : i.val + 1 < 2 ^ n then evenIndex ⟨i.val + 1, h⟩ else oddIndex i := by
+  unfold nextIndex
+  by_cases h : i.val + 1 < 2 ^ n
+  · rw [dif_pos h]
+    have hglobal : 2 * i.val + 1 + 1 < 2 ^ (n + 1) := by
+      rw [pow_succ, mul_comm]
+      omega
+    split
+    · apply Fin.ext
+      simp [oddIndex, evenIndex]
+      omega
+    · rename_i hg
+      exact (hg (by simpa [oddIndex] using hglobal)).elim
+  · rw [dif_neg h]
+    have hglobal : ¬2 * i.val + 1 + 1 < 2 ^ (n + 1) := by
+      rw [pow_succ, mul_comm]
+      omega
+    split
+    · rename_i hg
+      exact (hglobal (by simpa [oddIndex] using hg)).elim
+    · rfl
+
+private theorem cubePoint_terminal [CommRing R] :
+    cubePoint (R := R) n (terminalIndex n) = Vector.replicate n 1 := by
+  apply Vector.ext
+  intro k hk
+  have hlt : n - 1 - k < n := by omega
+  simp [cubePoint, terminalIndex, Nat.testBit_two_pow_sub_one, hlt]
+
+private theorem eqHat_cubePoint_terminal [CommRing R] (x : Vector R n) :
+    eqHat x (cubePoint n (terminalIndex n)) = ∏ j : Fin n, x[j] := by
+  rw [cubePoint_terminal]
+  unfold eqHat
+  simp
+
+private theorem cubePoint_evenIndex [CommRing R] (i : Fin (2 ^ n)) :
+    cubePoint (R := R) (n + 1) (evenIndex i) = (cubePoint n i).push 0 := by
+  apply Vector.ext
+  intro k hk
+  by_cases hkn : k < n
+  · have hexp : n + 1 - 1 - k = (n - 1 - k) + 1 := by omega
+    have hbit : (2 * i.val).testBit (n + 1 - 1 - k) =
+        i.val.testBit (n - 1 - k) := by
+      rw [hexp, ← Nat.bit_false_apply i.val, Nat.testBit_bit_succ]
+    simp only [cubePoint, Vector.getElem_ofFn, evenIndex]
+    rw [Vector.getElem_push_lt hkn]
+    rw [hbit]
+    simp only [Vector.getElem_ofFn]
+  · have hk : k = n := by omega
+    subst k
+    have hbit : (2 * i.val).testBit 0 = false := by
+      rw [← Nat.bit_false_apply i.val, Nat.testBit_bit_zero]
+    simp [cubePoint, evenIndex, hbit]
+
+private theorem cubePoint_oddIndex [CommRing R] (i : Fin (2 ^ n)) :
+    cubePoint (R := R) (n + 1) (oddIndex i) = (cubePoint n i).push 1 := by
+  apply Vector.ext
+  intro k hk
+  by_cases hkn : k < n
+  · have hexp : n + 1 - 1 - k = (n - 1 - k) + 1 := by omega
+    have hbit : (2 * i.val + 1).testBit (n + 1 - 1 - k) =
+        i.val.testBit (n - 1 - k) := by
+      rw [hexp, ← Nat.bit_true_apply i.val, Nat.testBit_bit_succ]
+    simp only [cubePoint, Vector.getElem_ofFn, oddIndex]
+    rw [Vector.getElem_push_lt hkn]
+    rw [hbit]
+    simp only [Vector.getElem_ofFn]
+  · have hk : k = n := by omega
+    subst k
+    have hbit : (2 * i.val + 1).testBit 0 = true := by
+      rw [← Nat.bit_true_apply i.val, Nat.testBit_bit_zero]
+    simp [cubePoint, oddIndex, hbit]
+
+/-- Split a `2^(n+1)`-term sum according to its low bit. -/
+private theorem sum_even_odd {S : Type*} [AddCommMonoid S]
+    (term : Fin (2 ^ (n + 1)) → S) :
+    (∑ i : Fin (2 ^ (n + 1)), term i) =
+      (∑ i : Fin (2 ^ n), term (evenIndex i)) +
+        ∑ i : Fin (2 ^ n), term (oddIndex i) := by
+  let f : ℕ → S := fun k ↦ if h : k < 2 ^ (n + 1) then term ⟨k, h⟩ else 0
+  symm
+  calc
+    (∑ i : Fin (2 ^ n), term (evenIndex i)) +
+          ∑ i : Fin (2 ^ n), term (oddIndex i) =
+        (∑ i : Fin (2 ^ n), f (2 * i.val)) +
+          ∑ i : Fin (2 ^ n), f (2 * i.val + 1) := by
+      congr 1
+      · exact Finset.sum_congr rfl fun i _ ↦ by
+          have hb : 2 * i.val < 2 ^ (n + 1) := (evenIndex i).isLt
+          dsimp only [f]
+          rw [dif_pos hb]
+          congr
+      · exact Finset.sum_congr rfl fun i _ ↦ by
+          have hb : 2 * i.val + 1 < 2 ^ (n + 1) := (oddIndex i).isLt
+          dsimp only [f]
+          rw [dif_pos hb]
+          congr
+    _ = ∑ i : Fin (2 ^ (n + 1)), f i.val := Fin.sum_univ_pow_two_even_add_odd f
+    _ = ∑ i : Fin (2 ^ (n + 1)), term i := by
+      exact Finset.sum_congr rfl fun i _ ↦ by
+        dsimp only [f]
+        rw [dif_pos i.isLt]
+
+private theorem eqHat_push [CommRing R] (x y : Vector R n) (a b : R) :
+    eqHat (x.push a) (y.push b) =
+      eqHat x y * (a * b + (1 - a) * (1 - b)) := by
+  unfold eqHat
+  rw [Fin.prod_univ_castSucc]
+  simp only [Fin.getElem_fin, Fin.val_castSucc, Fin.is_lt, Vector.getElem_push_lt,
+    Fin.val_last, Vector.getElem_push_eq]
+
+/-- Summing products of equality-kernel weights over the Boolean cube composes
+the two kernels. -/
+private theorem sum_eqHat_cubePoint_mul_eqHat_cubePoint [CommRing R]
+    (x y : Vector R n) :
+    (∑ i : Fin (2 ^ n), eqHat x (cubePoint n i) * eqHat y (cubePoint n i)) =
+      eqHat x y := by
+  induction n with
+  | zero =>
+      have hx : x = #v[] := Vector.eq_empty_of_size_eq_zero rfl
+      have hy : y = #v[] := Vector.eq_empty_of_size_eq_zero rfl
+      subst x
+      subst y
+      simp [eqHat, cubePoint]
+  | succ n ih =>
+      obtain ⟨x', a, hx⟩ : ∃ (x' : Vector R n) (a : R), x = x'.push a :=
+        Vector.exists_push
+      obtain ⟨y', b, hy⟩ : ∃ (y' : Vector R n) (b : R), y = y'.push b :=
+        Vector.exists_push
+      rw [hx, hy]
+      let term : Fin (2 ^ (n + 1)) → R := fun i ↦
+        eqHat (x'.push a) (cubePoint (n + 1) i) *
+          eqHat (y'.push b) (cubePoint (n + 1) i)
+      change (∑ i : Fin (2 ^ (n + 1)), term i) = _
+      rw [sum_even_odd]
+      dsimp only [term]
+      simp_rw [cubePoint_evenIndex, cubePoint_oddIndex, eqHat_push]
+      simp only [mul_zero, add_zero, zero_add, sub_zero, sub_self, mul_one]
+      have heven : ∀ i : Fin (2 ^ n),
+          eqHat x' (cubePoint n i) * (1 - a) *
+              (eqHat y' (cubePoint n i) * (1 - b)) =
+            (1 - a) * (1 - b) *
+              (eqHat x' (cubePoint n i) * eqHat y' (cubePoint n i)) :=
+        fun i ↦ by ring
+      have hodd : ∀ i : Fin (2 ^ n),
+          eqHat x' (cubePoint n i) * a * (eqHat y' (cubePoint n i) * b) =
+            a * b * (eqHat x' (cubePoint n i) * eqHat y' (cubePoint n i)) :=
+        fun i ↦ by ring
+      have hevenSum :
+          (∑ i : Fin (2 ^ n),
+            eqHat x' (cubePoint n i) * (1 - a) *
+              (eqHat y' (cubePoint n i) * (1 - b))) =
+            ∑ i : Fin (2 ^ n),
+              (1 - a) * (1 - b) *
+                (eqHat x' (cubePoint n i) * eqHat y' (cubePoint n i)) :=
+        Finset.sum_congr rfl fun i _ ↦ heven i
+      have hoddSum :
+          (∑ i : Fin (2 ^ n),
+            eqHat x' (cubePoint n i) * a * (eqHat y' (cubePoint n i) * b)) =
+            ∑ i : Fin (2 ^ n),
+              a * b * (eqHat x' (cubePoint n i) * eqHat y' (cubePoint n i)) :=
+        Finset.sum_congr rfl fun i _ ↦ hodd i
+      rw [hevenSum, hoddSum]
+      rw [← Finset.mul_sum, ← Finset.mul_sum, ih x' y']
+      ring
+
+/-- The multilinear "next" kernel in canonical interpolation form.
+
+`nextHat x y` is the `2n`-variable multilinear polynomial whose value on Boolean
+cube points is `1` exactly when the `y`-index is the terminal successor of the
+`x`-index, and `0` otherwise. -/
+def nextHat [CommRing R] (x y : Vector R n) : R :=
+  ∑ i : Fin (2 ^ n),
+    eqHat x (cubePoint n i) * eqHat y (cubePoint n (nextIndex n i))
+
+/-- With the right input fixed, `nextHat` is represented by a canonical
+`n`-variable multilinear-evaluation table in its left input. -/
+theorem nextHat_left_mle [CommRing R] (y : Vector R n) :
+    ∃ v : CMlPolynomialEval R n, ∀ x, nextHat x y = mleEval v x := by
+  let v : CMlPolynomialEval R n :=
+    Vector.ofFn fun i ↦ eqHat y (cubePoint n (nextIndex n i))
+  have hv (i : Fin (2 ^ n)) : v[i] = eqHat y (cubePoint n (nextIndex n i)) := by
+    change (Vector.ofFn fun i ↦ eqHat y (cubePoint n (nextIndex n i)))[i.val] = _
+    simp
+  refine ⟨v, fun x ↦ ?_⟩
+  unfold nextHat mleEval
+  exact Finset.sum_congr rfl fun i _ ↦ by rw [hv]
+
+/-- With the left input fixed, `nextHat` is represented by a canonical
+`n`-variable multilinear-evaluation table in its right input. Together with
+`nextHat_left_mle`, this records the kernel's degree-at-most-one property in
+each of its `2n` variables. -/
+theorem nextHat_right_mle [CommRing R] (x : Vector R n) :
+    ∃ v : CMlPolynomialEval R n, ∀ y, nextHat x y = mleEval v y := by
+  let v : CMlPolynomialEval R n := Vector.ofFn fun j ↦
+    ∑ i : Fin (2 ^ n),
+      if nextIndex n i = j then eqHat x (cubePoint n i) else 0
+  have hv (j : Fin (2 ^ n)) :
+      v[j] = ∑ i : Fin (2 ^ n),
+        if nextIndex n i = j then eqHat x (cubePoint n i) else 0 := by
+    change (Vector.ofFn fun j ↦
+      ∑ i : Fin (2 ^ n),
+        if nextIndex n i = j then eqHat x (cubePoint n i) else 0)[j.val] = _
+    simp
+  refine ⟨v, fun y ↦ ?_⟩
+  symm
+  calc
+    mleEval v y =
+        ∑ j : Fin (2 ^ n), ∑ i : Fin (2 ^ n),
+          eqHat y (cubePoint n j) *
+            (if nextIndex n i = j then eqHat x (cubePoint n i) else 0) := by
+      unfold mleEval
+      exact Finset.sum_congr rfl fun j _ ↦ by rw [hv, Finset.mul_sum]
+    _ = ∑ i : Fin (2 ^ n), ∑ j : Fin (2 ^ n),
+          eqHat y (cubePoint n j) *
+            (if nextIndex n i = j then eqHat x (cubePoint n i) else 0) :=
+      Finset.sum_comm
+    _ = ∑ i : Fin (2 ^ n),
+          eqHat x (cubePoint n i) * eqHat y (cubePoint n (nextIndex n i)) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [Finset.sum_eq_single (nextIndex n i)]
+      · simp only [if_pos, mul_comm]
+      · intro j _ hji
+        rw [if_neg (Ne.symm hji), mul_zero]
+      · simp
+    _ = nextHat x y := rfl
+
+/-- Recurrence for the interpolation definition after appending the low bit. -/
+private theorem nextHat_push [CommRing R] (x y : Vector R n) (a b : R) :
+    nextHat (x.push a) (y.push b) =
+      a * b *
+          (eqHat x (cubePoint n (terminalIndex n)) *
+            eqHat y (cubePoint n (terminalIndex n))) +
+        (1 - a) * b * eqHat x y +
+        a * (1 - b) *
+          (nextHat x y -
+            eqHat x (cubePoint n (terminalIndex n)) *
+              eqHat y (cubePoint n (terminalIndex n))) := by
+  let prefixTerm : Fin (2 ^ n) → R := fun i ↦
+    eqHat x (cubePoint n i) * eqHat y (cubePoint n (nextIndex n i))
+  let terminalWeight : R :=
+    eqHat x (cubePoint n (terminalIndex n)) *
+      eqHat y (cubePoint n (terminalIndex n))
+  let globalTerm : Fin (2 ^ (n + 1)) → R := fun i ↦
+    eqHat (x.push a) (cubePoint (n + 1) i) *
+      eqHat (y.push b) (cubePoint (n + 1) (nextIndex (n + 1) i))
+  change (∑ i : Fin (2 ^ (n + 1)), globalTerm i) = _
+  rw [sum_even_odd]
+  have heven : ∀ i : Fin (2 ^ n),
+      globalTerm (evenIndex i) =
+        (1 - a) * b *
+          (eqHat x (cubePoint n i) * eqHat y (cubePoint n i)) := by
+    intro i
+    dsimp only [globalTerm]
+    rw [nextIndex_evenIndex, cubePoint_evenIndex, cubePoint_oddIndex,
+      eqHat_push, eqHat_push]
+    ring
+  have hevenSum :
+      (∑ i : Fin (2 ^ n), globalTerm (evenIndex i)) = (1 - a) * b * eqHat x y := by
+    calc
+      (∑ i : Fin (2 ^ n), globalTerm (evenIndex i)) =
+          ∑ i : Fin (2 ^ n),
+            (1 - a) * b *
+              (eqHat x (cubePoint n i) * eqHat y (cubePoint n i)) :=
+        Finset.sum_congr rfl fun i _ ↦ heven i
+      _ = (1 - a) * b *
+          ∑ i : Fin (2 ^ n),
+            eqHat x (cubePoint n i) * eqHat y (cubePoint n i) := by
+        rw [Finset.mul_sum]
+      _ = (1 - a) * b * eqHat x y := by
+        rw [sum_eqHat_cubePoint_mul_eqHat_cubePoint]
+  have hodd : ∀ i : Fin (2 ^ n),
+      globalTerm (oddIndex i) =
+        a * (1 - b) * prefixTerm i +
+          if i = terminalIndex n then
+            a * (b - (1 - b)) * terminalWeight
+          else 0 := by
+    intro i
+    by_cases h : i.val + 1 < 2 ^ n
+    · have hne : i ≠ terminalIndex n := by
+        intro hi
+        exact (not_succ_lt_iff_eq_terminal i).2 hi h
+      dsimp only [globalTerm, prefixTerm]
+      rw [nextIndex_oddIndex, dif_pos h, cubePoint_oddIndex, cubePoint_evenIndex,
+        eqHat_push, eqHat_push, if_neg hne]
+      unfold nextIndex
+      rw [dif_pos h]
+      ring
+    · have hi : i = terminalIndex n := (not_succ_lt_iff_eq_terminal i).1 h
+      subst i
+      have hterminal :
+          ¬(terminalIndex n).val + 1 < 2 ^ n :=
+        (not_succ_lt_iff_eq_terminal (terminalIndex n)).2 rfl
+      have hnext : nextIndex n (terminalIndex n) = terminalIndex n := by
+        unfold nextIndex
+        rw [dif_neg hterminal]
+      dsimp only [globalTerm, prefixTerm, terminalWeight]
+      rw [nextIndex_oddIndex, dif_neg hterminal, cubePoint_oddIndex,
+        eqHat_push, eqHat_push, if_pos rfl, hnext]
+      ring
+  have hoddSum :
+      (∑ i : Fin (2 ^ n), globalTerm (oddIndex i)) =
+        a * (1 - b) * nextHat x y + a * (b - (1 - b)) * terminalWeight := by
+    calc
+      (∑ i : Fin (2 ^ n), globalTerm (oddIndex i)) =
+          ∑ i : Fin (2 ^ n),
+            (a * (1 - b) * prefixTerm i +
+              if i = terminalIndex n then
+                a * (b - (1 - b)) * terminalWeight
+              else 0) :=
+        Finset.sum_congr rfl fun i _ ↦ hodd i
+      _ = (∑ i : Fin (2 ^ n), a * (1 - b) * prefixTerm i) +
+          ∑ i : Fin (2 ^ n),
+            if i = terminalIndex n then a * (b - (1 - b)) * terminalWeight else 0 := by
+        rw [Finset.sum_add_distrib]
+      _ = a * (1 - b) * (∑ i : Fin (2 ^ n), prefixTerm i) +
+          a * (b - (1 - b)) * terminalWeight := by
+        rw [Finset.mul_sum]
+        simp
+      _ = a * (1 - b) * nextHat x y + a * (b - (1 - b)) * terminalWeight := by
+        rfl
+  rw [hevenSum, hoddSum]
+  dsimp only [terminalWeight]
+  ring
+
+/-- Equality factors strictly above carry-stop coordinate `k`. -/
+def carryPrefix [CommRing R] (x y : Vector R n) (k : Fin n) : R :=
+  ∏ j ∈ Finset.univ.filter (fun j : Fin n ↦ j < k),
+    (x[j] * y[j] + (1 - x[j]) * (1 - y[j]))
+
+/-- One-to-zero factors strictly below carry-stop coordinate `k`. -/
+def carrySuffix [CommRing R] (x y : Vector R n) (k : Fin n) : R :=
+  ∏ j ∈ Finset.univ.filter (fun j : Fin n ↦ k < j),
+    x[j] * (1 - y[j])
+
+/-- The closed carry-chain expression. The leading product is
+the all-ones self-loop. In summand `k`, high bits `j < k` agree, bit `k`
+changes from zero to one, and low bits `j > k` change from one to zero. -/
+def nextHatCarry [CommRing R] (x y : Vector R n) : R :=
+  (∏ j : Fin n, x[j] * y[j]) +
+    ∑ k : Fin n, carryPrefix x y k * ((1 - x[k]) * y[k]) * carrySuffix x y k
+
+private theorem carryPrefix_push_castSucc [CommRing R]
+    (x y : Vector R n) (a b : R) (k : Fin n) :
+    carryPrefix (x.push a) (y.push b) k.castSucc = carryPrefix x y k := by
+  have hlast : ¬Fin.last n < k.castSucc := not_lt_of_ge (Fin.le_last _)
+  simp [carryPrefix, Finset.prod_filter, Fin.prod_univ_castSucc, hlast]
+
+private theorem carryPrefix_push_last [CommRing R] (x y : Vector R n) (a b : R) :
+    carryPrefix (x.push a) (y.push b) (Fin.last n) = eqHat x y := by
+  simp [carryPrefix, eqHat, Finset.prod_filter, Fin.prod_univ_castSucc]
+
+private theorem carrySuffix_push_castSucc [CommRing R]
+    (x y : Vector R n) (a b : R) (k : Fin n) :
+    carrySuffix (x.push a) (y.push b) k.castSucc =
+      carrySuffix x y k * (a * (1 - b)) := by
+  simp [carrySuffix, Finset.prod_filter, Fin.prod_univ_castSucc]
+
+private theorem carrySuffix_push_last [CommRing R] (x y : Vector R n) (a b : R) :
+    carrySuffix (x.push a) (y.push b) (Fin.last n) = 1 := by
+  have hnone : ∀ k : Fin n, ¬Fin.last n < k.castSucc := by
+    intro k
+    exact not_lt_of_ge (Fin.le_last _)
+  simp [carrySuffix, Finset.prod_filter, Fin.prod_univ_castSucc, hnone]
+
+/-- Recurrence for the carry-chain expression after appending the low bit. -/
+private theorem nextHatCarry_push [CommRing R] (x y : Vector R n) (a b : R) :
+    nextHatCarry (x.push a) (y.push b) =
+      a * b * (∏ j : Fin n, x[j] * y[j]) +
+        (1 - a) * b * eqHat x y +
+        a * (1 - b) * (nextHatCarry x y - ∏ j : Fin n, x[j] * y[j]) := by
+  rw [nextHatCarry, Fin.prod_univ_castSucc, Fin.sum_univ_castSucc]
+  simp only [carryPrefix_push_castSucc, carryPrefix_push_last,
+    carrySuffix_push_castSucc, carrySuffix_push_last, mul_one]
+  simp only [Fin.getElem_fin, Fin.val_castSucc, Fin.is_lt, Vector.getElem_push_lt,
+    Fin.val_last, Vector.getElem_push_eq]
+  have hfactor :
+      (∑ k : Fin n,
+        carryPrefix x y k * ((1 - x[k]) * y[k]) *
+          (carrySuffix x y k * (a * (1 - b)))) =
+        a * (1 - b) *
+          ∑ k : Fin n, carryPrefix x y k * ((1 - x[k]) * y[k]) * carrySuffix x y k := by
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl fun k _ ↦ by ring
+  simp only [Fin.getElem_fin] at hfactor
+  rw [hfactor]
+  rw [nextHatCarry]
+  simp only [Fin.getElem_fin]
+  ring
+
+/-- The interpolation definition of `nextHat` equals the closed
+carry-chain expression at every field point, not only on the Boolean cube. -/
+theorem nextHat_eq_carry [CommRing R] (x y : Vector R n) :
+    nextHat x y = nextHatCarry x y := by
+  induction n with
+  | zero =>
+      have hx : x = #v[] := Vector.eq_empty_of_size_eq_zero rfl
+      have hy : y = #v[] := Vector.eq_empty_of_size_eq_zero rfl
+      subst x
+      subst y
+      simp [nextHat, nextHatCarry, eqHat, cubePoint, nextIndex]
+  | succ n ih =>
+      obtain ⟨x', a, hx⟩ : ∃ (x' : Vector R n) (a : R), x = x'.push a :=
+        Vector.exists_push
+      obtain ⟨y', b, hy⟩ : ∃ (y' : Vector R n) (b : R), y = y'.push b :=
+        Vector.exists_push
+      rw [hx, hy, nextHat_push, nextHatCarry_push, ih x' y',
+        eqHat_cubePoint_terminal, eqHat_cubePoint_terminal]
+      rw [← Finset.prod_mul_distrib]
+
+/-- The shifted column of a hypercube-evaluation table: the entry at index `i`
+is the original entry at the terminal-successor index `nextIndex i`. -/
+def shiftColumn (v : CMlPolynomialEval R n) : CMlPolynomialEval R n :=
+  Vector.ofFn (fun i : Fin (2 ^ n) ↦ v[nextIndex n i])
+
+/-- On Boolean points, `nextHat` is the indicator of the successor relation,
+including the all-ones self-loop. -/
+theorem nextHat_cubePoint [CommRing R] (i j : Fin (2 ^ n)) :
+    nextHat (cubePoint n i) (cubePoint n j) =
+      if nextIndex n i = j then (1 : R) else 0 := by
+  classical
+  unfold nextHat
+  rw [Finset.sum_eq_single i]
+  · simp only [eqHat_cubePoint_delta, if_pos, one_mul, eq_comm]
+  · intro b _ hbi
+    have hib : i ≠ b := fun h ↦ hbi h.symm
+    simp [eqHat_cubePoint_delta, hib]
+  · simp
+
+/-- The shift identity. Evaluating the multilinear extension of the shifted
+column `shiftColumn v` at a point `x` equals the finite sum over the original
+column values weighted by `nextHat x (cubePoint n i)`. -/
+theorem shift_eq_sum [CommRing R] (v : CMlPolynomialEval R n) (x : Vector R n) :
+    mleEval (shiftColumn v) x =
+      ∑ i : Fin (2 ^ n), nextHat x (cubePoint n i) * v[i] := by
+  convert eqHat_interpolation (shiftColumn v) x using 1
+  simp +decide only [nextHat, eqHat_cubePoint_delta, shiftColumn]
+  simp +decide [Finset.sum_mul, Vector.getElem_ofFn]
+  rw [Finset.sum_comm, Finset.sum_congr rfl]
+  intro i _
+  rw [Finset.sum_eq_single (nextIndex n i)]
+  · simp
+  · intro j _ hji
+    simp [hji]
+  · simp
+
+end CompPoly.Multilinear

--- a/CompPoly/Multilinear/Semantics.lean
+++ b/CompPoly/Multilinear/Semantics.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aristotle (Harmonic), Elias Judin
+-/
+import CompPoly.Multilinear.Equiv
+
+/-!
+# Bit order and the equality kernel
+
+This file relates CompPoly's native little-endian Boolean-cube coordinates to an explicit
+big-endian coordinate convention. It defines the multilinear equality kernel and proves the
+associated interpolation and uniqueness identities.
+-/
+
+open scoped BigOperators
+open CompPoly
+
+namespace CompPoly.Bits
+
+/-- Big-endian bit decomposition of `i` into `n` bits.
+
+The bit at index `k : Fin n` is bit `n - 1 - k` of `i`, so coordinate zero
+contains the most significant bit. -/
+def toBE (n i : ℕ) : Vector Bool n :=
+  Vector.ofFn (fun k : Fin n ↦ i.testBit (n - 1 - k.val))
+
+@[simp]
+theorem toBE_getElem (n i : ℕ) (k : ℕ) (hk : k < n) :
+    (toBE n i)[k] = i.testBit (n - 1 - k) := by
+  simp [toBE]
+
+@[simp]
+theorem toBE_zero (n : ℕ) : toBE n 0 = Vector.replicate n false := by
+  apply Vector.ext
+  intro i hi
+  simp [toBE]
+
+/-- The first coordinate of a nonempty big-endian bit vector is its most significant bit. -/
+theorem toBE_msb (n i : ℕ) (hn : 0 < n) :
+    (toBE n i)[0]'(by omega) = i.testBit (n - 1) := by
+  simp
+
+end CompPoly.Bits
+
+namespace CompPoly.Multilinear
+
+variable {R : Type*} {n : ℕ}
+
+/-- The multilinear equality kernel in closed product form:
+`eqHat z w = ∏ j, (z[j] * w[j] + (1 - z[j]) * (1 - w[j]))`. -/
+def eqHat [CommRing R] (z w : Vector R n) : R :=
+  ∏ j : Fin n, (z[j] * w[j] + (1 - z[j]) * (1 - w[j]))
+
+/-- The `R`-valued cube point in CompPoly's little-endian coordinate order. -/
+def cubePointLE [Zero R] [One R] (n : ℕ) (i : Fin (2 ^ n)) : Vector R n :=
+  Vector.ofFn (fun j : Fin n ↦ if (BitVec.ofFin i).getLsb j then (1 : R) else 0)
+
+/-- `eqHat z` at a little-endian cube point equals CompPoly's
+`i`-th `lagrangeBasis` entry. -/
+theorem eqHat_cubePointLE [CommRing R] (z : Vector R n) (i : Fin (2 ^ n)) :
+    eqHat z (cubePointLE n i) = (CMlPolynomialEval.lagrangeBasis z)[i] := by
+  unfold eqHat cubePointLE CMlPolynomialEval.lagrangeBasis
+  simp +decide [Vector.ofFn]
+  exact Finset.prod_congr rfl fun x _ ↦ by split_ifs <;> ring
+
+/-- The interpolation identity in CompPoly's little-endian coordinates. -/
+theorem eqHat_interpolationLE [CommRing R]
+    (v : CMlPolynomialEval R n) (z : Vector R n) :
+    v.eval z = ∑ i : Fin (2 ^ n), eqHat z (cubePointLE n i) * v[i] := by
+  have h_eval : v.eval z =
+      ∑ i : Fin (2 ^ n), v.get i * (CMlPolynomialEval.lagrangeBasis z).get i := by
+    rw [CMlPolynomialEval.eval, Vector.dotProduct_eq_root_dotProduct]
+    rfl
+  have h_lagrangeBasis : ∀ i : Fin (2 ^ n),
+      (CMlPolynomialEval.lagrangeBasis z).get i = eqHat z (cubePointLE n i) :=
+    fun i ↦ (eqHat_cubePointLE z i).symm
+  simp_all +decide
+  exact Finset.sum_congr rfl fun _ _ ↦ mul_comm _ _
+
+private theorem match_bool_zero_one [Zero R] [One R] (b : Bool) :
+    (match b with | false => (0 : R) | true => 1) = if b then 1 else 0 := by
+  cases b <;> rfl
+
+/-- The `R`-valued Boolean-cube point for index `i`, with the most
+significant bit in coordinate zero. -/
+def cubePoint [Zero R] [One R] (n : ℕ) (i : Fin (2 ^ n)) : Vector R n :=
+  Vector.ofFn fun j : Fin n ↦
+    match i.val.testBit (n - 1 - j.val) with
+    | false => 0
+    | true => 1
+
+/-- Reversing CompPoly's little-endian cube point gives the big-endian cube point. -/
+theorem cubePoint_eq_reverse_cubePointLE [CommRing R] (i : Fin (2 ^ n)) :
+    cubePoint (R := R) n i = (cubePointLE (R := R) n i).reverse := by
+  apply Vector.ext
+  intro j hj
+  simp [cubePoint, cubePointLE]
+  exact match_bool_zero_one _
+
+/-- The equality kernel is invariant under reversing both coordinate vectors. -/
+theorem eqHat_reverse [CommRing R] (z w : Vector R n) :
+    eqHat z.reverse w.reverse = eqHat z w := by
+  unfold eqHat
+  apply Fintype.prod_equiv Fin.revPerm
+  intro j
+  change z.reverse.get j * w.reverse.get j +
+      (1 - z.reverse.get j) * (1 - w.reverse.get j) =
+    z.get (Fin.revPerm j) * w.get (Fin.revPerm j) +
+      (1 - z.get (Fin.revPerm j)) * (1 - w.get (Fin.revPerm j))
+  rw [Vector.get_reverse, Vector.get_reverse]
+  rfl
+
+/-- The equality kernel factors over a concatenation of coordinate blocks. -/
+theorem eqHat_append [CommRing R] {m : ℕ}
+    (z₁ w₁ : Vector R n) (z₂ w₂ : Vector R m) :
+    eqHat (z₁ ++ z₂) (w₁ ++ w₂) = eqHat z₁ w₁ * eqHat z₂ w₂ := by
+  unfold eqHat
+  rw [Fin.prod_univ_add]
+  congr 1
+  · exact Finset.prod_congr rfl fun i _ ↦ by simp
+  · exact Finset.prod_congr rfl fun i _ ↦ by simp
+
+/-- The big-endian equality-kernel weight is CompPoly's
+little-endian weight at the reversed evaluation point. -/
+theorem eqHat_cubePoint_eqLE [CommRing R] (z : Vector R n) (i : Fin (2 ^ n)) :
+    eqHat z (cubePoint (R := R) n i) =
+      eqHat z.reverse (cubePointLE (R := R) n i) := by
+  rw [cubePoint_eq_reverse_cubePointLE (R := R)]
+  calc
+    eqHat z (cubePointLE n i).reverse =
+        eqHat z.reverse.reverse (cubePointLE n i).reverse := by simp
+    _ = eqHat z.reverse (cubePointLE n i) := eqHat_reverse _ _
+
+/-- Multilinear-extension evaluation in big-endian coordinates. -/
+def mleEval [CommRing R] (v : CMlPolynomialEval R n) (z : Vector R n) : R :=
+  ∑ i : Fin (2 ^ n), eqHat z (cubePoint n i) * v[i]
+
+/-- The big-endian MLE interpolation identity. -/
+theorem eqHat_interpolation [CommRing R]
+    (v : CMlPolynomialEval R n) (z : Vector R n) :
+    mleEval v z = ∑ i : Fin (2 ^ n), eqHat z (cubePoint n i) * v[i] := rfl
+
+/-- The endianness bridge from `mleEval` to CompPoly evaluation. -/
+theorem mleEval_eq_eval_reverse [CommRing R]
+    (v : CMlPolynomialEval R n) (z : Vector R n) :
+    mleEval v z = v.eval z.reverse := by
+  rw [eqHat_interpolationLE]
+  exact Finset.sum_congr rfl fun i _ ↦ by rw [eqHat_cubePoint_eqLE]
+
+/-- On big-endian Boolean points, the equality kernel is the Kronecker delta. -/
+theorem eqHat_cubePoint_delta [CommRing R] (i j : Fin (2 ^ n)) :
+    eqHat (cubePoint (R := R) n i) (cubePoint n j) =
+      if i = j then (1 : R) else 0 := by
+  split_ifs with h
+  · subst j
+    simp only [eqHat, cubePoint]
+    apply Finset.prod_eq_one
+    intro k _
+    by_cases hk : i.val.testBit (n - 1 - k.val) <;> simp [hk]
+  · obtain ⟨k, hk⟩ :
+        ∃ k : Fin n, i.val.testBit k.val ≠ j.val.testBit k.val := by
+      contrapose! h
+      refine Fin.ext (Nat.eq_of_testBit_eq fun k ↦ ?_)
+      by_cases hk : k < n
+      · exact h ⟨k, hk⟩
+      · have hkn : n ≤ k := Nat.le_of_not_gt hk
+        have hipow : i.val < 2 ^ k :=
+          lt_of_lt_of_le i.isLt (Nat.pow_le_pow_right two_pos hkn)
+        have hjpow : j.val < 2 ^ k :=
+          lt_of_lt_of_le j.isLt (Nat.pow_le_pow_right two_pos hkn)
+        rw [Nat.testBit_eq_false_of_lt hipow, Nat.testBit_eq_false_of_lt hjpow]
+    let rk : Fin n := ⟨n - 1 - k.val, by omega⟩
+    have hrk : n - 1 - rk.val = k.val := by
+      simp only [rk]
+      omega
+    refine Finset.prod_eq_zero (Finset.mem_univ rk) ?_
+    simp only [cubePoint]
+    cases hi : i.val.testBit k.val <;>
+      cases hj : j.val.testBit k.val <;>
+      simp_all
+
+/-- `mleEval` returns the stored value at each big-endian cube point. -/
+@[simp]
+theorem mleEval_cubePoint [CommRing R]
+    (v : CMlPolynomialEval R n) (i : Fin (2 ^ n)) :
+    mleEval v (cubePoint n i) = v[i] := by
+  classical
+  unfold mleEval
+  rw [Finset.sum_eq_single i]
+  · simp [eqHat_cubePoint_delta]
+  · intro b _ hbi
+    have hib : i ≠ b := fun h ↦ hbi h.symm
+    simp [eqHat_cubePoint_delta, hib]
+  · simp
+
+/-- A multilinear extension is uniquely determined by its values. -/
+theorem mleEval_ext [CommRing R] {v w : CMlPolynomialEval R n}
+    (h : ∀ z : Vector R n, mleEval v z = mleEval w z) :
+    v = w := by
+  apply Vector.ext
+  intro k hk
+  simpa using h (cubePoint n ⟨k, hk⟩)
+
+/-- Equality of all `mleEval` evaluations is equivalent to equality of
+the underlying Boolean-hypercube tables. -/
+theorem mleEval_eq_iff [CommRing R] (v w : CMlPolynomialEval R n) :
+    (∀ z : Vector R n, mleEval v z = mleEval w z) ↔ v = w := by
+  constructor
+  · exact mleEval_ext
+  · rintro rfl z
+    rfl
+
+end CompPoly.Multilinear

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -42,10 +42,11 @@ scripts/              repo utilities and validation helpers
 - Extending sparse monomial-based polynomial operations or `MvPolynomial`
   interoperability: start in `CompPoly/Multivariate/`.
 - Working on Boolean-hypercube evaluation form, basis conversion, or multilinear
-  equivalences: start in `CompPoly/Multilinear/`.
+  equivalences: start in `CompPoly/Multilinear/`. Coordinate semantics live in
+  `Semantics.lean`; the terminal-successor kernel and shifted tables live in `Next.lean`.
 - Working on the specialized two-variable API or the `R[X][Y]` bridge:
   start in `CompPoly/Bivariate/`.
-- Adding concrete fields, GHASH lemmas, tower-field infrastructure, or additive NTT:
+- Adding concrete fields, field extensions, GHASH lemmas, tower-field infrastructure, or additive NTT:
   start in `CompPoly/Fields/`.
 - Moving a reusable support lemma that should not live next to one specific feature:
   start in `CompPoly/Data/` or `CompPoly/ToMathlib/`.

--- a/docs/wiki/representations-and-bridges.md
+++ b/docs/wiki/representations-and-bridges.md
@@ -9,7 +9,7 @@ usually the first architectural decision in a change.
 |---|---|---|---|
 | Univariate | `CPolynomial.Raw R`, `CPolynomial R`, `QuotientCPolynomial R` | Canonical coefficient-sequence arithmetic, quotient reasoning, interpolation | `CompPoly/Univariate/README.md`, `CompPoly/Univariate/Basic.lean`, `CompPoly/Univariate/ToPoly.lean` |
 | Multivariate | `CMvPolynomial n R` | Sparse computable multivariate operations and `MvPolynomial` interop | `CompPoly/Multivariate/CMvPolynomial.lean`, `CompPoly/Multivariate/Operations.lean`, `CompPoly/Multivariate/MvPolyEquiv.lean` |
-| Multilinear | `CMlPolynomial R n`, `CMlPolynomialEval R n` | Boolean-hypercube evaluation form, basis conversion, multilinear extensions | `CompPoly/Multilinear/Basic.lean`, `CompPoly/Multilinear/Equiv.lean` |
+| Multilinear | `CMlPolynomial R n`, `CMlPolynomialEval R n` | Boolean-hypercube evaluation form, basis conversion, multilinear extensions | `CompPoly/Multilinear/Basic.lean`, `CompPoly/Multilinear/Equiv.lean`, `CompPoly/Multilinear/Semantics.lean` |
 | Bivariate | `CBivariate R` | Specialized two-variable APIs and `R[X][Y]` transport | `CompPoly/Bivariate/README.md`, `CompPoly/Bivariate/Basic.lean`, `CompPoly/Bivariate/ToPoly.lean`, `CompPoly/ToMathlib/Polynomial/BivariateDegree.lean`, `CompPoly/ToMathlib/Polynomial/BivariateWeightedDegree.lean`, `CompPoly/ToMathlib/Polynomial/BivariateMultiplicity.lean` |
 
 ## Univariate Family
@@ -87,6 +87,15 @@ It already has two distinct computable forms:
 These are both represented as vectors of length `2 ^ n`, with little-endian indexing.
 That design is described directly in
 [`../../CompPoly/Multilinear/Basic.lean`](../../CompPoly/Multilinear/Basic.lean).
+
+[`../../CompPoly/Multilinear/Semantics.lean`](../../CompPoly/Multilinear/Semantics.lean)
+defines explicit little-endian and big-endian Boolean-cube points and proves the reversal theorem
+between CompPoly evaluation and big-endian multilinear evaluation. Consumers must choose a
+coordinate convention explicitly; the two orders are never identified definitionally.
+
+[`../../CompPoly/Multilinear/Next.lean`](../../CompPoly/Multilinear/Next.lean) defines the
+terminal-successor relation, its closed carry-chain form, shifted evaluation tables, and the shift
+identity in the documented big-endian coordinates.
 
 Use this area for:
 


### PR DESCRIPTION
Formalizes a kernel-checked degree-five KoalaBear extension, arbitrary-commutative-ring evaluation bridges, explicit Boolean-cube endianness, and terminal-successor multilinear shift semantics in Lean 4.

No CompPoly formalization remains incomplete; ArkLib still needs to update its pinned CompPoly revision and Lean toolchain before consuming these APIs.

Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>