### PR TITLE
feat(ReedSolomon): decoder refusal as a farness certificate for Gao decoding

### DIFF
--- a/CompPoly/Univariate/ReedSolomon/GaoCorrectness.lean
+++ b/CompPoly/Univariate/ReedSolomon/GaoCorrectness.lean
@@ -297,6 +297,19 @@ theorem decode_eq_some [Field F]
   show (if G.mod V == 0 then if (G / V).degree < k then some (G / V) else none else none) = _
   rw [if_pos (beq_iff_eq.mpr hmod0), if_pos (hdiveq ▸ messagePoly_degree_lt msg), hdiveq]
 
+/-- **Decoder refusal is a farness certificate**: if the decoder returns `none`, the
+received word is beyond the guaranteed radius `⌊(n-k)/2⌋` of *every* codeword — positive,
+polynomial-time-checkable evidence of farness from the code (the contrapositive of
+`decode_eq_some`). -/
+theorem decode_none_farness [Field F]
+    (k : ℕ) (D : Domain F) (r : Vector F D.n) (hkn : k < D.n)
+    (hnone : Gao.decode k D r = none) :
+    ∀ msg : Vector F k, D.n - k < 2 * hammingDist r.get (encode D msg).get := by
+  intro msg
+  by_contra hle
+  rw [Gao.decode_eq_some k D r hkn msg (Nat.le_of_not_lt hle)] at hnone
+  exact Option.some_ne_none _ hnone
+
 /-- Uniqueness: within the guaranteed-decoding radius `⌊(D.n-k)/2⌋`, two messages
 whose codewords lie within that radius of `r` decode to the same polynomial. -/
 theorem decode_unique [Field F] (k : ℕ) (D : Domain F) (r : Vector F D.n)


### PR DESCRIPTION
## Summary

One theorem, added to `GaoCorrectness.lean` beside the completeness/failure pair: **`decode_none_farness`** — if `Gao.decode` returns `none`, the received word is beyond the guaranteed radius `⌊(n-k)/2⌋` of **every** codeword:

```
Gao.decode k D r = none → ∀ msg, D.n - k < 2 * hammingDist r.get (encode D msg).get
```

It is the contrapositive of `decode_eq_some`, completing the square of decode-outcome characterizations (`decode_sound` / `decode_eq_none` already give the other diagonal): a decoder *refusal* is now positive, `O(n²)`-checkable evidence of proximity-gap-style farness from the code — the certificate shape proximity testing wants, produced by machinery the library already trusts.

`#print axioms`: `[propext, Classical.choice, Quot.sound]`.

## Validation performed (not in the diff)

Full `lake build CompPoly` green (2516 jobs, warning-free). Concrete check over `ZMod 17`, RS(8, 4), radius 2: the honest codeword `#[10,15,7,13,15,11,6,16]` decodes to `some #[1,2,3,4]` (its exact message), and a 3-position corruption of it decodes to `none` — on which the theorem certifies farness from the entire code.

Complements #266 (certified NTT encoder): together, fast-encode lands provably *in* the code and decoder-refusal provably certifies *far from* the code.

---

*Contributed by The Institute for Ontological Mathematics (IAOM) / Equation Capital dba Apoth3osis.*