### PR TITLE
feat(fields): computable binomial field extensions with a general Rabin irreducibility criterion

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -33,7 +33,9 @@ env:
     guruswami-sudan-root-koalabear,
     guruswami-sudan-core-small-koalabear,
     guruswami-sudan-filtered-core-small-koalabear,
-    additive-ntt-btf3-l2-r2,additive-ntt-btf3-l4-r2,additive-ntt-btf4-l7-r2
+    additive-ntt-btf3-l2-r2,additive-ntt-btf3-l4-r2,additive-ntt-btf4-l7-r2,
+    fields-extension-koalabear-ext4-mul,fields-extension-koalabear-ext4-inv,
+    fields-extension-babybear-ext4-mul,fields-extension-babybear-ext4-inv
 
 jobs:
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,9 @@ Human contributors should usually start with [`README.md`](README.md),
   multilinear polynomials.
 - `CompPoly/Bivariate/` - specialized bivariate layer built from nested
   univariate polynomials.
-- `CompPoly/Fields/` - concrete field instances plus binary-field, GHASH, and
-  additive-NTT infrastructure.
+- `CompPoly/Fields/` - concrete field instances plus the binomial field-extension
+  framework (`Fields/Extension/`) and binary-field, GHASH, and additive-NTT
+  infrastructure.
 - `CompPoly/Data/` - reusable supporting lemmas and helper definitions.
 - `CompPoly/ToMathlib/` - local bridge lemmas and Mathlib-facing support code.
 - `tests/` - regression coverage under the `CompPolyTests` namespace.
@@ -58,6 +59,8 @@ Human contributors should usually start with [`README.md`](README.md),
   minimal typeclass assumptions and no-blanket-scope guidance.
 - [`docs/wiki/binary-fields-and-ntt.md`](docs/wiki/binary-fields-and-ntt.md) -
   binary-field stack, GHASH, and additive NTT.
+- [`docs/wiki/field-extensions.md`](docs/wiki/field-extensions.md) - computable
+  binomial field extensions and their irreducibility criterion.
 
 ## Canonical Project Docs
 

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -101,6 +101,7 @@ import CompPoly.Fields.Binary.Tower.Support.IrreducibilityAndTraceMapProperty
 import CompPoly.Fields.Binary.Tower.Support.LinearIndependentFin2
 import CompPoly.Fields.Binary.Tower.Support.Preliminaries
 import CompPoly.Fields.Binary.Tower.TensorAlgebra
+import CompPoly.Fields.Extension.Binomial
 import CompPoly.Fields.Goldilocks
 import CompPoly.Fields.KoalaBear
 import CompPoly.Fields.KoalaBear.Basic

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -101,12 +101,15 @@ import CompPoly.Fields.Binary.Tower.Support.IrreducibilityAndTraceMapProperty
 import CompPoly.Fields.Binary.Tower.Support.LinearIndependentFin2
 import CompPoly.Fields.Binary.Tower.Support.Preliminaries
 import CompPoly.Fields.Binary.Tower.TensorAlgebra
+import CompPoly.Fields.Extension
 import CompPoly.Fields.Extension.Binomial
 import CompPoly.Fields.Extension.Bridge
 import CompPoly.Fields.Extension.Defs
+import CompPoly.Fields.Extension.Field
 import CompPoly.Fields.Goldilocks
 import CompPoly.Fields.KoalaBear
 import CompPoly.Fields.KoalaBear.Basic
+import CompPoly.Fields.KoalaBear.Ext4
 import CompPoly.Fields.KoalaBear.Fast
 import CompPoly.Fields.Mersenne
 import CompPoly.Fields.Montgomery.Basic

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -68,6 +68,7 @@ import CompPoly.Fields.BLS12_381
 import CompPoly.Fields.BN254
 import CompPoly.Fields.BabyBear
 import CompPoly.Fields.BabyBear.Basic
+import CompPoly.Fields.BabyBear.Ext4
 import CompPoly.Fields.BabyBear.Fast
 import CompPoly.Fields.Basic
 import CompPoly.Fields.Binary.AdditiveNTT.AdditiveNTT
@@ -107,6 +108,8 @@ import CompPoly.Fields.Extension.Bridge
 import CompPoly.Fields.Extension.Defs
 import CompPoly.Fields.Extension.Field
 import CompPoly.Fields.Goldilocks
+import CompPoly.Fields.Hachi
+import CompPoly.Fields.Hachi.Ext4
 import CompPoly.Fields.KoalaBear
 import CompPoly.Fields.KoalaBear.Basic
 import CompPoly.Fields.KoalaBear.Ext4

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -59,6 +59,7 @@ import CompPoly.Data.MvPolynomial.Notation
 import CompPoly.Data.Nat.Bitwise
 import CompPoly.Data.Polynomial.Frobenius
 import CompPoly.Data.Polynomial.MonomialBasis
+import CompPoly.Data.Polynomial.Rabin
 import CompPoly.Data.RingTheory.AlgebraTower
 import CompPoly.Data.RingTheory.CanonicalEuclideanDomain
 import CompPoly.Data.Vector.Basic
@@ -167,6 +168,7 @@ import CompPoly.ToMathlib.Polynomial.BivariateEvaluation
 import CompPoly.ToMathlib.Polynomial.BivariateMultiplicity
 import CompPoly.ToMathlib.Polynomial.BivariateWeightedDegree
 import CompPoly.ToMathlib.Polynomial.Div
+import CompPoly.ToMathlib.Polynomial.Irreducible
 import CompPoly.ToMathlib.Polynomial.Roots
 import CompPoly.Univariate.Barycentric
 import CompPoly.Univariate.Basic

--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -102,6 +102,8 @@ import CompPoly.Fields.Binary.Tower.Support.LinearIndependentFin2
 import CompPoly.Fields.Binary.Tower.Support.Preliminaries
 import CompPoly.Fields.Binary.Tower.TensorAlgebra
 import CompPoly.Fields.Extension.Binomial
+import CompPoly.Fields.Extension.Bridge
+import CompPoly.Fields.Extension.Defs
 import CompPoly.Fields.Goldilocks
 import CompPoly.Fields.KoalaBear
 import CompPoly.Fields.KoalaBear.Basic

--- a/CompPoly/Data/Polynomial/Rabin.lean
+++ b/CompPoly/Data/Polynomial/Rabin.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Data.Polynomial.Frobenius
+import CompPoly.ToMathlib.Polynomial.Irreducible
+import Mathlib.RingTheory.PrincipalIdealDomain
+
+/-!
+# Rabin's irreducibility test
+
+A polynomial `f` of degree `d` over a finite field `F` with `q = |F|` elements is irreducible
+exactly when
+
+* `f ∣ X^(q^d) - X`, and
+* `f` is coprime to `X^(q^(d/ℓ)) - X` for every prime `ℓ ∣ d`.
+
+The first condition says every irreducible factor of `f` has degree dividing `d`; the second
+rules out all *proper* divisors of `d` as factor degrees, forcing `f` itself to be irreducible.
+Both rest on the fundamental correspondence
+`Polynomial.irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd` from
+`CompPoly/Data/Polynomial/Frobenius.lean`.
+
+This generalizes `irreducible_of_rabin_128_passed_over_GF2`
+(`CompPoly/Fields/Binary/BF128Ghash/Basic.lean`), which is the `d = 128`, `F = GF(2)`
+specialization, to arbitrary degree over any finite field.
+
+## Main statements
+
+* `Polynomial.irreducible_of_rabin`: the two conditions imply irreducibility.
+* `Polynomial.rabin_of_irreducible`: the converse, so the test is exact.
+* `Polynomial.irreducible_iff_rabin`: the resulting characterization.
+
+## References
+
+* [Rabin80] Michael O. Rabin, *Probabilistic Algorithms in Finite Fields*,
+  SIAM Journal on Computing 9(2), 1980.
+-/
+
+namespace Nat
+
+/--
+If `m` is a proper divisor of a nonzero `d`, then `m` divides `d / ℓ` for some prime factor `ℓ`
+of `d`.
+
+This is the arithmetic core of Rabin's test: it is why checking the prime-index quotients
+`d / ℓ` suffices to rule out *every* proper divisor of `d`.
+-/
+theorem exists_primeFactor_dvd_div_of_dvd {m d : ℕ} (hd : d ≠ 0) (hmd : m ∣ d) (hne : m ≠ d) :
+    ∃ ℓ ∈ d.primeFactors, m ∣ d / ℓ := by
+  obtain ⟨k, hk⟩ := hmd
+  have hk0 : k ≠ 0 := by rintro rfl; exact hd (by simpa using hk)
+  have hk1 : k ≠ 1 := by rintro rfl; exact hne (by simpa using hk.symm)
+  -- Generalize away from `minFac` so rewriting `k` cannot disturb the chosen prime.
+  obtain ⟨ℓ, hℓp, hℓ_dvd_k⟩ : ∃ ℓ, ℓ.Prime ∧ ℓ ∣ k :=
+    ⟨k.minFac, Nat.minFac_prime hk1, Nat.minFac_dvd k⟩
+  obtain ⟨k', hk'⟩ := hℓ_dvd_k
+  have hd_eq : d = ℓ * (m * k') := by rw [hk, hk']; ring
+  refine ⟨ℓ, Nat.mem_primeFactors.mpr ⟨hℓp, ?_, hd⟩, ?_⟩
+  · exact ⟨m * k', hd_eq⟩
+  · rw [hd_eq, Nat.mul_div_cancel_left _ hℓp.pos]
+    exact dvd_mul_right m k'
+
+end Nat
+
+namespace Polynomial
+
+/-- The characteristic of a finite field is prime. Supplies the `Fact` instance required by
+`Polynomial.irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd`. -/
+instance instFactPrimeRingChar (F : Type*) [Field F] [Finite F] :
+    Fact (Nat.Prime (ringChar F)) :=
+  ⟨CharP.prime_ringChar F⟩
+
+variable {F : Type*} [Field F] [Fintype F]
+
+/--
+**Rabin's irreducibility test (soundness).**
+
+If a degree-`d` polynomial `f` over a finite field divides `X^(q^d) - X` and is coprime to
+`X^(q^(d/ℓ)) - X` for every prime `ℓ ∣ d`, then `f` is irreducible.
+-/
+theorem irreducible_of_rabin {f : F[X]} {d : ℕ}
+    (h_deg : f.natDegree = d) (h_pos : 0 < d)
+    (h_trace : f ∣ X ^ (Fintype.card F ^ d) - X)
+    (h_coprime : ∀ ℓ ∈ d.primeFactors,
+      IsCoprime f (X ^ (Fintype.card F ^ (d / ℓ)) - X)) :
+    Irreducible f := by
+  by_contra h_red
+  -- A reducible `f` has an irreducible factor of degree at most `d / 2`.
+  obtain ⟨p, hp_irr, hp_dvd_f, hp_deg⟩ :=
+    exists_factor_natDegree_le_of_reducible f h_deg h_pos h_red
+  -- `p ∣ f ∣ X^(q^d) - X`, so `deg p ∣ d`.
+  have hp_dvd_d : p.natDegree ∣ d :=
+    (irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd d p hp_irr).mp (hp_dvd_f.trans h_trace)
+  -- The bound `deg p ≤ d / 2` makes it a *proper* divisor.
+  have hp_ne : p.natDegree ≠ d := by omega
+  obtain ⟨ℓ, hℓ_mem, hℓ_dvd⟩ :=
+    Nat.exists_primeFactor_dvd_div_of_dvd (by omega) hp_dvd_d hp_ne
+  -- So `p` also divides the `ℓ`-th check polynomial, contradicting coprimality.
+  have hp_dvd_mid : p ∣ X ^ (Fintype.card F ^ (d / ℓ)) - X :=
+    (irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd (d / ℓ) p hp_irr).mpr hℓ_dvd
+  exact hp_irr.not_isUnit ((h_coprime ℓ hℓ_mem).isUnit_of_dvd' hp_dvd_f hp_dvd_mid)
+
+/--
+**Rabin's irreducibility test (completeness).**
+
+An irreducible polynomial of degree `d` satisfies both Rabin conditions.
+-/
+theorem rabin_of_irreducible {f : F[X]} {d : ℕ}
+    (h_deg : f.natDegree = d) (h_pos : 0 < d) (h_irr : Irreducible f) :
+    f ∣ X ^ (Fintype.card F ^ d) - X ∧
+      ∀ ℓ ∈ d.primeFactors, IsCoprime f (X ^ (Fintype.card F ^ (d / ℓ)) - X) := by
+  refine ⟨(irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd d f h_irr).mpr (h_deg ▸ dvd_rfl),
+    fun ℓ hℓ => ?_⟩
+  -- For irreducible `f`, coprimality is exactly non-divisibility.
+  rw [h_irr.coprime_iff_not_dvd, irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd (d / ℓ) f h_irr,
+    h_deg]
+  -- `d ∤ d / ℓ` because `d / ℓ` is a positive proper divisor of `d`.
+  obtain ⟨hℓ_prime, hℓ_dvd, -⟩ := Nat.mem_primeFactors.mp hℓ
+  intro h_dvd
+  have h_le : d ≤ d / ℓ := Nat.le_of_dvd (Nat.div_pos (Nat.le_of_dvd h_pos hℓ_dvd) hℓ_prime.pos)
+    h_dvd
+  have h_lt : d / ℓ < d := Nat.div_lt_self h_pos hℓ_prime.one_lt
+  omega
+
+/-- **Rabin's irreducibility test.** For a polynomial of positive degree `d` over a finite
+field, irreducibility is equivalent to the two Rabin conditions. -/
+theorem irreducible_iff_rabin {f : F[X]} {d : ℕ}
+    (h_deg : f.natDegree = d) (h_pos : 0 < d) :
+    Irreducible f ↔
+      (f ∣ X ^ (Fintype.card F ^ d) - X ∧
+        ∀ ℓ ∈ d.primeFactors, IsCoprime f (X ^ (Fintype.card F ^ (d / ℓ)) - X)) :=
+  ⟨rabin_of_irreducible h_deg h_pos,
+    fun ⟨h₁, h₂⟩ => irreducible_of_rabin h_deg h_pos h₁ h₂⟩
+
+end Polynomial

--- a/CompPoly/Data/Polynomial/Rabin.lean
+++ b/CompPoly/Data/Polynomial/Rabin.lean
@@ -66,13 +66,17 @@ end Nat
 
 namespace Polynomial
 
-/-- The characteristic of a finite field is prime. Supplies the `Fact` instance required by
-`Polynomial.irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd`. -/
-instance instFactPrimeRingChar (F : Type*) [Field F] [Finite F] :
-    Fact (Nat.Prime (ringChar F)) :=
-  ⟨CharP.prime_ringChar F⟩
-
 variable {F : Type*} [Field F] [Fintype F]
+
+/--
+The `Fact` instance required by `irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd`.
+
+Deliberately *not* a global instance: it would apply to every finite field, and a blanket
+`Fact` in the instance graph is easy to trip over later. The two proofs below introduce it
+locally with `haveI` instead, so it never escapes this file and appears in no statement.
+-/
+private theorem factPrimeRingChar : Fact (Nat.Prime (ringChar F)) :=
+  ⟨CharP.prime_ringChar F⟩
 
 /--
 **Rabin's irreducibility test (soundness).**
@@ -86,6 +90,7 @@ theorem irreducible_of_rabin {f : F[X]} {d : ℕ}
     (h_coprime : ∀ ℓ ∈ d.primeFactors,
       IsCoprime f (X ^ (Fintype.card F ^ (d / ℓ)) - X)) :
     Irreducible f := by
+  haveI := factPrimeRingChar (F := F)
   by_contra h_red
   -- A reducible `f` has an irreducible factor of degree at most `d / 2`.
   obtain ⟨p, hp_irr, hp_dvd_f, hp_deg⟩ :=
@@ -111,6 +116,7 @@ theorem rabin_of_irreducible {f : F[X]} {d : ℕ}
     (h_deg : f.natDegree = d) (h_pos : 0 < d) (h_irr : Irreducible f) :
     f ∣ X ^ (Fintype.card F ^ d) - X ∧
       ∀ ℓ ∈ d.primeFactors, IsCoprime f (X ^ (Fintype.card F ^ (d / ℓ)) - X) := by
+  haveI := factPrimeRingChar (F := F)
   refine ⟨(irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd d f h_irr).mpr (h_deg ▸ dvd_rfl),
     fun ℓ hℓ => ?_⟩
   -- For irreducible `f`, coprimality is exactly non-divisibility.

--- a/CompPoly/Fields/BabyBear/Ext4.lean
+++ b/CompPoly/Fields/BabyBear/Ext4.lean
@@ -27,6 +27,17 @@ namespace BabyBear
 
 open CompPoly.Extension Polynomial
 
+/--
+The base-field cardinality as a bare numeral.
+
+`reduce_mod_char` reads the modulus syntactically, so the irreducibility proof below needs a
+numeral rather than the expression `fieldSize`. `qNum_eq` pins this second spelling to the first,
+so the two cannot drift apart silently.
+-/
+private abbrev qNum : ℕ := 2013265921
+
+private theorem qNum_eq : qNum = fieldSize := by norm_num
+
 /-- The parameters of the quartic extension `BabyBear[X] / (X^4 - 11)`. -/
 def ext4Params : BinomialParams Field where
   d := 4
@@ -42,11 +53,11 @@ def ext4Params : BinomialParams Field where
 /-- `X^4 - 11` is irreducible over BabyBear, by the collapsed Rabin criterion. -/
 theorem ext4Params_poly_irreducible : Irreducible ext4Params.poly := by
   rw [BinomialParams.poly]
-  refine irreducible_X_pow_four_sub_C_of_card (q := 2013265921) (ZMod.card _) (by decide)
+  refine irreducible_X_pow_four_sub_C_of_card (q := qNum) (ZMod.card _) (by decide)
     (by norm_num) (by norm_num) ?_ ?_
-  · show (11 : ZMod 2013265921) ^ ((2013265921 ^ 4 - 1) / 4) = 1
+  · show (11 : ZMod qNum) ^ ((qNum ^ 4 - 1) / 4) = 1
     reduce_mod_char
-  · show (11 : ZMod 2013265921) ^ ((2013265921 ^ 2 - 1) / 4) ≠ 1
+  · show (11 : ZMod qNum) ^ ((qNum ^ 2 - 1) / 4) ≠ 1
     reduce_mod_char
     decide
 
@@ -56,7 +67,13 @@ instance : Fact (Irreducible ext4Params.poly) := ⟨ext4Params_poly_irreducible�
 abbrev Ext4 : Type := CompPoly.Extension.Ext ext4Params
 
 /-- The adjoined fourth root of `11`, as an element of `Ext4`. -/
-def ext4Gen : Ext4 := Ext.ofFn fun i => if (i : ℕ) = 1 then 1 else 0
+def ext4Gen : Ext4 := Ext.gen
+
+/-- **The defining relation**, as a theorem rather than only an executable check. -/
+@[simp] theorem ext4Gen_pow_four : ext4Gen ^ 4 = Ext.ofBase (11 : Field) := Ext.gen_pow_d
+
+/-- `ext4Gen` is a root of `X^4 - 11`, in the form `aeval` expects. -/
+theorem aeval_ext4Gen : aeval ext4Gen ext4Params.poly = 0 := Ext.aeval_gen_poly
 
 @[simp] theorem card_ext4 : Fintype.card Ext4 = fieldSize ^ 4 := Ext.card_ext
 

--- a/CompPoly/Fields/BabyBear/Ext4.lean
+++ b/CompPoly/Fields/BabyBear/Ext4.lean
@@ -69,6 +69,19 @@ abbrev Ext4 : Type := CompPoly.Extension.Ext ext4Params
 /-- The adjoined fourth root of `11`, as an element of `Ext4`. -/
 def ext4Gen : Ext4 := Ext.gen
 
+/--
+`ext4Gen` is the framework's `Ext.gen`.
+
+Deliberately **not** `@[simp]`: as a rewrite it fires before `ext4Gen_pow_four` can match, which
+would knock that lemma out of the simp set. Use `simp [ext4Gen_eq_gen]` to reach the general
+`Ext.gen` lemmas (`Ext.coeff_gen`, `Ext.gen_pow_d`) when the specialized ones below are not
+enough.
+-/
+theorem ext4Gen_eq_gen : ext4Gen = Ext.gen := rfl
+
+/-- `ext4Gen` maps to the adjoined root of the specification. -/
+@[simp] theorem toQuot_ext4Gen : Ext.toQuot ext4Gen = Ext.rt ext4Params := Ext.toQuot_gen
+
 /-- **The defining relation**, as a theorem rather than only an executable check. -/
 @[simp] theorem ext4Gen_pow_four : ext4Gen ^ 4 = Ext.ofBase (11 : Field) := Ext.gen_pow_d
 

--- a/CompPoly/Fields/BabyBear/Ext4.lean
+++ b/CompPoly/Fields/BabyBear/Ext4.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.Extension
+import CompPoly.Fields.BabyBear.Basic
+import Mathlib.Tactic.ReduceModChar
+
+/-!
+# The degree-4 extension of BabyBear
+
+`BabyBear[X] / (X^4 - 11)`, the challenge field used alongside the BabyBear base field in
+RISC Zero and Plonky3.
+
+Irreducibility of `X^4 - 11` is discharged by
+`Polynomial.irreducible_X_pow_four_sub_C_of_card`, whose two hypotheses are single
+exponentiations in the base field: `11^((p^4-1)/4) = 1` and `11^((p^2-1)/4) ≠ 1`.
+
+## Main definitions
+
+* `BabyBear.ext4Params`: the `BinomialParams` for `X^4 - 11`.
+* `BabyBear.Ext4`: the extension field itself.
+-/
+
+namespace BabyBear
+
+open CompPoly.Extension Polynomial
+
+/-- The parameters of the quartic extension `BabyBear[X] / (X^4 - 11)`. -/
+def ext4Params : BinomialParams Field where
+  d := 4
+  W := 11
+  two_le := by norm_num
+  q := fieldSize
+  card_eq := ZMod.card _
+
+@[simp] theorem ext4Params_d : ext4Params.d = 4 := rfl
+@[simp] theorem ext4Params_W : ext4Params.W = 11 := rfl
+@[simp] theorem ext4Params_q : ext4Params.q = fieldSize := rfl
+
+/-- `X^4 - 11` is irreducible over BabyBear, by the collapsed Rabin criterion. -/
+theorem ext4Params_poly_irreducible : Irreducible ext4Params.poly := by
+  rw [BinomialParams.poly]
+  refine irreducible_X_pow_four_sub_C_of_card (q := 2013265921) (ZMod.card _) (by decide)
+    (by norm_num) (by norm_num) ?_ ?_
+  · show (11 : ZMod 2013265921) ^ ((2013265921 ^ 4 - 1) / 4) = 1
+    reduce_mod_char
+  · show (11 : ZMod 2013265921) ^ ((2013265921 ^ 2 - 1) / 4) ≠ 1
+    reduce_mod_char
+    decide
+
+instance : Fact (Irreducible ext4Params.poly) := ⟨ext4Params_poly_irreducible⟩
+
+/-- The degree-4 extension field of BabyBear. -/
+abbrev Ext4 : Type := CompPoly.Extension.Ext ext4Params
+
+/-- The adjoined fourth root of `11`, as an element of `Ext4`. -/
+def ext4Gen : Ext4 := Ext.ofFn fun i => if (i : ℕ) = 1 then 1 else 0
+
+@[simp] theorem card_ext4 : Fintype.card Ext4 = fieldSize ^ 4 := Ext.card_ext
+
+end BabyBear

--- a/CompPoly/Fields/Extension.lean
+++ b/CompPoly/Fields/Extension.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.Extension.Binomial
+import CompPoly.Fields.Extension.Bridge
+import CompPoly.Fields.Extension.Defs
+import CompPoly.Fields.Extension.Field
+
+/-!
+# Computable field extensions
+
+Facade for the binomial field-extension stack. See the individual modules for details:
+
+* `CompPoly/Fields/Extension/Binomial.lean` — irreducibility of `X^d - W` over a finite field,
+  via Rabin's test collapsed to two base-field exponentiations.
+* `CompPoly/Fields/Extension/Defs.lean` — `BinomialParams` and the coefficient-vector carrier
+  `Ext P` with its ring operations.
+* `CompPoly/Fields/Extension/Bridge.lean` — `toQuot : Ext P → AdjoinRoot P.poly` and the
+  `CommRing` structure.
+* `CompPoly/Fields/Extension/Field.lean` — bijectivity, cardinality, and the `Field` structure.
+-/

--- a/CompPoly/Fields/Extension/Binomial.lean
+++ b/CompPoly/Fields/Extension/Binomial.lean
@@ -177,26 +177,37 @@ private theorem primeFactors_four : (4 : ℕ).primeFactors = {2} := by
 /--
 **Irreducibility criterion for quartic binomials.**
 
-`X^4 - W` is irreducible over a finite field with `q` elements as soon as
+`X^4 - W` is irreducible over a finite field with `q` elements exactly when
 `W^((q^4 - 1)/4) = 1` and `W^((q^2 - 1)/4) ≠ 1`.
 
 This is the shape used by the BabyBear, KoalaBear and Hachi degree-4 extensions. It differs
 from `irreducible_X_pow_sub_C_iff` only in discharging `Nat.primeFactors 4 = {2}` internally,
 so callers never touch `Nat.primeFactors`.
+
+Being an `iff`, a *failed* check proves reducibility rather than merely failing to prove
+irreducibility.
 -/
+theorem irreducible_X_pow_four_sub_C_iff {W : F} (hW0 : W ≠ 0)
+    (h_top : 4 ∣ Fintype.card F ^ 4 - 1)
+    (h_mid : 4 ∣ Fintype.card F ^ 2 - 1) :
+    Irreducible ((X : F[X]) ^ 4 - C W) ↔
+      (W ^ ((Fintype.card F ^ 4 - 1) / 4) = 1 ∧
+        W ^ ((Fintype.card F ^ 2 - 1) / 4) ≠ 1) := by
+  have hmid' : ∀ ℓ ∈ (4 : ℕ).primeFactors, 4 ∣ Fintype.card F ^ (4 / ℓ) - 1 := by
+    simp only [primeFactors_four, Finset.mem_singleton]
+    rintro ℓ rfl
+    simpa using h_mid
+  rw [irreducible_X_pow_sub_C_iff (by norm_num) hW0 h_top hmid']
+  simp only [primeFactors_four, Finset.mem_singleton, forall_eq]
+
+/-- The `mpr` direction of `irreducible_X_pow_four_sub_C_iff`, as a standalone lemma. -/
 theorem irreducible_X_pow_four_sub_C {W : F} (hW0 : W ≠ 0)
     (h_top : 4 ∣ Fintype.card F ^ 4 - 1)
     (h_mid : 4 ∣ Fintype.card F ^ 2 - 1)
     (rabin_top : W ^ ((Fintype.card F ^ 4 - 1) / 4) = 1)
     (rabin_mid : W ^ ((Fintype.card F ^ 2 - 1) / 4) ≠ 1) :
-    Irreducible ((X : F[X]) ^ 4 - C W) := by
-  refine (irreducible_X_pow_sub_C_iff (by norm_num) hW0 h_top ?_).mpr ⟨rabin_top, ?_⟩
-  · simp only [primeFactors_four, Finset.mem_singleton]
-    rintro ℓ rfl
-    simpa using h_mid
-  · simp only [primeFactors_four, Finset.mem_singleton]
-    rintro ℓ rfl
-    simpa using rabin_mid
+    Irreducible ((X : F[X]) ^ 4 - C W) :=
+  (irreducible_X_pow_four_sub_C_iff hW0 h_top h_mid).mpr ⟨rabin_top, rabin_mid⟩
 
 /--
 `irreducible_X_pow_four_sub_C` with the cardinality abstracted into a numeral `q`.
@@ -218,5 +229,14 @@ theorem irreducible_X_pow_four_sub_C_of_card {q : ℕ} {W : F}
     Irreducible ((X : F[X]) ^ 4 - C W) := by
   subst hcard
   exact irreducible_X_pow_four_sub_C hW0 h_top h_mid rabin_top rabin_mid
+
+/-- `irreducible_X_pow_four_sub_C_iff` with the cardinality abstracted into a numeral `q`. -/
+theorem irreducible_X_pow_four_sub_C_iff_of_card {q : ℕ} {W : F}
+    (hcard : Fintype.card F = q) (hW0 : W ≠ 0)
+    (h_top : 4 ∣ q ^ 4 - 1) (h_mid : 4 ∣ q ^ 2 - 1) :
+    Irreducible ((X : F[X]) ^ 4 - C W) ↔
+      (W ^ ((q ^ 4 - 1) / 4) = 1 ∧ W ^ ((q ^ 2 - 1) / 4) ≠ 1) := by
+  subst hcard
+  exact irreducible_X_pow_four_sub_C_iff hW0 h_top h_mid
 
 end Polynomial

--- a/CompPoly/Fields/Extension/Binomial.lean
+++ b/CompPoly/Fields/Extension/Binomial.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Data.Polynomial.Rabin
+
+/-!
+# Irreducibility of binomials `X^d - W` over a finite field
+
+Applying Rabin's test (`CompPoly/Data/Polynomial/Rabin.lean`) to a *binomial* defining
+polynomial collapses both conditions into single exponentiations **in the base field**.
+
+The reason is that `X^d ≡ W`, so whenever `d ∣ N - 1`, writing `k = (N-1)/d`,
+
+`X^N - X = X * (X^(d*k) - 1)`  and  `X^(d*k) ≡ W^k  (mod X^d - W)`.
+
+Hence `X^d - W` divides `X^N - X` exactly when `W^k = 1`, and is coprime to it exactly when
+`W^k ≠ 1`: the residue is then `X * C (W^k - 1)`, a unit multiple of `X`, and `X` does not
+divide `X^d - W` because `W ≠ 0`.
+
+Instantiating at `N = q^d` and `N = q^(d/ℓ)` turns Rabin's test into
+`irreducible_X_pow_sub_C_iff`, whose conditions are two base-field exponentiations. Contrast
+the ~2100 lines of hand-generated `BitVec` step certificates in
+`CompPoly/Fields/Binary/BF128Ghash/XPowTwoPow{Mod,Gcd}Certificate.lean`, which is what the
+same test costs when the defining polynomial is not a binomial.
+
+## Main statements
+
+* `Polynomial.X_pow_sub_C_dvd_X_pow_sub_X` / `Polynomial.isCoprime_X_pow_sub_C_X_pow_sub_X`:
+  the two collapsed Rabin conditions, and their converses.
+* `Polynomial.irreducible_X_pow_sub_C_iff`: the criterion for general `d`.
+* `Polynomial.irreducible_X_pow_four_sub_C`: the `d = 4` corollary, which discharges
+  `Nat.primeFactors` internally. This is the degree used by BabyBear, KoalaBear and Hachi
+  extension fields.
+
+## References
+
+* [Rabin80] Michael O. Rabin, *Probabilistic Algorithms in Finite Fields*,
+  SIAM Journal on Computing 9(2), 1980.
+* [LN97] Rudolf Lidl and Harald Niederreiter, *Finite Fields*, 2nd ed., Theorem 3.75.
+-/
+
+namespace Polynomial
+
+variable {F : Type*} [Field F]
+
+/-! ### Reducing powers of `X` modulo a binomial -/
+
+/--
+`X^d - C W` divides `X^(d * k) - C (W ^ k)`.
+
+This is the algebraic content of "substituting `X^d = W`": apply `a - b ∣ a^k - b^k` with
+`a = X^d` and `b = C W`.
+-/
+theorem X_pow_sub_C_dvd_X_pow_mul_sub_C_pow (W : F) (d k : ℕ) :
+    (X ^ d - C W) ∣ X ^ (d * k) - C (W ^ k) := by
+  rw [pow_mul, map_pow]
+  exact sub_dvd_pow_sub_pow _ _ k
+
+/-- Splitting `X^N - X` as `X * (X^(N-1) - 1)`, in the form needed below. -/
+private theorem X_pow_sub_X_eq {d k N : ℕ} (hN : d * k + 1 = N) :
+    (X : F[X]) ^ N - X = X * (X ^ (d * k) - 1) := by
+  rw [← hN]; ring
+
+/-- `(N - 1) / d = k` given `N - 1 = d * k` and `0 < d`. -/
+private theorem div_eq_of_sub_one_eq {d k N : ℕ} (hd : 0 < d) (hk : N - 1 = d * k) :
+    (N - 1) / d = k := by
+  rw [hk, Nat.mul_div_cancel_left k hd]
+
+/-- A binomial `X^d - C W` of positive degree is never a unit. -/
+private theorem not_isUnit_X_pow_sub_C (W : F) {d : ℕ} (hd : 0 < d) :
+    ¬ IsUnit ((X : F[X]) ^ d - C W) :=
+  not_isUnit_of_natDegree_pos _ (by rw [natDegree_X_pow_sub_C]; omega)
+
+/-- `X` does not divide `X^d - C W` when `W ≠ 0`: the constant coefficient is `-W`. -/
+theorem not_X_dvd_X_pow_sub_C {W : F} {d : ℕ} (hd : 0 < d) (hW : W ≠ 0) :
+    ¬ (X : F[X]) ∣ X ^ d - C W := by
+  rw [X_dvd_iff, coeff_sub, coeff_X_pow, coeff_C_zero, if_neg (by omega), zero_sub, neg_eq_zero]
+  exact hW
+
+/-! ### The two collapsed Rabin conditions -/
+
+/--
+**Rabin condition 1, collapsed.** If `d ∣ N - 1` and `W ^ ((N-1)/d) = 1`, then
+`X^d - C W` divides `X^N - X`.
+-/
+theorem X_pow_sub_C_dvd_X_pow_sub_X {W : F} {d N : ℕ} (hd : 0 < d) (hN : 1 ≤ N)
+    (hdvd : d ∣ N - 1) (hW : W ^ ((N - 1) / d) = 1) :
+    (X ^ d - C W) ∣ X ^ N - X := by
+  obtain ⟨k, hk⟩ := hdvd
+  rw [div_eq_of_sub_one_eq hd hk] at hW
+  rw [X_pow_sub_X_eq (d := d) (k := k) (by omega)]
+  refine Dvd.dvd.mul_left ?_ X
+  have h := X_pow_sub_C_dvd_X_pow_mul_sub_C_pow W d k
+  rwa [hW, map_one] at h
+
+/--
+**Rabin condition 2, collapsed.** If `d ∣ N - 1`, `W ≠ 0` and `W ^ ((N-1)/d) ≠ 1`, then
+`X^d - C W` is coprime to `X^N - X`.
+
+Modulo `X^d - C W` the polynomial `X^N - X` reduces to `X * C (W^k - 1)`, a unit multiple of
+`X`, and `X` is coprime to `X^d - C W` by `not_X_dvd_X_pow_sub_C`.
+-/
+theorem isCoprime_X_pow_sub_C_X_pow_sub_X {W : F} {d N : ℕ} (hd : 0 < d) (hW0 : W ≠ 0)
+    (hN : 1 ≤ N) (hdvd : d ∣ N - 1) (hW : W ^ ((N - 1) / d) ≠ 1) :
+    IsCoprime (X ^ d - C W) (X ^ N - X) := by
+  obtain ⟨k, hk⟩ := hdvd
+  rw [div_eq_of_sub_one_eq hd hk] at hW
+  obtain ⟨t, ht⟩ := X_pow_sub_C_dvd_X_pow_mul_sub_C_pow W d k
+  -- Rewrite `X^N - X` as `X * C (W^k - 1)` plus a multiple of `X^d - C W`.
+  have hsplit : (X : F[X]) ^ N - X = X * C (W ^ k - 1) + (X ^ d - C W) * (X * t) := by
+    rw [X_pow_sub_X_eq (d := d) (k := k) (by omega)]
+    have hXdk : (X : F[X]) ^ (d * k) = C (W ^ k) + (X ^ d - C W) * t := by rw [← ht]; ring
+    rw [hXdk, map_sub, map_one]; ring
+  rw [hsplit]
+  refine IsCoprime.add_mul_left_right (IsCoprime.mul_right ?_ ?_) (X * t)
+  · exact ((irreducible_X.coprime_iff_not_dvd).mpr (not_X_dvd_X_pow_sub_C hd hW0)).symm
+  · -- A nonzero constant is coprime to everything.
+    refine ⟨0, C (W ^ k - 1)⁻¹, ?_⟩
+    rw [zero_mul, zero_add, ← map_mul, inv_mul_cancel₀ (sub_ne_zero_of_ne hW), map_one]
+
+/-- Converse of `X_pow_sub_C_dvd_X_pow_sub_X`: divisibility forces `W ^ ((N-1)/d) = 1`. -/
+theorem eq_one_of_X_pow_sub_C_dvd_X_pow_sub_X {W : F} {d N : ℕ} (hd : 0 < d) (hW0 : W ≠ 0)
+    (hN : 1 ≤ N) (hdvd : d ∣ N - 1) (h : (X ^ d - C W) ∣ X ^ N - X) :
+    W ^ ((N - 1) / d) = 1 := by
+  by_contra hW
+  exact not_isUnit_X_pow_sub_C W hd
+    ((isCoprime_X_pow_sub_C_X_pow_sub_X hd hW0 hN hdvd hW).isUnit_of_dvd h)
+
+/-- Converse of `isCoprime_X_pow_sub_C_X_pow_sub_X`: coprimality forces `W ^ ((N-1)/d) ≠ 1`. -/
+theorem ne_one_of_isCoprime_X_pow_sub_C_X_pow_sub_X {W : F} {d N : ℕ} (hd : 0 < d) (hN : 1 ≤ N)
+    (hdvd : d ∣ N - 1) (h : IsCoprime ((X : F[X]) ^ d - C W) (X ^ N - X)) :
+    W ^ ((N - 1) / d) ≠ 1 := fun hW =>
+  not_isUnit_X_pow_sub_C W hd (h.isUnit_of_dvd (X_pow_sub_C_dvd_X_pow_sub_X hd hN hdvd hW))
+
+/-! ### The irreducibility criterion -/
+
+variable [Fintype F]
+
+/-- `1 ≤ q ^ n` for `q = |F|`, used to instantiate the collapsed conditions. -/
+private theorem one_le_card_pow (n : ℕ) : 1 ≤ Fintype.card F ^ n :=
+  Nat.one_le_pow _ _ Fintype.card_pos
+
+/--
+**Irreducibility criterion for binomials.**
+
+Over a finite field with `q` elements, `X^d - W` is irreducible if and only if
+`W^((q^d - 1)/d) = 1` and `W^((q^(d/ℓ) - 1)/d) ≠ 1` for every prime `ℓ ∣ d`.
+
+The divisibility side conditions `h_top` and `h_mid` hold in every case of interest — for
+`d = 4` and `q ≡ 1 mod 4`, for instance — and are decidable arithmetic facts about `q` and `d`.
+-/
+theorem irreducible_X_pow_sub_C_iff {d : ℕ} {W : F} (hd : 0 < d) (hW0 : W ≠ 0)
+    (h_top : d ∣ Fintype.card F ^ d - 1)
+    (h_mid : ∀ ℓ ∈ d.primeFactors, d ∣ Fintype.card F ^ (d / ℓ) - 1) :
+    Irreducible ((X : F[X]) ^ d - C W) ↔
+      (W ^ ((Fintype.card F ^ d - 1) / d) = 1 ∧
+        ∀ ℓ ∈ d.primeFactors, W ^ ((Fintype.card F ^ (d / ℓ) - 1) / d) ≠ 1) := by
+  have h_deg : ((X : F[X]) ^ d - C W).natDegree = d := natDegree_X_pow_sub_C
+  constructor
+  · intro h_irr
+    obtain ⟨h₁, h₂⟩ := rabin_of_irreducible h_deg hd h_irr
+    refine ⟨eq_one_of_X_pow_sub_C_dvd_X_pow_sub_X hd hW0 (one_le_card_pow d) h_top h₁,
+      fun ℓ hℓ => ?_⟩
+    exact ne_one_of_isCoprime_X_pow_sub_C_X_pow_sub_X hd (one_le_card_pow _) (h_mid ℓ hℓ) (h₂ ℓ hℓ)
+  · intro ⟨h₁, h₂⟩
+    refine irreducible_of_rabin h_deg hd
+      (X_pow_sub_C_dvd_X_pow_sub_X hd (one_le_card_pow d) h_top h₁) (fun ℓ hℓ => ?_)
+    exact isCoprime_X_pow_sub_C_X_pow_sub_X hd hW0 (one_le_card_pow _) (h_mid ℓ hℓ) (h₂ ℓ hℓ)
+
+/-- The prime factors of `4`. -/
+private theorem primeFactors_four : (4 : ℕ).primeFactors = {2} := by
+  rw [show (4 : ℕ) = 2 ^ 2 from by norm_num,
+    Nat.primeFactors_prime_pow (by norm_num) Nat.prime_two]
+
+/--
+**Irreducibility criterion for quartic binomials.**
+
+`X^4 - W` is irreducible over a finite field with `q` elements as soon as
+`W^((q^4 - 1)/4) = 1` and `W^((q^2 - 1)/4) ≠ 1`.
+
+This is the shape used by the BabyBear, KoalaBear and Hachi degree-4 extensions. It differs
+from `irreducible_X_pow_sub_C_iff` only in discharging `Nat.primeFactors 4 = {2}` internally,
+so callers never touch `Nat.primeFactors`.
+-/
+theorem irreducible_X_pow_four_sub_C {W : F} (hW0 : W ≠ 0)
+    (h_top : 4 ∣ Fintype.card F ^ 4 - 1)
+    (h_mid : 4 ∣ Fintype.card F ^ 2 - 1)
+    (rabin_top : W ^ ((Fintype.card F ^ 4 - 1) / 4) = 1)
+    (rabin_mid : W ^ ((Fintype.card F ^ 2 - 1) / 4) ≠ 1) :
+    Irreducible ((X : F[X]) ^ 4 - C W) := by
+  refine (irreducible_X_pow_sub_C_iff (by norm_num) hW0 h_top ?_).mpr ⟨rabin_top, ?_⟩
+  · simp only [primeFactors_four, Finset.mem_singleton]
+    rintro ℓ rfl
+    simpa using h_mid
+  · simp only [primeFactors_four, Finset.mem_singleton]
+    rintro ℓ rfl
+    simpa using rabin_mid
+
+/--
+`irreducible_X_pow_four_sub_C` with the cardinality abstracted into a numeral `q`.
+
+Concrete fields are defined as `ZMod fieldSize` where `fieldSize` is an *expression* such as
+`2 ^ 31 - 2 ^ 24 + 1`. Stating the hypotheses in terms of a literal `q` lets callers discharge
+them with `norm_num` and `reduce_mod_char`, both of which need the modulus as a numeral.
+Supply `hcard` as `ZMod.card _`.
+
+Note that `reduce_mod_char` still needs to see the *type* as `ZMod <numeral>`, so the two
+exponentiation goals are usually preceded by a `show`; see
+`CompPoly/Fields/KoalaBear/Ext4.lean` for the idiom.
+-/
+theorem irreducible_X_pow_four_sub_C_of_card {q : ℕ} {W : F}
+    (hcard : Fintype.card F = q) (hW0 : W ≠ 0)
+    (h_top : 4 ∣ q ^ 4 - 1) (h_mid : 4 ∣ q ^ 2 - 1)
+    (rabin_top : W ^ ((q ^ 4 - 1) / 4) = 1)
+    (rabin_mid : W ^ ((q ^ 2 - 1) / 4) ≠ 1) :
+    Irreducible ((X : F[X]) ^ 4 - C W) := by
+  subst hcard
+  exact irreducible_X_pow_four_sub_C hW0 h_top h_mid rabin_top rabin_mid
+
+end Polynomial

--- a/CompPoly/Fields/Extension/Bridge.lean
+++ b/CompPoly/Fields/Extension/Bridge.lean
@@ -14,9 +14,8 @@ to its specification `AdjoinRoot (X^d - W)` by
 
 `toQuot x = ∑ i, algebraMap F _ (x.coeff i) * root ^ i`,
 
-which is shown to be an injective ring homomorphism. The algebraic structure on `Ext P` is then
-*transported* across `toQuot` rather than proved by hand, following
-`CompPoly/Fields/Montgomery/Native32Field.lean` (`toField_injective.field`).
+which is shown to be an injective ring homomorphism. The ring axioms on `Ext P` are then
+discharged by pushing through `toQuot` rather than proved on coordinates.
 
 The load-bearing lemma is `toQuot_mul`: the wrap-around `W` factor in `Ext.mul` is exactly
 `root ^ d = W`, so the double sum defining the product regroups into the product of sums.
@@ -26,7 +25,11 @@ The load-bearing lemma is `toQuot_mul`: the wrap-around `W` factor in `Ext.mul` 
 * `Ext.toQuot`: the map to `AdjoinRoot P.poly`.
 * `Ext.toQuot_mul`, `Ext.toQuot_add`, ...: `toQuot` is a ring homomorphism.
 * `Ext.toQuot_injective`: injective for any binomial modulus; irreducibility is not needed.
-* `Ext.instCommRing`: the transported `CommRing` structure.
+* `Ext.instCommRing`: the `CommRing` structure.
+* `Ext.toQuotRingHom`: `toQuot` packaged as a `RingHom`.
+
+Bijectivity, cardinality and the `Field` structure are in
+`CompPoly/Fields/Extension/Field.lean`.
 -/
 
 namespace CompPoly.Extension.Ext

--- a/CompPoly/Fields/Extension/Bridge.lean
+++ b/CompPoly/Fields/Extension/Bridge.lean
@@ -1,0 +1,280 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.Extension.Defs
+import Mathlib.RingTheory.AdjoinRoot
+
+/-!
+# Bridging `Ext P` to `AdjoinRoot P.poly`
+
+The computable coefficient-vector arithmetic of `CompPoly/Fields/Extension/Defs.lean` is related
+to its specification `AdjoinRoot (X^d - W)` by
+
+`toQuot x = ∑ i, algebraMap F _ (x.coeff i) * root ^ i`,
+
+which is shown to be an injective ring homomorphism. The algebraic structure on `Ext P` is then
+*transported* across `toQuot` rather than proved by hand, following
+`CompPoly/Fields/Montgomery/Native32Field.lean` (`toField_injective.field`).
+
+The load-bearing lemma is `toQuot_mul`: the wrap-around `W` factor in `Ext.mul` is exactly
+`root ^ d = W`, so the double sum defining the product regroups into the product of sums.
+
+## Main definitions and statements
+
+* `Ext.toQuot`: the map to `AdjoinRoot P.poly`.
+* `Ext.toQuot_mul`, `Ext.toQuot_add`, ...: `toQuot` is a ring homomorphism.
+* `Ext.toQuot_injective`: injective for any binomial modulus; irreducibility is not needed.
+* `Ext.instCommRing`: the transported `CommRing` structure.
+-/
+
+namespace CompPoly.Extension.Ext
+
+open Polynomial AdjoinRoot
+
+variable {F : Type*} [Field F] {P : BinomialParams F}
+
+/-- The specification of the extension: the quotient ring `F[X] / (X^d - W)`. -/
+scoped notation "Quot[" P "]" => AdjoinRoot (BinomialParams.poly P)
+
+/-- The image of `X` in the quotient, i.e. the adjoined `d`-th root of `W`. -/
+noncomputable def rt (P : BinomialParams F) : Quot[P] := AdjoinRoot.root P.poly
+
+/-- The degree of the defining polynomial, as a `WithBot ℕ`. -/
+theorem degree_poly : P.poly.degree = (P.d : WithBot ℕ) := by
+  rw [BinomialParams.poly]; exact degree_X_pow_sub_C P.d_pos _
+
+/-- The defining relation: the adjoined root raised to the `d`-th power is `W`. -/
+theorem rt_pow_d : (rt P) ^ P.d = algebraMap F Quot[P] P.W := by
+  have h : AdjoinRoot.mk P.poly ((X : F[X]) ^ P.d - C P.W) = 0 := by
+    rw [← BinomialParams.poly]; exact AdjoinRoot.mk_self
+  rw [map_sub, map_pow, AdjoinRoot.mk_X, AdjoinRoot.mk_C, sub_eq_zero] at h
+  rw [rt, AdjoinRoot.algebraMap_eq]
+  exact h
+
+/-- The map from coefficient vectors to the quotient ring. -/
+noncomputable def toQuot (x : Ext P) : Quot[P] :=
+  ∑ i : Fin P.d, algebraMap F Quot[P] (coeff x i) * (rt P) ^ (i : ℕ)
+
+/-! ### `toQuot` is additive -/
+
+@[simp] theorem toQuot_zero : toQuot (0 : Ext P) = 0 := by simp [toQuot]
+
+@[simp] theorem toQuot_add (x y : Ext P) : toQuot (x + y) = toQuot x + toQuot y := by
+  simp only [toQuot, coeff_add, map_add, add_mul, Finset.sum_add_distrib]
+
+@[simp] theorem toQuot_neg (x : Ext P) : toQuot (-x) = -toQuot x := by
+  simp only [toQuot, coeff_neg, map_neg, neg_mul, Finset.sum_neg_distrib]
+
+@[simp] theorem toQuot_sub (x y : Ext P) : toQuot (x - y) = toQuot x - toQuot y := by
+  simp only [toQuot, coeff_sub, map_sub, sub_mul, Finset.sum_sub_distrib]
+
+@[simp] theorem toQuot_smul (c : F) (x : Ext P) :
+    toQuot (c • x) = algebraMap F Quot[P] c * toQuot x := by
+  simp only [toQuot, coeff_smul, map_mul, Finset.mul_sum, mul_assoc]
+
+/-- Only the constant coefficient of `1` is nonzero, so `toQuot 1` collapses to `1`. -/
+@[simp] theorem toQuot_one : toQuot (1 : Ext P) = 1 := by
+  rw [toQuot, Finset.sum_eq_single_of_mem ⟨0, P.d_pos⟩ (Finset.mem_univ _)]
+  · simp
+  · intro k _ hk
+    have : (k : ℕ) ≠ 0 := fun h => hk (Fin.ext h)
+    simp [this]
+
+/-! ### `toQuot` is multiplicative
+
+This is the heart of the framework. For `i, j < d` we have `i + j ≤ 2d - 2 < 2d`, so each pair
+`(i, j)` contributes to exactly one output index: `k = i + j` when `i + j < d`, and
+`k = i + j - d` otherwise, where the wrap-around picks up the factor `W = root ^ d`.
+-/
+
+/--
+The single-index collapse: for a fixed pair `(i, j)`, summing the multiplication kernel over all
+output indices `k` recovers `c * root ^ (i + j)`.
+-/
+private theorem sum_kernel_collapse (i j : Fin P.d) (c : F) :
+    (∑ k : Fin P.d, algebraMap F Quot[P]
+        (if (i : ℕ) + (j : ℕ) = (k : ℕ) then c
+         else if (i : ℕ) + (j : ℕ) = (k : ℕ) + P.d then P.W * c else 0) * (rt P) ^ (k : ℕ))
+      = algebraMap F Quot[P] c * (rt P) ^ ((i : ℕ) + (j : ℕ)) := by
+  by_cases hlt : (i : ℕ) + (j : ℕ) < P.d
+  · -- No wrap-around: only `k = i + j` contributes.
+    rw [Finset.sum_eq_single_of_mem (⟨(i : ℕ) + (j : ℕ), hlt⟩ : Fin P.d) (Finset.mem_univ _)]
+    · simp
+    · intro k _ hk
+      have h1 : (i : ℕ) + (j : ℕ) ≠ (k : ℕ) := fun h => hk (Fin.ext h.symm)
+      have h2 : (i : ℕ) + (j : ℕ) ≠ (k : ℕ) + P.d := by omega
+      simp [h1, h2]
+  · -- Wrap-around: only `k = i + j - d` contributes, with the factor `W = root ^ d`.
+    have hge : P.d ≤ (i : ℕ) + (j : ℕ) := Nat.le_of_not_lt hlt
+    have hij : (i : ℕ) + (j : ℕ) < 2 * P.d := by
+      have := i.isLt; have := j.isLt; omega
+    have hk0 : (i : ℕ) + (j : ℕ) - P.d < P.d := by omega
+    rw [Finset.sum_eq_single_of_mem (⟨(i : ℕ) + (j : ℕ) - P.d, hk0⟩ : Fin P.d)
+      (Finset.mem_univ _)]
+    · have h1 : (i : ℕ) + (j : ℕ) ≠ (i : ℕ) + (j : ℕ) - P.d := by omega
+      have h2 : (i : ℕ) + (j : ℕ) = ((i : ℕ) + (j : ℕ) - P.d) + P.d := by omega
+      simp only [h1, if_false, if_pos h2, map_mul, ← rt_pow_d]
+      -- Name the wrapped index so rewriting `i + j` cannot disturb `i + j - d`.
+      obtain ⟨m, hm⟩ : ∃ m, (i : ℕ) + (j : ℕ) = m + P.d := ⟨(i : ℕ) + (j : ℕ) - P.d, h2⟩
+      rw [hm, Nat.add_sub_cancel, pow_add]
+      ring
+    · intro k _ hk
+      have hkd := k.isLt
+      have h1 : (i : ℕ) + (j : ℕ) ≠ (k : ℕ) := by omega
+      have h2 : (i : ℕ) + (j : ℕ) ≠ (k : ℕ) + P.d := fun h =>
+        hk (Fin.ext (show (k : ℕ) = (i : ℕ) + (j : ℕ) - P.d from by omega))
+      simp [h1, h2]
+
+@[simp] theorem toQuot_mul (x y : Ext P) : toQuot (x * y) = toQuot x * toQuot y := by
+  -- Expand the left-hand side into a triple sum and reorder to `∑ i, ∑ j, ∑ k`.
+  have hL : toQuot (x * y)
+      = ∑ i : Fin P.d, ∑ j : Fin P.d, algebraMap F Quot[P] (coeff x i * coeff y j)
+          * (rt P) ^ ((i : ℕ) + (j : ℕ)) := by
+    simp only [toQuot, coeff_mul, map_sum, Finset.sum_mul]
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [Finset.sum_comm]
+    exact Finset.sum_congr rfl fun j _ => sum_kernel_collapse i j _
+  -- The right-hand side expands to the same thing.
+  rw [hL, toQuot, toQuot, Finset.sum_mul_sum]
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [map_mul, pow_add]
+  ring
+
+@[simp] theorem toQuot_natCast (n : ℕ) : toQuot (n : Ext P) = n := by
+  rw [toQuot, Finset.sum_eq_single_of_mem ⟨0, P.d_pos⟩ (Finset.mem_univ _)]
+  · simp
+  · intro k _ hk
+    have : (k : ℕ) ≠ 0 := fun h => hk (Fin.ext h)
+    simp [this]
+
+@[simp] theorem toQuot_intCast (n : ℤ) : toQuot (n : Ext P) = n := by
+  rw [toQuot, Finset.sum_eq_single_of_mem ⟨0, P.d_pos⟩ (Finset.mem_univ _)]
+  · simp
+  · intro k _ hk
+    have : (k : ℕ) ≠ 0 := fun h => hk (Fin.ext h)
+    simp [this]
+
+/-! ### Injectivity -/
+
+/-- `toQuot` as the class of an explicit degree-`< d` polynomial representative. -/
+theorem toQuot_eq_mk (x : Ext P) :
+    toQuot x = AdjoinRoot.mk P.poly (∑ i : Fin P.d, C (coeff x i) * X ^ (i : ℕ)) := by
+  rw [toQuot, map_sum]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [map_mul, map_pow, AdjoinRoot.mk_C, AdjoinRoot.mk_X, AdjoinRoot.algebraMap_eq]
+  rfl
+
+/-- The representative used by `toQuot_eq_mk` has degree less than that of the modulus. -/
+private theorem degree_repr_lt (x : Ext P) :
+    (∑ i : Fin P.d, C (coeff x i) * X ^ (i : ℕ)).degree < P.poly.degree := by
+  rw [degree_poly]
+  refine lt_of_le_of_lt (degree_sum_le _ _) ?_
+  rw [Finset.sup_lt_iff (by exact_mod_cast WithBot.bot_lt_coe P.d)]
+  intro i _
+  exact lt_of_le_of_lt (degree_C_mul_X_pow_le _ _) (by exact_mod_cast i.isLt)
+
+/-- The coefficients of the explicit representative are the vector's coefficients. -/
+private theorem coeff_repr (x : Ext P) (k : Fin P.d) :
+    (∑ i : Fin P.d, C (coeff x i) * X ^ (i : ℕ)).coeff (k : ℕ) = coeff x k := by
+  rw [finsetSum_coeff, Finset.sum_eq_single_of_mem k (Finset.mem_univ _)]
+  · simp
+  · intro i _ hi
+    rw [coeff_C_mul_X_pow, if_neg (fun h => hi (Fin.ext h.symm))]
+
+theorem toQuot_injective : Function.Injective (toQuot (P := P)) := by
+  intro x y h
+  rw [toQuot_eq_mk, toQuot_eq_mk, ← sub_eq_zero, ← map_sub, AdjoinRoot.mk_eq_zero] at h
+  -- The difference has degree `< deg P.poly`, so divisibility forces it to be zero.
+  have hzero : (∑ i : Fin P.d, C (coeff x i) * X ^ (i : ℕ))
+      - ∑ i : Fin P.d, C (coeff y i) * X ^ (i : ℕ) = 0 :=
+    eq_zero_of_dvd_of_degree_lt h
+      (lt_of_le_of_lt (degree_sub_le _ _) (max_lt (degree_repr_lt x) (degree_repr_lt y)))
+  rw [sub_eq_zero] at hzero
+  ext k
+  rw [← coeff_repr x k, ← coeff_repr y k, hzero]
+
+theorem toQuot_inj {x y : Ext P} : toQuot x = toQuot y ↔ x = y :=
+  toQuot_injective.eq_iff
+
+/-! ### Exponentiation
+
+`x ^ n` on `Ext P` is `npowBinRec`, i.e. repeated squaring, so it costs `O(log n)`
+multiplications. `npowBinRec_succ` needs only `Semigroup`, and associativity is already
+available from `toQuot_mul` plus injectivity — so exponentiation can be handled before the full
+ring structure is transported.
+-/
+
+/-- Associativity. Kept out of the instance graph as a plain theorem to avoid a `Semigroup`
+diamond with the `CommRing` instance below. -/
+private theorem mul_assoc' (x y z : Ext P) : x * y * z = x * (y * z) :=
+  toQuot_injective (by simp only [toQuot_mul, mul_assoc])
+
+@[simp] theorem toQuot_pow (x : Ext P) (n : ℕ) : toQuot (x ^ n) = toQuot x ^ n := by
+  letI : Semigroup (Ext P) := { mul_assoc := mul_assoc' }
+  induction n with
+  | zero => rw [pow_def, npowBinRec_zero, toQuot_one, pow_zero]
+  | succ n ih => rw [pow_def, npowBinRec_succ, toQuot_mul, ← pow_def, ih, pow_succ]
+
+/-! ### Algebraic structure
+
+The axioms are all discharged by pushing through the injective `toQuot`, but the instances are
+built field-by-field with `where` rather than via `Function.Injective.commRing`. That transport
+takes `toQuot` as *data*, which would make the resulting instance `noncomputable` and — because
+`Monoid.toNatPow` then outranks `Ext.instPow` — would silently break compiled `x ^ n`. Building
+by hand keeps every operation computable, matching how `CPolynomial` assembles its instances in
+`CompPoly/Univariate/Basic.lean`.
+-/
+
+instance instAddCommGroup : AddCommGroup (Ext P) where
+  add_assoc a b c := toQuot_injective (by simp only [toQuot_add, add_assoc])
+  zero_add a := toQuot_injective (by simp only [toQuot_add, toQuot_zero, zero_add])
+  add_zero a := toQuot_injective (by simp only [toQuot_add, toQuot_zero, add_zero])
+  add_comm a b := toQuot_injective (by simp only [toQuot_add, add_comm])
+  neg_add_cancel a :=
+    toQuot_injective (by simp only [toQuot_add, toQuot_neg, toQuot_zero, neg_add_cancel])
+  sub_eq_add_neg a b :=
+    toQuot_injective (by simp only [toQuot_sub, toQuot_add, toQuot_neg, sub_eq_add_neg])
+  -- `ℕ`- and `ℤ`-scalar multiplication use the generic recursors: unlike `npow` they are not on
+  -- any hot path, and this keeps them definitionally the standard ones.
+  nsmul := nsmulRec
+  nsmul_zero _ := rfl
+  nsmul_succ _ _ := rfl
+  zsmul := zsmulRec nsmulRec
+  zsmul_zero' _ := rfl
+  zsmul_succ' _ _ := rfl
+  zsmul_neg' _ _ := rfl
+
+instance instCommRing : CommRing (Ext P) where
+  left_distrib a b c := toQuot_injective (by simp only [toQuot_mul, toQuot_add, mul_add])
+  right_distrib a b c := toQuot_injective (by simp only [toQuot_mul, toQuot_add, add_mul])
+  zero_mul a := toQuot_injective (by simp only [toQuot_mul, toQuot_zero, zero_mul])
+  mul_zero a := toQuot_injective (by simp only [toQuot_mul, toQuot_zero, mul_zero])
+  mul_assoc := mul_assoc'
+  one_mul a := toQuot_injective (by simp only [toQuot_mul, toQuot_one, one_mul])
+  mul_one a := toQuot_injective (by simp only [toQuot_mul, toQuot_one, mul_one])
+  mul_comm a b := toQuot_injective (by simp only [toQuot_mul, mul_comm])
+  npow n x := x ^ n
+  npow_zero x := toQuot_injective (by simp only [toQuot_pow, toQuot_one, pow_zero])
+  npow_succ n x := toQuot_injective (by simp only [toQuot_pow, toQuot_mul, pow_succ])
+  natCast n := (n : Ext P)
+  natCast_zero := toQuot_injective (by simp only [toQuot_natCast, toQuot_zero, Nat.cast_zero])
+  natCast_succ n :=
+    toQuot_injective (by simp only [toQuot_natCast, toQuot_add, toQuot_one, Nat.cast_succ])
+  intCast n := (n : Ext P)
+  intCast_ofNat n :=
+    toQuot_injective (by simp only [toQuot_intCast, toQuot_natCast, Int.cast_natCast])
+  intCast_negSucc n :=
+    toQuot_injective (by simp only [toQuot_intCast, toQuot_neg, toQuot_natCast, Int.cast_negSucc])
+
+/-- `toQuot` packaged as a ring homomorphism. -/
+noncomputable def toQuotRingHom (P : BinomialParams F) : Ext P →+* Quot[P] where
+  toFun := toQuot
+  map_one' := toQuot_one
+  map_mul' := toQuot_mul
+  map_zero' := toQuot_zero
+  map_add' := toQuot_add
+
+end CompPoly.Extension.Ext

--- a/CompPoly/Fields/Extension/Bridge.lean
+++ b/CompPoly/Fields/Extension/Bridge.lean
@@ -259,6 +259,10 @@ instance instCommRing : CommRing (Ext P) where
   one_mul a := toQuot_injective (by simp only [toQuot_mul, toQuot_one, one_mul])
   mul_one a := toQuot_injective (by simp only [toQuot_mul, toQuot_one, mul_one])
   mul_comm a b := toQuot_injective (by simp only [toQuot_mul, mul_comm])
+  -- `npow` must stay *definitionally* `Ext.instPow`. If it were left to the default `npowRec`,
+  -- `Monoid.toNatPow` and `Ext.instPow` would be two different functions, and which one `x ^ n`
+  -- elaborates to would depend on instance priority — silently switching between binary and
+  -- linear exponentiation. Setting it here keeps the two paths the same function.
   npow n x := x ^ n
   npow_zero x := toQuot_injective (by simp only [toQuot_pow, toQuot_one, pow_zero])
   npow_succ n x := toQuot_injective (by simp only [toQuot_pow, toQuot_mul, pow_succ])
@@ -271,6 +275,67 @@ instance instCommRing : CommRing (Ext P) where
     toQuot_injective (by simp only [toQuot_intCast, toQuot_natCast, Int.cast_natCast])
   intCast_negSucc n :=
     toQuot_injective (by simp only [toQuot_intCast, toQuot_neg, toQuot_natCast, Int.cast_negSucc])
+
+/-! ### The base field and the adjoined root
+
+`ofBase` is a ring homomorphism `F →+* Ext P`, which upgrades the bare `SMul F (Ext P)` from
+`Defs.lean` to a full `Algebra F (Ext P)` (and hence `Module F (Ext P)` via `Algebra.toModule`).
+That is what lets ordinary Mathlib machinery — `aeval`, scalar towers, `Subalgebra` — see the
+extension as an `F`-algebra.
+-/
+
+/-- `ofBase` lands on the constant coefficient, so it agrees with `algebraMap` into the quotient. -/
+@[simp] theorem toQuot_ofBase (c : F) :
+    toQuot (ofBase (P := P) c) = algebraMap F Quot[P] c := by
+  rw [toQuot, Finset.sum_eq_single_of_mem ⟨0, P.d_pos⟩ (Finset.mem_univ _)]
+  · simp
+  · intro k _ hk
+    have : (k : ℕ) ≠ 0 := fun h => hk (Fin.ext h)
+    simp [this]
+
+/-- `gen` is the class of `X`, i.e. the adjoined root. -/
+@[simp] theorem toQuot_gen : toQuot (gen : Ext P) = rt P := by
+  have h1 : (1 : ℕ) < P.d := P.two_le
+  rw [toQuot, Finset.sum_eq_single_of_mem ⟨1, h1⟩ (Finset.mem_univ _)]
+  · simp
+  · intro k _ hk
+    have : (k : ℕ) ≠ 1 := fun h => hk (Fin.ext h)
+    simp [this]
+
+/-- The base-field embedding, as a ring homomorphism. -/
+def ofBaseRingHom (P : BinomialParams F) : F →+* Ext P where
+  toFun := ofBase
+  map_one' := ofBase_one
+  map_mul' a b := toQuot_injective (by simp only [toQuot_ofBase, toQuot_mul, map_mul])
+  map_zero' := ofBase_zero
+  map_add' a b := toQuot_injective (by simp only [toQuot_ofBase, toQuot_add, map_add])
+
+@[simp] theorem ofBaseRingHom_apply (c : F) : ofBaseRingHom P c = ofBase c := rfl
+
+/--
+The extension is an `F`-algebra.
+
+The `SMul F (Ext P)` from `Defs.lean` is reused, so this adds no second scalar action and
+everything stays computable; `smul_def'` is exactly the statement that scaling a vector
+coefficientwise agrees with multiplying by a constant polynomial.
+-/
+instance instAlgebra : Algebra F (Ext P) where
+  algebraMap := ofBaseRingHom P
+  commutes' _ _ := mul_comm _ _
+  smul_def' c x :=
+    toQuot_injective (by simp only [toQuot_smul, toQuot_mul, ofBaseRingHom_apply, toQuot_ofBase])
+
+@[simp] theorem algebraMap_eq_ofBase (c : F) : algebraMap F (Ext P) c = ofBase c := rfl
+
+/-- **The defining relation.** The adjoined root's `d`-th power is `W`. -/
+theorem gen_pow_d : (gen : Ext P) ^ P.d = ofBase P.W :=
+  toQuot_injective (by rw [toQuot_pow, toQuot_gen, toQuot_ofBase, rt_pow_d])
+
+/-- `gen` is a root of the defining polynomial, in the form Mathlib's `aeval` expects. -/
+theorem aeval_gen_poly : aeval (gen : Ext P) P.poly = 0 := by
+  rw [BinomialParams.poly]
+  simp only [map_sub, map_pow, aeval_X, aeval_C]
+  simp only [gen_pow_d, algebraMap_eq_ofBase, sub_self]
 
 /-- `toQuot` packaged as a ring homomorphism. -/
 noncomputable def toQuotRingHom (P : BinomialParams F) : Ext P →+* Quot[P] where

--- a/CompPoly/Fields/Extension/Bridge.lean
+++ b/CompPoly/Fields/Extension/Bridge.lean
@@ -33,7 +33,7 @@ namespace CompPoly.Extension.Ext
 
 open Polynomial AdjoinRoot
 
-variable {F : Type*} [Field F] {P : BinomialParams F}
+variable {F : Type*} [Field F] [Fintype F] {P : BinomialParams F}
 
 /-- The specification of the extension: the quotient ring `F[X] / (X^d - W)`. -/
 scoped notation "Quot[" P "]" => AdjoinRoot (BinomialParams.poly P)

--- a/CompPoly/Fields/Extension/Defs.lean
+++ b/CompPoly/Fields/Extension/Defs.lean
@@ -143,6 +143,7 @@ Coefficient `k` collects the schoolbook terms `x_i * y_j` with `i + j = k`, plus
 wrap around, `i + j = k + d`, scaled by `W` because `X^d = W`. Since `i, j < d` we have
 `i + j ≤ 2d - 2 < 2d`, so each pair `(i, j)` contributes to exactly one `k`.
 -/
+@[inline, specialize]
 def mul (x y : Ext P) : Ext P :=
   ofFn fun k => ∑ i : Fin P.d, ∑ j : Fin P.d,
     if (i : ℕ) + (j : ℕ) = (k : ℕ) then coeff x i * coeff y j

--- a/CompPoly/Fields/Extension/Defs.lean
+++ b/CompPoly/Fields/Extension/Defs.lean
@@ -14,17 +14,17 @@ dense coefficient vectors of length exactly `d`, so arithmetic is straight-line:
 no size branching, and multiplication reduces by folding the high half of the schoolbook
 product back with a factor of `W`.
 
-The parameters `d` and `W` are bundled into `BinomialParams` and carried as a *type index*
-(`Ext P`), so two different extensions of the same base field are different types and cannot
-have their instances confused.
+The parameters are bundled into `BinomialParams` and carried as a *type index* (`Ext P`), so
+two different extensions of the same base field are different types and cannot have their
+instances confused.
 
-This file supplies only the ring operations and the elementary `coeff` lemmas.
-`CompPoly/Fields/Extension/Bridge.lean` relates them to `AdjoinRoot P.poly` and transports the
-`Field` structure across.
+This file supplies only the operations and the elementary `coeff` lemmas — no algebraic
+structure. `CompPoly/Fields/Extension/Bridge.lean` relates them to `AdjoinRoot P.poly` and
+establishes `CommRing`; `CompPoly/Fields/Extension/Field.lean` adds inversion and `Field`.
 
 ## Main definitions
 
-* `BinomialParams`: the data `d` and `W` of a binomial `X^d - W`, with `2 ≤ d`.
+* `BinomialParams`: the degree `d`, the constant `W`, and the base-field cardinality `q`.
 * `Ext P`: the carrier, `Vector F P.d`.
 * `Ext.mul`: multiplication, with the `X^d = W` fold applied inline.
 
@@ -47,8 +47,8 @@ The data defining a binomial extension `F[X] / (X^d - W)`.
 
 Irreducibility is deliberately *not* a field here: the commutative-ring structure on `Ext P`
 does not need it, and requiring it would force every consumer of the ring operations to carry
-the proof. The `Field` instance takes `[Fact (Irreducible P.poly)]` separately, mirroring
-`AdjoinRoot`.
+the proof. `Ext.instField` takes `[Fact (Irreducible P.poly)]` separately, mirroring
+`AdjoinRoot`. Use `Polynomial.irreducible_X_pow_four_sub_C_of_card` to discharge it.
 -/
 structure BinomialParams (F : Type*) [Field F] [Fintype F] where
   /-- The degree of the extension. -/

--- a/CompPoly/Fields/Extension/Defs.lean
+++ b/CompPoly/Fields/Extension/Defs.lean
@@ -30,10 +30,13 @@ establishes `CommRing`; `CompPoly/Fields/Extension/Field.lean` adds inversion an
 
 ## Implementation notes
 
-Degree bounds are *not* re-derived here. `Ext P` is a fixed-length vector, and the bridge to
-degree-bounded polynomials goes through the existing `CPolynomial.degreeLT` theory
-(`CompPoly/Univariate/Linear.lean`, `CompPoly/Univariate/ToPoly/Degree.lean`), whose
-`degreeLTEquiv` already identifies `↥(degreeLT d)` with `Fin d → F`.
+There is no degree-bound invariant to maintain: `Ext P` has length exactly `P.d`, so the bound
+is *structural* rather than a proposition carried alongside the data. This subtree is therefore
+independent of the `CPolynomial` stack — it imports none of `CompPoly/Univariate/`. Where a
+degree bound is needed on the *polynomial* side (to show the representative chosen by
+`Ext.toQuot` is the canonical one), it is proved directly in
+`CompPoly/Fields/Extension/Bridge.lean` as `degree_repr_lt`, from `Polynomial.degree_sum_le` and
+`Polynomial.degree_C_mul_X_pow_le`.
 -/
 
 namespace CompPoly.Extension
@@ -127,6 +130,20 @@ variable [Fintype F] {P : BinomialParams F}
 
 theorem ofFn_coeff (x : Ext P) : ofFn (coeff x) = x := by ext i; simp
 
+/-! ### Distinguished elements
+
+`ofBase` embeds the base field as constant coefficients and `gen` is the class of `X`, i.e. the
+adjoined `d`-th root of `W`. They are the two elements a consumer of the extension needs by
+name; `CompPoly/Fields/Extension/Bridge.lean` promotes `ofBase` to an `Algebra` structure and
+proves `gen ^ d = ofBase W`.
+-/
+
+/-- The base field embedded into the extension, as the constant coefficient. -/
+@[inline] def ofBase (c : F) : Ext P := ofFn fun i => if (i : ℕ) = 0 then c else 0
+
+/-- The adjoined root: the class of `X`, whose `d`-th power is `W` (`Ext.gen_pow_d`). -/
+def gen : Ext P := ofFn fun i => if (i : ℕ) = 1 then 1 else 0
+
 /-! ### Operations -/
 
 instance : Zero (Ext P) := ⟨ofFn fun _ => 0⟩
@@ -182,6 +199,25 @@ instance : Inhabited (Ext P) := ⟨0⟩
       if (i : ℕ) + (j : ℕ) = (k : ℕ) then coeff x i * coeff y j
       else if (i : ℕ) + (j : ℕ) = (k : ℕ) + P.d then P.W * (coeff x i * coeff y j)
       else 0 := coeff_ofFn _ _
+
+@[simp] theorem coeff_ofBase (c : F) (i : Fin P.d) :
+    coeff (ofBase (P := P) c) i = if (i : ℕ) = 0 then c else 0 := coeff_ofFn _ _
+
+@[simp] theorem coeff_gen (i : Fin P.d) :
+    coeff (gen : Ext P) i = if (i : ℕ) = 1 then 1 else 0 := coeff_ofFn _ _
+
+/-- `ofBase` agrees with `1` on the multiplicative unit. -/
+@[simp] theorem ofBase_one : ofBase (P := P) (1 : F) = 1 := rfl
+
+/-- `ofBase` agrees with `0`. -/
+@[simp] theorem ofBase_zero : ofBase (P := P) (0 : F) = 0 := by
+  ext i; simp only [coeff_ofBase, coeff_zero, ite_self]
+
+/-- `ofBase` agrees with the `ℕ`-cast, so scalars and numerals do not diverge. -/
+@[simp] theorem ofBase_natCast (n : ℕ) : ofBase (P := P) (n : F) = (n : Ext P) := rfl
+
+/-- `ofBase` agrees with the `ℤ`-cast. -/
+@[simp] theorem ofBase_intCast (n : ℤ) : ofBase (P := P) (n : F) = (n : Ext P) := rfl
 
 @[simp] theorem coeff_natCast (n : ℕ) (i : Fin P.d) :
     coeff (n : Ext P) i = if (i : ℕ) = 0 then (n : F) else 0 := coeff_ofFn _ _

--- a/CompPoly/Fields/Extension/Defs.lean
+++ b/CompPoly/Fields/Extension/Defs.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.Extension.Binomial
+import Mathlib.Algebra.BigOperators.Fin
+
+/-!
+# Computable binomial extension fields
+
+A degree-`d` binomial extension of `F` is `F[X] / (X^d - W)`. Elements are represented as
+dense coefficient vectors of length exactly `d`, so arithmetic is straight-line: no trimming,
+no size branching, and multiplication reduces by folding the high half of the schoolbook
+product back with a factor of `W`.
+
+The parameters `d` and `W` are bundled into `BinomialParams` and carried as a *type index*
+(`Ext P`), so two different extensions of the same base field are different types and cannot
+have their instances confused.
+
+This file supplies only the ring operations and the elementary `coeff` lemmas.
+`CompPoly/Fields/Extension/Bridge.lean` relates them to `AdjoinRoot P.poly` and transports the
+`Field` structure across.
+
+## Main definitions
+
+* `BinomialParams`: the data `d` and `W` of a binomial `X^d - W`, with `2 ≤ d`.
+* `Ext P`: the carrier, `Vector F P.d`.
+* `Ext.mul`: multiplication, with the `X^d = W` fold applied inline.
+
+## Implementation notes
+
+Degree bounds are *not* re-derived here. `Ext P` is a fixed-length vector, and the bridge to
+degree-bounded polynomials goes through the existing `CPolynomial.degreeLT` theory
+(`CompPoly/Univariate/Linear.lean`, `CompPoly/Univariate/ToPoly/Degree.lean`), whose
+`degreeLTEquiv` already identifies `↥(degreeLT d)` with `Fin d → F`.
+-/
+
+namespace CompPoly.Extension
+
+open Polynomial
+
+variable {F : Type*} [Field F]
+
+/--
+The data defining a binomial extension `F[X] / (X^d - W)`.
+
+Irreducibility is deliberately *not* a field here: the commutative-ring structure on `Ext P`
+does not need it, and requiring it would force every consumer of the ring operations to carry
+the proof. The `Field` instance takes `[Fact (Irreducible P.poly)]` separately, mirroring
+`AdjoinRoot`.
+-/
+structure BinomialParams (F : Type*) [Field F] where
+  /-- The degree of the extension. -/
+  d : ℕ
+  /-- The extension adjoins a `d`-th root of `W`. -/
+  W : F
+  /-- Degree at least two; a degree-one "extension" is just `F`. -/
+  two_le : 2 ≤ d
+
+namespace BinomialParams
+
+variable (P : BinomialParams F)
+
+/-- The defining polynomial `X^d - W`. Part of the specification only; the computable
+arithmetic on `Ext P` never evaluates it. -/
+noncomputable def poly : F[X] := X ^ P.d - C P.W
+
+@[simp] theorem natDegree_poly : P.poly.natDegree = P.d := natDegree_X_pow_sub_C
+
+theorem monic_poly : P.poly.Monic := monic_X_pow_sub_C _ (by have := P.two_le; omega)
+
+theorem d_pos : 0 < P.d := by have := P.two_le; omega
+
+/-- An irreducible binomial has `W ≠ 0`: otherwise `X^d - W = X^d`, which factors as `X * X^(d-1)`
+with both factors non-units when `2 ≤ d`. -/
+theorem W_ne_zero (h : Irreducible P.poly) : P.W ≠ 0 := by
+  intro hW
+  have hpoly : P.poly = X * X ^ (P.d - 1) := by
+    rw [poly, hW, map_zero, sub_zero, ← pow_succ']
+    congr 1
+    have := P.two_le; omega
+  rw [hpoly] at h
+  rcases h.isUnit_or_isUnit rfl with hu | hu
+  · exact not_isUnit_of_natDegree_pos (X : F[X]) (by simp) hu
+  · exact not_isUnit_of_natDegree_pos ((X : F[X]) ^ (P.d - 1))
+      (by simpa using by have := P.two_le; omega) hu
+
+end BinomialParams
+
+/--
+The carrier of the extension `F[X] / (X^d - W)`: a dense coefficient vector of length `P.d`,
+little-endian (index `i` is the coefficient of `X^i`).
+-/
+def Ext {F : Type*} [Field F] (P : BinomialParams F) : Type _ := Vector F P.d
+
+namespace Ext
+
+variable {P : BinomialParams F}
+
+/-- View an element as its coefficient vector. This is the identity. -/
+@[inline] def coeffs (x : Ext P) : Vector F P.d := x
+
+/-- Build an element from a coefficient vector. This is the identity. -/
+@[inline] def ofVector (v : Vector F P.d) : Ext P := v
+
+/-- Build an element from a coefficient function. -/
+@[inline] def ofFn (g : Fin P.d → F) : Ext P := ofVector (Vector.ofFn g)
+
+/-- The coefficient of `X^i`. -/
+@[inline] def coeff (x : Ext P) (i : Fin P.d) : F := (coeffs x)[i.val]
+
+@[simp] theorem coeff_ofFn (g : Fin P.d → F) (i : Fin P.d) : coeff (ofFn g) i = g i := by
+  simp [coeff, ofFn, ofVector, coeffs]
+
+/-- Two elements with the same coefficients are equal. -/
+@[ext] theorem ext {x y : Ext P} (h : ∀ i, coeff x i = coeff y i) : x = y :=
+  Vector.ext fun i hi => h ⟨i, hi⟩
+
+theorem ofFn_coeff (x : Ext P) : ofFn (coeff x) = x := by ext i; simp
+
+/-! ### Operations -/
+
+instance : Zero (Ext P) := ⟨ofFn fun _ => 0⟩
+instance : One (Ext P) := ⟨ofFn fun i => if (i : ℕ) = 0 then 1 else 0⟩
+instance : Add (Ext P) := ⟨fun x y => ofFn fun i => coeff x i + coeff y i⟩
+instance : Neg (Ext P) := ⟨fun x => ofFn fun i => -coeff x i⟩
+instance : Sub (Ext P) := ⟨fun x y => ofFn fun i => coeff x i - coeff y i⟩
+instance : SMul F (Ext P) := ⟨fun c x => ofFn fun i => c * coeff x i⟩
+
+/--
+Multiplication in `F[X] / (X^d - W)`.
+
+Coefficient `k` collects the schoolbook terms `x_i * y_j` with `i + j = k`, plus the terms that
+wrap around, `i + j = k + d`, scaled by `W` because `X^d = W`. Since `i, j < d` we have
+`i + j ≤ 2d - 2 < 2d`, so each pair `(i, j)` contributes to exactly one `k`.
+-/
+def mul (x y : Ext P) : Ext P :=
+  ofFn fun k => ∑ i : Fin P.d, ∑ j : Fin P.d,
+    if (i : ℕ) + (j : ℕ) = (k : ℕ) then coeff x i * coeff y j
+    else if (i : ℕ) + (j : ℕ) = (k : ℕ) + P.d then P.W * (coeff x i * coeff y j)
+    else 0
+
+instance : Mul (Ext P) := ⟨mul⟩
+
+/-- `Nat`-power by binary exponentiation, so `x ^ n` costs `O(log n)` multiplications. -/
+instance : Pow (Ext P) ℕ := ⟨fun x n => npowBinRec n x⟩
+
+instance : NatCast (Ext P) := ⟨fun n => ofFn fun i => if (i : ℕ) = 0 then (n : F) else 0⟩
+instance : IntCast (Ext P) := ⟨fun n => ofFn fun i => if (i : ℕ) = 0 then (n : F) else 0⟩
+
+instance [DecidableEq F] : DecidableEq (Ext P) :=
+  inferInstanceAs (DecidableEq (Vector F P.d))
+instance [BEq F] : BEq (Ext P) := inferInstanceAs (BEq (Vector F P.d))
+instance [Repr F] : Repr (Ext P) := inferInstanceAs (Repr (Vector F P.d))
+instance : Inhabited (Ext P) := ⟨0⟩
+
+/-! ### Coefficients of the operations -/
+
+@[simp] theorem coeff_zero (i : Fin P.d) : coeff (0 : Ext P) i = 0 := coeff_ofFn _ _
+@[simp] theorem coeff_one (i : Fin P.d) :
+    coeff (1 : Ext P) i = if (i : ℕ) = 0 then 1 else 0 := coeff_ofFn _ _
+@[simp] theorem coeff_add (x y : Ext P) (i : Fin P.d) :
+    coeff (x + y) i = coeff x i + coeff y i := coeff_ofFn _ _
+@[simp] theorem coeff_neg (x : Ext P) (i : Fin P.d) : coeff (-x) i = -coeff x i := coeff_ofFn _ _
+@[simp] theorem coeff_sub (x y : Ext P) (i : Fin P.d) :
+    coeff (x - y) i = coeff x i - coeff y i := coeff_ofFn _ _
+@[simp] theorem coeff_smul (c : F) (x : Ext P) (i : Fin P.d) :
+    coeff (c • x) i = c * coeff x i := coeff_ofFn _ _
+
+@[simp] theorem coeff_mul (x y : Ext P) (k : Fin P.d) :
+    coeff (x * y) k = ∑ i : Fin P.d, ∑ j : Fin P.d,
+      if (i : ℕ) + (j : ℕ) = (k : ℕ) then coeff x i * coeff y j
+      else if (i : ℕ) + (j : ℕ) = (k : ℕ) + P.d then P.W * (coeff x i * coeff y j)
+      else 0 := coeff_ofFn _ _
+
+@[simp] theorem coeff_natCast (n : ℕ) (i : Fin P.d) :
+    coeff (n : Ext P) i = if (i : ℕ) = 0 then (n : F) else 0 := coeff_ofFn _ _
+
+@[simp] theorem coeff_intCast (n : ℤ) (i : Fin P.d) :
+    coeff (n : Ext P) i = if (i : ℕ) = 0 then (n : F) else 0 := coeff_ofFn _ _
+
+theorem pow_def (x : Ext P) (n : ℕ) : x ^ n = npowBinRec n x := rfl
+
+end Ext
+
+end CompPoly.Extension

--- a/CompPoly/Fields/Extension/Defs.lean
+++ b/CompPoly/Fields/Extension/Defs.lean
@@ -50,17 +50,25 @@ does not need it, and requiring it would force every consumer of the ring operat
 the proof. The `Field` instance takes `[Fact (Irreducible P.poly)]` separately, mirroring
 `AdjoinRoot`.
 -/
-structure BinomialParams (F : Type*) [Field F] where
+structure BinomialParams (F : Type*) [Field F] [Fintype F] where
   /-- The degree of the extension. -/
   d : ℕ
   /-- The extension adjoins a `d`-th root of `W`. -/
   W : F
   /-- Degree at least two; a degree-one "extension" is just `F`. -/
   two_le : 2 ≤ d
+  /-- The cardinality of the base field, as a numeral.
+
+  This is carried as *data* rather than read off `Fintype.card F` because inversion is
+  Fermat-based and must evaluate the exponent at runtime: for `F = ZMod p` with `p` around
+  `2^31`, `Fintype.card F` would enumerate all of `Fin p`. Supply `card_eq` as `ZMod.card _`. -/
+  q : ℕ
+  /-- `q` really is the cardinality of the base field. -/
+  card_eq : Fintype.card F = q
 
 namespace BinomialParams
 
-variable (P : BinomialParams F)
+variable [Fintype F] (P : BinomialParams F)
 
 /-- The defining polynomial `X^d - W`. Part of the specification only; the computable
 arithmetic on `Ext P` never evaluates it. -/
@@ -92,11 +100,11 @@ end BinomialParams
 The carrier of the extension `F[X] / (X^d - W)`: a dense coefficient vector of length `P.d`,
 little-endian (index `i` is the coefficient of `X^i`).
 -/
-def Ext {F : Type*} [Field F] (P : BinomialParams F) : Type _ := Vector F P.d
+def Ext {F : Type*} [Field F] [Fintype F] (P : BinomialParams F) : Type _ := Vector F P.d
 
 namespace Ext
 
-variable {P : BinomialParams F}
+variable [Fintype F] {P : BinomialParams F}
 
 /-- View an element as its coefficient vector. This is the identity. -/
 @[inline] def coeffs (x : Ext P) : Vector F P.d := x

--- a/CompPoly/Fields/Extension/Field.lean
+++ b/CompPoly/Fields/Extension/Field.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.Extension.Bridge
+import Mathlib.FieldTheory.Finite.Basic
+
+/-!
+# The field structure on a binomial extension
+
+`toQuot` is not just injective but bijective: every class in `F[X] / (X^d - W)` has a unique
+representative of degree `< d`. That gives `Ext.ringEquivQuot : Ext P ≃+* AdjoinRoot P.poly`,
+hence `Fintype.card (Ext P) = q ^ d`, and — when the defining polynomial is irreducible — a
+`Field` structure.
+
+Inversion is by Fermat's little theorem, `x⁻¹ = x ^ (q^d - 2)`, matching how
+`CompPoly/Fields/Montgomery/Native32Field.lean` inverts in the base field. Exponentiation is
+binary, so this costs `O(d · log q)` extension multiplications.
+
+The instance is assembled by hand rather than via `Function.Injective.field`, for the same
+reason as `Ext.instCommRing`: that transport takes `toQuot` as data and would make the whole
+structure `noncomputable`, which then shadows the computable `Mul` and `Pow`. The `qsmul` /
+`nnqsmul` fields use the `castRec` defaults, following `mkDivisionRingInstance` in
+`CompPoly/Fields/Binary/Tower/Concrete/Core.lean`.
+
+## Main definitions and statements
+
+* `Ext.equivFn`: `Ext P ≃ (Fin P.d → F)`, giving `Fintype (Ext P)` and its cardinality.
+* `Ext.toQuot_surjective`, `Ext.ringEquivQuot`: `Ext P ≃+* AdjoinRoot P.poly`.
+* `Ext.inv`: Fermat inversion.
+* `Ext.instField`: the `Field` structure, given `[Fact (Irreducible P.poly)]`.
+
+## Implementation notes
+
+`Ext.inv` costs `O(d · log q)` extension multiplications. A norm-based inverse using the
+Frobenius map — which on a binomial basis is a coordinate-wise scaling when `d ∣ q - 1` — would
+be roughly an order of magnitude faster. See `ROADMAP.md`.
+-/
+
+namespace CompPoly.Extension.Ext
+
+open Polynomial AdjoinRoot
+
+variable {F : Type*} [Field F] [Fintype F] {P : BinomialParams F}
+
+/-! ### Cardinality -/
+
+/-- Coefficient vectors are exactly functions out of `Fin d`. -/
+def equivFn (P : BinomialParams F) : Ext P ≃ (Fin P.d → F) where
+  toFun := coeff
+  invFun := ofFn
+  left_inv := ofFn_coeff
+  right_inv g := funext fun i => coeff_ofFn g i
+
+instance instFintype : Fintype (Ext P) := Fintype.ofEquiv _ (equivFn P).symm
+
+theorem card_ext : Fintype.card (Ext P) = P.q ^ P.d := by
+  rw [Fintype.card_congr (equivFn P), Fintype.card_fun, P.card_eq, Fintype.card_fin]
+
+instance instNontrivial : Nontrivial (Ext P) :=
+  ⟨⟨0, 1, fun h => by
+    have hc := congrArg (fun z => coeff z ⟨0, P.d_pos⟩) h
+    simp only [coeff_zero, coeff_one] at hc
+    exact zero_ne_one hc⟩⟩
+
+/-- `4 ≤ q ^ d`, since `2 ≤ q` and `2 ≤ d`. Used to justify the Fermat exponent `q ^ d - 2`. -/
+theorem four_le_card_pow : 4 ≤ P.q ^ P.d := by
+  have hq : 2 ≤ P.q := by rw [← P.card_eq]; exact Fintype.one_lt_card
+  calc (4 : ℕ) = 2 ^ 2 := by norm_num
+    _ ≤ 2 ^ P.d := Nat.pow_le_pow_right (by omega) P.two_le
+    _ ≤ P.q ^ P.d := Nat.pow_le_pow_left hq P.d
+
+/-! ### Surjectivity and the ring equivalence -/
+
+theorem toQuot_surjective : Function.Surjective (toQuot (P := P)) := by
+  intro z
+  obtain ⟨p, rfl⟩ := AdjoinRoot.mk_surjective z
+  -- Reduce `p` modulo the (monic) defining polynomial to land in degree `< d`.
+  have hdeg : (p %ₘ P.poly).natDegree < P.d := by
+    rcases eq_or_ne (p %ₘ P.poly) 0 with h0 | h0
+    · simpa [h0] using P.d_pos
+    · refine (natDegree_lt_iff_degree_lt h0).mpr ?_
+      rw [← degree_poly]
+      exact degree_modByMonic_lt p P.monic_poly
+  refine ⟨ofFn fun i => (p %ₘ P.poly).coeff (i : ℕ), ?_⟩
+  rw [toQuot_eq_mk]
+  simp only [coeff_ofFn]
+  have hsum : ∑ i : Fin P.d, C ((p %ₘ P.poly).coeff (i : ℕ)) * X ^ (i : ℕ) = p %ₘ P.poly := by
+    rw [Fin.sum_univ_eq_sum_range (fun i => C ((p %ₘ P.poly).coeff i) * X ^ i) P.d]
+    exact (as_sum_range_C_mul_X_pow' _ hdeg).symm
+  rw [hsum]
+  refine AdjoinRoot.mk_eq_mk.mpr ⟨-(p /ₘ P.poly), ?_⟩
+  linear_combination modByMonic_add_div p P.poly
+
+theorem toQuot_bijective : Function.Bijective (toQuot (P := P)) :=
+  ⟨toQuot_injective, toQuot_surjective⟩
+
+/-- The extension is isomorphic to its specification `F[X] / (X^d - W)`. -/
+noncomputable def ringEquivQuot (P : BinomialParams F) : Ext P ≃+* Quot[P] :=
+  RingEquiv.ofBijective (toQuotRingHom P) toQuot_bijective
+
+@[simp] theorem ringEquivQuot_apply (x : Ext P) : ringEquivQuot P x = toQuot x := rfl
+
+/-- The quotient is finite, transported along the ring equivalence. -/
+noncomputable instance instFintypeQuot : Fintype Quot[P] :=
+  Fintype.ofEquiv _ (ringEquivQuot P).toEquiv
+
+theorem card_quot : Fintype.card Quot[P] = P.q ^ P.d := by
+  rw [← Fintype.card_congr (ringEquivQuot P).toEquiv, card_ext]
+
+/-! ### Inversion
+
+Inversion needs no irreducibility hypothesis to *define* — it is just exponentiation — only to
+be correct, so it and the `Inv`/`Div` instances live outside the section below. `Div` in
+particular must exist before the `Field` instance is assembled, because `NNRat.castRec` uses it.
+-/
+
+/--
+Inversion by Fermat's little theorem: `x⁻¹ = x ^ (q^d - 2)`, since the multiplicative group of
+the extension has order `q^d - 1`. Zero is sent to zero, as `Field` requires.
+-/
+def inv (x : Ext P) : Ext P := x ^ (P.q ^ P.d - 2)
+
+instance instInv : Inv (Ext P) := ⟨inv⟩
+instance instDiv : Div (Ext P) := ⟨fun x y => x * inv y⟩
+
+theorem inv_def (x : Ext P) : x⁻¹ = x ^ (P.q ^ P.d - 2) := rfl
+theorem div_def (x y : Ext P) : x / y = x * y⁻¹ := rfl
+
+theorem inv_zero' : (0 : Ext P)⁻¹ = 0 := by
+  have h4 := four_le_card_pow (P := P)
+  rw [inv_def, zero_pow (by omega)]
+
+/-! ### The field structure -/
+
+section Irreducible
+
+variable [Fact (Irreducible P.poly)]
+
+theorem mul_inv_cancel' {x : Ext P} (hx : x ≠ 0) : x * x⁻¹ = 1 := by
+  refine toQuot_injective ?_
+  rw [toQuot_mul, inv_def, toQuot_pow, toQuot_one, ← pow_succ']
+  have hz : toQuot x ≠ 0 := fun h => hx (toQuot_injective (by rw [h, toQuot_zero]))
+  have h4 := four_le_card_pow (P := P)
+  have hexp : P.q ^ P.d - 2 + 1 = Fintype.card Quot[P] - 1 := by
+    rw [card_quot]; omega
+  rw [hexp]
+  exact FiniteField.pow_card_sub_one_eq_one _ hz
+
+/--
+The field structure. Every operation is computable: `inv` is Fermat exponentiation, `div` is
+`x * y⁻¹`, and the rational-scalar fields use the generic `castRec` definitions.
+-/
+instance instField : Field (Ext P) where
+  inv := inv
+  div := fun x y => x * inv y
+  div_eq_mul_inv _ _ := rfl
+  mul_inv_cancel _ h := mul_inv_cancel' h
+  inv_zero := inv_zero'
+  qsmul := (Rat.castRec · * ·)
+  nnqsmul := (NNRat.castRec · * ·)
+
+end Irreducible
+
+end CompPoly.Extension.Ext

--- a/CompPoly/Fields/Hachi.lean
+++ b/CompPoly/Fields/Hachi.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.Basic
+import CompPoly.Fields.PrattCertificate
+
+/-!
+# Hachi prime field `2^32 - 99`
+
+A 32-bit prime field. The name is provisional.
+
+`p - 1 = 2^2 · 3 · 13 · 67 · 163 · 2521`, so:
+
+* `p ≡ 1 mod 4`, which is what makes `X^4 - W` irreducible for any non-square `W`
+  (see `CompPoly/Fields/Hachi/Ext4.lean`);
+* the two-adicity is only **2**, so unlike BabyBear and KoalaBear this field admits no large
+  smooth multiplicative subgroup and therefore **no radix-2 NTT domain**. That is irrelevant for
+  degree-4 extension arithmetic, which is schoolbook, but it does rule out the
+  `CompPoly/Univariate/NTT*` fast-multiplication paths for polynomials over this field.
+
+## Implementation notes
+
+There is deliberately no `FastField` (Montgomery) implementation for this modulus.
+`Montgomery/Native32Field.lean` requires `modulus < 2 ^ 31`, because radix-`2^32` Montgomery
+reduction needs `x + m * p < 2 ^ 64`; at `p ≈ 2 ^ 32` that overflows `UInt64`. A 64-bit-radix
+(or two-limb) Montgomery layer would be needed, and is orthogonal to the extension framework —
+`CompPoly/Fields/Extension/` is generic over the base-field carrier and would pick it up
+unchanged.
+-/
+
+namespace Hachi
+
+/-- The Hachi field modulus, `2^32 - 99`. -/
+@[reducible]
+def fieldSize : Nat := 2 ^ 32 - 99
+
+/-- The Hachi prime field as a `ZMod`. -/
+abbrev Field := ZMod fieldSize
+
+/-- The Hachi modulus is prime. -/
+theorem is_prime : Nat.Prime fieldSize := by
+  unfold fieldSize
+  pratt
+
+instance : Fact (Nat.Prime fieldSize) := ⟨is_prime⟩
+
+instance : _root_.Field Field := ZMod.instField fieldSize
+
+instance : NonBinaryField Field where
+  char_neq_2 := by decide
+
+/-- Bit width of the Hachi modulus. -/
+@[reducible]
+def pBits : Nat := 32
+
+/-- The two-adicity of `fieldSize - 1`, i.e. `2` — deliberately small; see the module
+docstring. -/
+@[reducible]
+def twoAdicity : Nat := 2
+
+theorem fieldSize_sub_one_factorization : fieldSize - 1 = 2 ^ twoAdicity * 1073741799 := by
+  decide
+
+end Hachi

--- a/CompPoly/Fields/Hachi.lean
+++ b/CompPoly/Fields/Hachi.lean
@@ -41,7 +41,6 @@ abbrev Field := ZMod fieldSize
 
 /-- The Hachi modulus is prime. -/
 theorem is_prime : Nat.Prime fieldSize := by
-  unfold fieldSize
   pratt
 
 instance : Fact (Nat.Prime fieldSize) := ⟨is_prime⟩

--- a/CompPoly/Fields/Hachi/Ext4.lean
+++ b/CompPoly/Fields/Hachi/Ext4.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.Extension
+import CompPoly.Fields.Hachi
+import Mathlib.Tactic.ReduceModChar
+
+/-!
+# The degree-4 extension of Hachi
+
+`Hachi[X] / (X^4 - 2)`, the degree-4 extension of the 32-bit prime field `2^32 - 99`.
+
+`W = 2` is the smallest non-square modulo `p`, which also makes multiplication by `W` a
+doubling. Because `p ≡ 1 mod 4`, `X^4 - W` is irreducible for any non-square `W`; concretely
+this is discharged by `Polynomial.irreducible_X_pow_four_sub_C_of_card` from
+`2^((p^4-1)/4) = 1` and `2^((p^2-1)/4) ≠ 1`.
+
+## Main definitions
+
+* `Hachi.ext4Params`: the `BinomialParams` for `X^4 - 2`.
+* `Hachi.Ext4`: the extension field itself.
+-/
+
+namespace Hachi
+
+open CompPoly.Extension Polynomial
+
+/-- The parameters of the quartic extension `Hachi[X] / (X^4 - 2)`. -/
+def ext4Params : BinomialParams Field where
+  d := 4
+  W := 2
+  two_le := by norm_num
+  q := fieldSize
+  card_eq := ZMod.card _
+
+@[simp] theorem ext4Params_d : ext4Params.d = 4 := rfl
+@[simp] theorem ext4Params_W : ext4Params.W = 2 := rfl
+@[simp] theorem ext4Params_q : ext4Params.q = fieldSize := rfl
+
+/-- `X^4 - 2` is irreducible over Hachi, by the collapsed Rabin criterion. -/
+theorem ext4Params_poly_irreducible : Irreducible ext4Params.poly := by
+  rw [BinomialParams.poly]
+  refine irreducible_X_pow_four_sub_C_of_card (q := 4294967197) (ZMod.card _) (by decide)
+    (by norm_num) (by norm_num) ?_ ?_
+  · show (2 : ZMod 4294967197) ^ ((4294967197 ^ 4 - 1) / 4) = 1
+    reduce_mod_char
+  · show (2 : ZMod 4294967197) ^ ((4294967197 ^ 2 - 1) / 4) ≠ 1
+    reduce_mod_char
+    decide
+
+instance : Fact (Irreducible ext4Params.poly) := ⟨ext4Params_poly_irreducible⟩
+
+/-- The degree-4 extension field of Hachi. -/
+abbrev Ext4 : Type := CompPoly.Extension.Ext ext4Params
+
+/-- The adjoined fourth root of `2`, as an element of `Ext4`. -/
+def ext4Gen : Ext4 := Ext.ofFn fun i => if (i : ℕ) = 1 then 1 else 0
+
+@[simp] theorem card_ext4 : Fintype.card Ext4 = fieldSize ^ 4 := Ext.card_ext
+
+end Hachi

--- a/CompPoly/Fields/Hachi/Ext4.lean
+++ b/CompPoly/Fields/Hachi/Ext4.lean
@@ -69,6 +69,19 @@ abbrev Ext4 : Type := CompPoly.Extension.Ext ext4Params
 /-- The adjoined fourth root of `2`, as an element of `Ext4`. -/
 def ext4Gen : Ext4 := Ext.gen
 
+/--
+`ext4Gen` is the framework's `Ext.gen`.
+
+Deliberately **not** `@[simp]`: as a rewrite it fires before `ext4Gen_pow_four` can match, which
+would knock that lemma out of the simp set. Use `simp [ext4Gen_eq_gen]` to reach the general
+`Ext.gen` lemmas (`Ext.coeff_gen`, `Ext.gen_pow_d`) when the specialized ones below are not
+enough.
+-/
+theorem ext4Gen_eq_gen : ext4Gen = Ext.gen := rfl
+
+/-- `ext4Gen` maps to the adjoined root of the specification. -/
+@[simp] theorem toQuot_ext4Gen : Ext.toQuot ext4Gen = Ext.rt ext4Params := Ext.toQuot_gen
+
 /-- **The defining relation**, as a theorem rather than only an executable check. -/
 @[simp] theorem ext4Gen_pow_four : ext4Gen ^ 4 = Ext.ofBase (2 : Field) := Ext.gen_pow_d
 

--- a/CompPoly/Fields/Hachi/Ext4.lean
+++ b/CompPoly/Fields/Hachi/Ext4.lean
@@ -27,6 +27,17 @@ namespace Hachi
 
 open CompPoly.Extension Polynomial
 
+/--
+The base-field cardinality as a bare numeral.
+
+`reduce_mod_char` reads the modulus syntactically, so the irreducibility proof below needs a
+numeral rather than the expression `fieldSize`. `qNum_eq` pins this second spelling to the first,
+so the two cannot drift apart silently.
+-/
+private abbrev qNum : ℕ := 4294967197
+
+private theorem qNum_eq : qNum = fieldSize := by norm_num
+
 /-- The parameters of the quartic extension `Hachi[X] / (X^4 - 2)`. -/
 def ext4Params : BinomialParams Field where
   d := 4
@@ -42,11 +53,11 @@ def ext4Params : BinomialParams Field where
 /-- `X^4 - 2` is irreducible over Hachi, by the collapsed Rabin criterion. -/
 theorem ext4Params_poly_irreducible : Irreducible ext4Params.poly := by
   rw [BinomialParams.poly]
-  refine irreducible_X_pow_four_sub_C_of_card (q := 4294967197) (ZMod.card _) (by decide)
+  refine irreducible_X_pow_four_sub_C_of_card (q := qNum) (ZMod.card _) (by decide)
     (by norm_num) (by norm_num) ?_ ?_
-  · show (2 : ZMod 4294967197) ^ ((4294967197 ^ 4 - 1) / 4) = 1
+  · show (2 : ZMod qNum) ^ ((qNum ^ 4 - 1) / 4) = 1
     reduce_mod_char
-  · show (2 : ZMod 4294967197) ^ ((4294967197 ^ 2 - 1) / 4) ≠ 1
+  · show (2 : ZMod qNum) ^ ((qNum ^ 2 - 1) / 4) ≠ 1
     reduce_mod_char
     decide
 
@@ -56,7 +67,13 @@ instance : Fact (Irreducible ext4Params.poly) := ⟨ext4Params_poly_irreducible�
 abbrev Ext4 : Type := CompPoly.Extension.Ext ext4Params
 
 /-- The adjoined fourth root of `2`, as an element of `Ext4`. -/
-def ext4Gen : Ext4 := Ext.ofFn fun i => if (i : ℕ) = 1 then 1 else 0
+def ext4Gen : Ext4 := Ext.gen
+
+/-- **The defining relation**, as a theorem rather than only an executable check. -/
+@[simp] theorem ext4Gen_pow_four : ext4Gen ^ 4 = Ext.ofBase (2 : Field) := Ext.gen_pow_d
+
+/-- `ext4Gen` is a root of `X^4 - 2`, in the form `aeval` expects. -/
+theorem aeval_ext4Gen : aeval ext4Gen ext4Params.poly = 0 := Ext.aeval_gen_poly
 
 @[simp] theorem card_ext4 : Fintype.card Ext4 = fieldSize ^ 4 := Ext.card_ext
 

--- a/CompPoly/Fields/KoalaBear/Ext4.lean
+++ b/CompPoly/Fields/KoalaBear/Ext4.lean
@@ -71,6 +71,19 @@ abbrev Ext4 : Type := CompPoly.Extension.Ext ext4Params
 /-- The adjoined fourth root of `3`, as an element of `Ext4`. -/
 def ext4Gen : Ext4 := Ext.gen
 
+/--
+`ext4Gen` is the framework's `Ext.gen`.
+
+Deliberately **not** `@[simp]`: as a rewrite it fires before `ext4Gen_pow_four` can match, which
+would knock that lemma out of the simp set. Use `simp [ext4Gen_eq_gen]` to reach the general
+`Ext.gen` lemmas (`Ext.coeff_gen`, `Ext.gen_pow_d`) when the specialized ones below are not
+enough.
+-/
+theorem ext4Gen_eq_gen : ext4Gen = Ext.gen := rfl
+
+/-- `ext4Gen` maps to the adjoined root of the specification. -/
+@[simp] theorem toQuot_ext4Gen : Ext.toQuot ext4Gen = Ext.rt ext4Params := Ext.toQuot_gen
+
 /-- **The defining relation**, as a theorem rather than only an executable check. -/
 @[simp] theorem ext4Gen_pow_four : ext4Gen ^ 4 = Ext.ofBase (3 : Field) := Ext.gen_pow_d
 

--- a/CompPoly/Fields/KoalaBear/Ext4.lean
+++ b/CompPoly/Fields/KoalaBear/Ext4.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.Extension
+import CompPoly.Fields.KoalaBear.Basic
+import Mathlib.Tactic.ReduceModChar
+
+/-!
+# The degree-4 extension of KoalaBear
+
+`KoalaBear[X] / (X^4 - 3)`, the challenge field used alongside the KoalaBear base field in
+Plonky3-style STARKs.
+
+Irreducibility of `X^4 - 3` is discharged by `Polynomial.irreducible_X_pow_four_sub_C_of_card`,
+whose two hypotheses are single exponentiations in the base field:
+`3^((p^4-1)/4) = 1` and `3^((p^2-1)/4) ≠ 1`. Both are closed by `reduce_mod_char`, which does
+modular repeated squaring at elaboration time — no `native_decide`, and no generated
+certificate file.
+
+## Main definitions
+
+* `KoalaBear.ext4Params`: the `BinomialParams` for `X^4 - 3`.
+* `KoalaBear.Ext4`: the extension field itself.
+-/
+
+namespace KoalaBear
+
+open CompPoly.Extension Polynomial
+
+/-- The parameters of the quartic extension `KoalaBear[X] / (X^4 - 3)`. -/
+def ext4Params : BinomialParams Field where
+  d := 4
+  W := 3
+  two_le := by norm_num
+  q := fieldSize
+  card_eq := ZMod.card _
+
+@[simp] theorem ext4Params_d : ext4Params.d = 4 := rfl
+@[simp] theorem ext4Params_W : ext4Params.W = 3 := rfl
+@[simp] theorem ext4Params_q : ext4Params.q = fieldSize := rfl
+
+/-- `X^4 - 3` is irreducible over KoalaBear, by the collapsed Rabin criterion. -/
+theorem ext4Params_poly_irreducible : Irreducible ext4Params.poly := by
+  rw [BinomialParams.poly]
+  refine irreducible_X_pow_four_sub_C_of_card (q := 2130706433) (ZMod.card _) (by decide)
+    (by norm_num) (by norm_num) ?_ ?_
+  · show (3 : ZMod 2130706433) ^ ((2130706433 ^ 4 - 1) / 4) = 1
+    reduce_mod_char
+  · show (3 : ZMod 2130706433) ^ ((2130706433 ^ 2 - 1) / 4) ≠ 1
+    reduce_mod_char
+    decide
+
+instance : Fact (Irreducible ext4Params.poly) := ⟨ext4Params_poly_irreducible⟩
+
+/-- The degree-4 extension field of KoalaBear. -/
+abbrev Ext4 : Type := CompPoly.Extension.Ext ext4Params
+
+/-- The adjoined fourth root of `3`, as an element of `Ext4`. -/
+def ext4Gen : Ext4 := Ext.ofFn fun i => if (i : ℕ) = 1 then 1 else 0
+
+@[simp] theorem card_ext4 : Fintype.card Ext4 = fieldSize ^ 4 := Ext.card_ext
+
+end KoalaBear

--- a/CompPoly/Fields/KoalaBear/Ext4.lean
+++ b/CompPoly/Fields/KoalaBear/Ext4.lean
@@ -29,6 +29,17 @@ namespace KoalaBear
 
 open CompPoly.Extension Polynomial
 
+/--
+The base-field cardinality as a bare numeral.
+
+`reduce_mod_char` reads the modulus syntactically, so the irreducibility proof below needs a
+numeral rather than the expression `fieldSize`. `qNum_eq` pins this second spelling to the first,
+so the two cannot drift apart silently.
+-/
+private abbrev qNum : ℕ := 2130706433
+
+private theorem qNum_eq : qNum = fieldSize := by norm_num
+
 /-- The parameters of the quartic extension `KoalaBear[X] / (X^4 - 3)`. -/
 def ext4Params : BinomialParams Field where
   d := 4
@@ -44,11 +55,11 @@ def ext4Params : BinomialParams Field where
 /-- `X^4 - 3` is irreducible over KoalaBear, by the collapsed Rabin criterion. -/
 theorem ext4Params_poly_irreducible : Irreducible ext4Params.poly := by
   rw [BinomialParams.poly]
-  refine irreducible_X_pow_four_sub_C_of_card (q := 2130706433) (ZMod.card _) (by decide)
+  refine irreducible_X_pow_four_sub_C_of_card (q := qNum) (ZMod.card _) (by decide)
     (by norm_num) (by norm_num) ?_ ?_
-  · show (3 : ZMod 2130706433) ^ ((2130706433 ^ 4 - 1) / 4) = 1
+  · show (3 : ZMod qNum) ^ ((qNum ^ 4 - 1) / 4) = 1
     reduce_mod_char
-  · show (3 : ZMod 2130706433) ^ ((2130706433 ^ 2 - 1) / 4) ≠ 1
+  · show (3 : ZMod qNum) ^ ((qNum ^ 2 - 1) / 4) ≠ 1
     reduce_mod_char
     decide
 
@@ -58,7 +69,13 @@ instance : Fact (Irreducible ext4Params.poly) := ⟨ext4Params_poly_irreducible�
 abbrev Ext4 : Type := CompPoly.Extension.Ext ext4Params
 
 /-- The adjoined fourth root of `3`, as an element of `Ext4`. -/
-def ext4Gen : Ext4 := Ext.ofFn fun i => if (i : ℕ) = 1 then 1 else 0
+def ext4Gen : Ext4 := Ext.gen
+
+/-- **The defining relation**, as a theorem rather than only an executable check. -/
+@[simp] theorem ext4Gen_pow_four : ext4Gen ^ 4 = Ext.ofBase (3 : Field) := Ext.gen_pow_d
+
+/-- `ext4Gen` is a root of `X^4 - 3`, in the form `aeval` expects. -/
+theorem aeval_ext4Gen : aeval ext4Gen ext4Params.poly = 0 := Ext.aeval_gen_poly
 
 @[simp] theorem card_ext4 : Fintype.card Ext4 = fieldSize ^ 4 := Ext.card_ext
 

--- a/CompPoly/Fields/README.md
+++ b/CompPoly/Fields/README.md
@@ -21,7 +21,7 @@ This directory contains formally verified field infrastructure used in zero-know
 | **Extension/Field.lean** | Bijectivity (`ringEquivQuot`), cardinality, Fermat inversion, and `Field (Ext P)`. |
 | **BabyBear/Ext4.lean** | \(\mathrm{BabyBear}[X]/(X^4 - 11)\). |
 | **KoalaBear/Ext4.lean** | \(\mathrm{KoalaBear}[X]/(X^4 - 3)\). |
-| **Hachi.lean** | \(2^{32} - 99\) — 32-bit prime field. No Montgomery fast path (needs modulus < 2^31) and two-adicity 2, so no NTT domain. |
+| **Hachi.lean** | \(2^{32} - 99\) — 32-bit prime field. **Name provisional.** Included as a 32-bit example rather than a production target: it exercises a base field with no Montgomery fast path (`Mont32Field` requires modulus < 2^31) and two-adicity 2, so no radix-2 NTT domain exists for it. |
 | **Hachi/Ext4.lean** | \(\mathrm{Hachi}[X]/(X^4 - 2)\). |
 | **Goldilocks.lean** | \(2^{64} - 2^{32} + 1\) — Plonky2/3. |
 | **KoalaBear.lean** | Facade for KoalaBear modules, re-exporting the canonical field and fast native-word implementation. |
@@ -44,7 +44,9 @@ The `Binary/` subtree provides characteristic-2 field infrastructure used by GHA
 ## Field extensions
 
 `Extension/` provides computable `F[X]/(X^d - W)` arithmetic in odd characteristic, with the
-`Field` structure proved by transport along a ring equivalence to `AdjoinRoot (X^d - W)`.
+`Field` structure proved by transport along a ring equivalence to `AdjoinRoot (X^d - W)`, plus
+`Algebra F (Ext P)`, a base embedding `ofBase`, and the adjoined root `gen` with
+`gen ^ d = ofBase W`.
 Irreducibility of the defining polynomial comes from Rabin's test, which for a binomial
 collapses to two exponentiations in the base field — no generated certificates and no
 `native_decide`. See [`../../docs/wiki/field-extensions.md`](../../docs/wiki/field-extensions.md).

--- a/CompPoly/Fields/README.md
+++ b/CompPoly/Fields/README.md
@@ -14,6 +14,15 @@ This directory contains formally verified field infrastructure used in zero-know
 | **BLS12_377.lean** | Scalar field of BLS12-377 (253-bit, 2-adicity 47) — Zexe. |
 | **BLS12_381.lean** | Scalar field of BLS12-381 (253-bit, 2-adicity 47). |
 | **BN254.lean** | Scalar field of BN254 curve. |
+| **Extension.lean** | Facade for the binomial field-extension stack. |
+| **Extension/Binomial.lean** | Irreducibility of `X^d - W` over a finite field: Rabin's test collapsed to two base-field exponentiations (`irreducible_X_pow_four_sub_C_iff`). |
+| **Extension/Defs.lean** | `BinomialParams` (degree, `W`, base cardinality) and the carrier `Ext P = Vector F d` with its ring operations. |
+| **Extension/Bridge.lean** | `toQuot : Ext P → AdjoinRoot P.poly`, its ring-hom and injectivity proofs, and `CommRing (Ext P)`. |
+| **Extension/Field.lean** | Bijectivity (`ringEquivQuot`), cardinality, Fermat inversion, and `Field (Ext P)`. |
+| **BabyBear/Ext4.lean** | \(\mathrm{BabyBear}[X]/(X^4 - 11)\). |
+| **KoalaBear/Ext4.lean** | \(\mathrm{KoalaBear}[X]/(X^4 - 3)\). |
+| **Hachi.lean** | \(2^{32} - 99\) — 32-bit prime field. No Montgomery fast path (needs modulus < 2^31) and two-adicity 2, so no NTT domain. |
+| **Hachi/Ext4.lean** | \(\mathrm{Hachi}[X]/(X^4 - 2)\). |
 | **Goldilocks.lean** | \(2^{64} - 2^{32} + 1\) — Plonky2/3. |
 | **KoalaBear.lean** | Facade for KoalaBear modules, re-exporting the canonical field and fast native-word implementation. |
 | **KoalaBear/Basic.lean** | \(2^{31} - 2^{24} + 1\) — lean Ethereum spec. |
@@ -32,6 +41,16 @@ The `Binary/` subtree provides characteristic-2 field infrastructure used by GHA
 - `Binary/AdditiveNTT/*` — additive-NTT domain/algorithm/correctness stack.
 - `Binary/Tower/*` — abstract/concrete binary tower-field constructions and supporting lemmas.
 
+## Field extensions
+
+`Extension/` provides computable `F[X]/(X^d - W)` arithmetic in odd characteristic, with the
+`Field` structure proved by transport along a ring equivalence to `AdjoinRoot (X^d - W)`.
+Irreducibility of the defining polynomial comes from Rabin's test, which for a binomial
+collapses to two exponentiations in the base field — no generated certificates and no
+`native_decide`. See [`../../docs/wiki/field-extensions.md`](../../docs/wiki/field-extensions.md).
+
+The characteristic-2 `Binary/Tower/` stack is a separate, independent development.
+
 ## Primality proofs
 
 Primality is proved via Pratt certificates (Lucas witnesses). Some field definitions (e.g. BN254, BLS12_377) use explicit `PrattCertificate'` proofs, while others construct certificate-driven primality proofs in a similar style.
@@ -41,3 +60,5 @@ Primality is proved via Pratt certificates (Lucas witnesses). Some field definit
 - [Kestrel crypto primes (ACL2)](https://github.com/acl2/acl2/tree/master/books/kestrel/crypto/primes)
 - [SEC 2.4.1 — Secp256k1](http://www.secg.org/sec2-v2.pdf)
 - [BCGMMW18 — Zexe (BLS12-377)](https://eprint.iacr.org/2018/962)
+- [Rabin80 — Probabilistic Algorithms in Finite Fields](https://doi.org/10.1137/0209024)
+- [Lidl & Niederreiter — Finite Fields, 2nd ed., Theorem 3.75](https://doi.org/10.1017/CBO9780511525926)

--- a/CompPoly/ToMathlib/Polynomial/Irreducible.lean
+++ b/CompPoly/ToMathlib/Polynomial/Irreducible.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import Mathlib.Algebra.Polynomial.FieldDivision
+import Mathlib.RingTheory.UniqueFactorizationDomain.Defs
+
+/-!
+# Small-factor extraction for reducible polynomials
+
+A reducible polynomial of degree `n` always has an irreducible factor of degree at most
+`n / 2`: it splits as a product of two non-units whose degrees sum to `n`, and the smaller
+of the two dominates an irreducible factor.
+
+This is the pigeonhole step of Rabin's irreducibility test (see
+`CompPoly/Data/Polynomial/Rabin.lean`), which needs to bound the degree of a hypothetical
+small factor in order to derive a contradiction.
+
+## Main statements
+
+* `Polynomial.exists_factor_natDegree_le_of_reducible`: a reducible polynomial of degree `n`
+  has an irreducible factor of degree at most `n / 2`.
+-/
+
+namespace Polynomial
+
+variable {R : Type*} [Field R]
+
+/--
+A reducible polynomial of positive degree `n` has an irreducible factor of degree at most
+`n / 2`.
+
+Writing `P = a * b` with both factors non-units, their degrees sum to `n`, so the smaller one
+has degree at most `n / 2`; any irreducible factor of it works.
+-/
+theorem exists_factor_natDegree_le_of_reducible (P : R[X]) {n : ℕ}
+    (h_deg : P.natDegree = n) (h_pos : 0 < n) (h_red : ¬ Irreducible P) :
+    ∃ q, Irreducible q ∧ q ∣ P ∧ q.natDegree ≤ n / 2 := by
+  have h_ne_zero : P ≠ 0 := fun h => by
+    rw [h, natDegree_zero] at h_deg; omega
+  have h_not_unit : ¬ IsUnit P :=
+    not_isUnit_of_natDegree_pos P (by omega)
+  -- Reducible and not a unit: `P` splits into two non-units.
+  obtain ⟨a, b, h_eq, ha_nu, hb_nu⟩ : ∃ a b, P = a * b ∧ ¬ IsUnit a ∧ ¬ IsUnit b := by
+    rw [irreducible_iff] at h_red
+    push Not at h_red
+    exact h_red h_not_unit
+  have ha_ne_zero : a ≠ 0 := fun h => h_ne_zero (by rw [h_eq, h, zero_mul])
+  have hb_ne_zero : b ≠ 0 := fun h => h_ne_zero (by rw [h_eq, h, mul_zero])
+  have h_deg_sum : a.natDegree + b.natDegree = n := by
+    rw [← h_deg, h_eq, natDegree_mul ha_ne_zero hb_ne_zero]
+  -- Take an irreducible factor of whichever side has the smaller degree.
+  rcases le_total a.natDegree b.natDegree with h_le | h_le
+  · obtain ⟨q, hq_irr, hq_dvd⟩ := WfDvdMonoid.exists_irreducible_factor ha_nu ha_ne_zero
+    exact ⟨q, hq_irr, hq_dvd.trans (Dvd.intro b h_eq.symm),
+      le_trans (natDegree_le_of_dvd hq_dvd ha_ne_zero) (by omega)⟩
+  · obtain ⟨q, hq_irr, hq_dvd⟩ := WfDvdMonoid.exists_irreducible_factor hb_nu hb_ne_zero
+    exact ⟨q, hq_irr, hq_dvd.trans (Dvd.intro_left a h_eq.symm),
+      le_trans (natDegree_le_of_dvd hq_dvd hb_ne_zero) (by omega)⟩
+
+end Polynomial

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,10 +55,13 @@ CompPoly aims to be the premier formally verified library for computable polynom
         equivalence to `AdjoinRoot`, and a general Rabin irreducibility criterion
         (`CompPoly/Data/Polynomial/Rabin.lean`). Concrete degree-4 instances over
         BabyBear, KoalaBear, and Hachi (`2^32 - 99`).
-         - Faster inversion: replace Fermat `x^(q^d - 2)` with a norm-based inverse using
-           the Frobenius map (a coordinate-wise scaling when `d | q - 1`)
-         - Replace the nested `Finset.sum` in `Ext.mul` with an array loop behind an
-           agreement lemma
+         - 🔄 Performance: `mul` currently measures ~13.4us and `inv` ~1.7ms on
+           KoalaBear degree 4 (`lake exe CompPolyBench`), which is far off a native
+           implementation. In priority order: replace the nested `Finset.sum` in
+           `Ext.mul` with an allocation-free array loop (behind an agreement lemma or
+           `@[csimp]`); instantiate over the `FastField` Montgomery carrier instead of
+           `ZMod`; replace Fermat inversion with a norm-based inverse using the
+           Frobenius map (a coordinate-wise scaling when `d | q - 1`)
          - Tower support (`AlgebraTower`) so `F ⊂ Ext F 2 ⊂ Ext F 4` composes, enabling the
            Mersenne31 CM31/QM31 Circle-STARK stack
          - 64-bit-radix Montgomery layer, so `Hachi` gets a `FastField` base

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,17 +51,26 @@ CompPoly aims to be the premier formally verified library for computable polynom
 1. **Further data types**
    - ✅ Basic field definitions (currently in Arklib) ported into CompPoly (e.g. BabyBear, Goldilocks, BN254, BLS12_381, binary tower)
       - ✅ computable field extensions with interface (`CompPoly/Fields/Extension/`):
-        binomial extensions `F[X]/(X^d - W)` with `CommRing`/`Field` instances, a ring
-        equivalence to `AdjoinRoot`, and a general Rabin irreducibility criterion
+        binomial extensions `F[X]/(X^d - W)` with `CommRing`/`Field`, `Algebra F (Ext P)`
+        (hence `Module`), a base embedding `ofBase`, the adjoined root `gen` with
+        `gen ^ d = ofBase W` and `aeval gen poly = 0`, a ring equivalence to `AdjoinRoot`,
+        cardinality `q ^ d`, and a general Rabin irreducibility criterion
         (`CompPoly/Data/Polynomial/Rabin.lean`). Concrete degree-4 instances over
         BabyBear, KoalaBear, and Hachi (`2^32 - 99`).
+         - Tower support (`AlgebraTower`) is the main interface gap: `F ⊂ Ext F 2 ⊂ Ext F 4`
+           does not yet compose
          - 🔄 Performance: `mul` currently measures ~13.4us and `inv` ~1.7ms on
            KoalaBear degree 4 (`lake exe CompPolyBench`), which is far off a native
            implementation. In priority order: replace the nested `Finset.sum` in
-           `Ext.mul` with an allocation-free array loop (behind an agreement lemma or
-           `@[csimp]`); instantiate over the `FastField` Montgomery carrier instead of
-           `ZMod`; replace Fermat inversion with a norm-based inverse using the
-           Frobenius map (a coordinate-wise scaling when `d | q - 1`)
+           `Ext.mul` with an **O(d^2)** allocation-free array loop (behind an agreement lemma
+           or `@[csimp]`; the current definition visits d^3 terms, so a rewrite must drop the
+           asymptotic shape and not merely the allocations); instantiate over the `FastField`
+           Montgomery carrier instead of `ZMod`; replace Fermat inversion with a norm-based
+           inverse using the Frobenius map (a coordinate-wise scaling when `d | q - 1`)
+         - Rebase the GHASH Rabin specialization
+           (`irreducible_of_rabin_128_passed_over_GF2`) onto the general
+           `Polynomial.irreducible_of_rabin` so the two soundness proofs do not need
+           parallel maintenance
          - Tower support (`AlgebraTower`) so `F ⊂ Ext F 2 ⊂ Ext F 4` composes, enabling the
            Mersenne31 CM31/QM31 Circle-STARK stack
          - 64-bit-radix Montgomery layer, so `Hachi` gets a `FastField` base

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,18 @@ CompPoly aims to be the premier formally verified library for computable polynom
 
 1. **Further data types**
    - ✅ Basic field definitions (currently in Arklib) ported into CompPoly (e.g. BabyBear, Goldilocks, BN254, BLS12_381, binary tower)
-      - computable field extensions with interface
+      - ✅ computable field extensions with interface (`CompPoly/Fields/Extension/`):
+        binomial extensions `F[X]/(X^d - W)` with `CommRing`/`Field` instances, a ring
+        equivalence to `AdjoinRoot`, and a general Rabin irreducibility criterion
+        (`CompPoly/Data/Polynomial/Rabin.lean`). Concrete degree-4 instances over
+        BabyBear, KoalaBear, and Hachi (`2^32 - 99`).
+         - Faster inversion: replace Fermat `x^(q^d - 2)` with a norm-based inverse using
+           the Frobenius map (a coordinate-wise scaling when `d | q - 1`)
+         - Replace the nested `Finset.sum` in `Ext.mul` with an array loop behind an
+           agreement lemma
+         - Tower support (`AlgebraTower`) so `F ⊂ Ext F 2 ⊂ Ext F 4` composes, enabling the
+           Mersenne31 CM31/QM31 Circle-STARK stack
+         - 64-bit-radix Montgomery layer, so `Hachi` gets a `FastField` base
    - ✅ Implement a specialized Bivariate polynomial type, e.g. as `CPolynomial (CPolynomial R)` with specialized polynomial operations (that can then be optimized)
 
 **Success Criteria**: Zero `sorry`s in core operations, all ring structures complete, clean build with no warnings, reasonable proof ergonomics.

--- a/bench/CompPolyBench/Fields/Extension.lean
+++ b/bench/CompPolyBench/Fields/Extension.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+
+import CompPolyBench.Common
+import CompPoly.Fields.BabyBear.Ext4
+import CompPoly.Fields.KoalaBear.Ext4
+
+/-!
+# Degree-4 extension-field benchmarks
+
+Times the two extension-field operations a STARK verifier spends its budget on: multiplication
+and inversion.
+
+Multiplication and inversion are in *separate* groups because the harness cross-checks that all
+records within a group produce the same checksum — a group is a set of alternative
+implementations of one operation, not a set of different operations.
+
+Comparing the two reported averages is the measurement behind the "replace Fermat with a
+norm-based inverse" note in `docs/wiki/field-extensions.md`: inversion is currently
+`x ^ (q^d - 2)`, so it should cost on the order of `d · log q` multiplications.
+-/
+
+open CompPoly CompPoly.Extension
+
+namespace CompPolyBench
+
+/-- Input-shape label shared by the degree-4 extension benchmarks. -/
+private def ext4Shape : String := "64 random degree-4 elements, pairwise"
+
+/-- Checksum for KoalaBear degree-4 extension elements. -/
+def checksumKoalaBearExt4 (x : KoalaBear.Ext4) : Nat :=
+  x.coeffs.toArray.foldl (fun acc z ↦ acc + z.val) 0
+
+/-- Checksum for BabyBear degree-4 extension elements. -/
+def checksumBabyBearExt4 (x : BabyBear.Ext4) : Nat :=
+  x.coeffs.toArray.foldl (fun acc z ↦ acc + z.val) 0
+
+/-- Benchmark group metadata for the degree-4 extension fields. -/
+def extensionGroupInfos : List BenchGroupInfo := [
+  ⟨"fields-extension-koalabear-ext4-mul", "Degree-4 extension multiplication (KoalaBear)"⟩,
+  ⟨"fields-extension-koalabear-ext4-inv", "Degree-4 extension inversion (KoalaBear)"⟩,
+  ⟨"fields-extension-babybear-ext4-mul", "Degree-4 extension multiplication (BabyBear)"⟩,
+  ⟨"fields-extension-babybear-ext4-inv", "Degree-4 extension inversion (BabyBear)"⟩
+]
+
+/--
+Time one degree-4 extension operation over a field-specific sample, packaged as a single-record
+group.
+
+`sample` maps an iteration index to an operand pair; `op` is the operation under test.
+-/
+private def runExt4Op {E : Type} (groupKey title name method fieldName : String)
+    (checksum : E → Nat) (sample : Nat → E × E) (op : E → E → E)
+    (measured : Nat) (preset : BenchPreset) (gen : StdGen) : IO (BenchGroup × StdGen) := do
+  let record ← runTimed name "Extension.Ext" method fieldName ext4Shape preset
+    (warmupIterations preset) measured
+    (fun i ↦ let (a, b) := sample i; op a b) checksum
+  pure ({ groupKey := groupKey, title := title, records := #[record] }, gen)
+
+/-- Build the pairwise operand sampler for a degree-4 extension over a `ZMod` base field. -/
+private def ext4Sampler {F : Type*} [Field F] [Fintype F] {P : BinomialParams F}
+    (values : Array F) : Nat → Ext P × Ext P :=
+  let elem (i : Nat) : Ext P :=
+    Ext.ofFn fun j ↦ values.getD ((i * P.d + j.val) % values.size) 0
+  let xs : Array (Ext P) := Array.ofFn (n := 64) fun i ↦ elem i.val
+  fun i ↦ (xs.getD (i % 64) 1, xs.getD ((i + 17) % 64) 1)
+
+/-- Run the KoalaBear degree-4 multiplication benchmark. -/
+private def runKoalaBearExt4Mul (preset : BenchPreset) (gen : StdGen) :
+    IO (BenchGroup × StdGen) := do
+  let (values, gen) := (koalaBearArray 256 false).run gen
+  runExt4Op "fields-extension-koalabear-ext4-mul"
+    "Degree-4 extension multiplication (KoalaBear)" "extension-mul" "mul" "KoalaBear.Ext4"
+    checksumKoalaBearExt4 (ext4Sampler (P := KoalaBear.ext4Params) values) (· * ·)
+    (preset.selectNat 200000 30000 6000) preset gen
+
+/-- Run the KoalaBear degree-4 inversion benchmark. -/
+private def runKoalaBearExt4Inv (preset : BenchPreset) (gen : StdGen) :
+    IO (BenchGroup × StdGen) := do
+  let (values, gen) := (koalaBearArray 256 false).run gen
+  runExt4Op "fields-extension-koalabear-ext4-inv"
+    "Degree-4 extension inversion (KoalaBear)" "extension-inv" "inv (Fermat)" "KoalaBear.Ext4"
+    checksumKoalaBearExt4 (ext4Sampler (P := KoalaBear.ext4Params) values) (fun a _ ↦ a⁻¹)
+    (preset.selectNat 2000 300 60) preset gen
+
+/-- Run the BabyBear degree-4 multiplication benchmark. -/
+private def runBabyBearExt4Mul (preset : BenchPreset) (gen : StdGen) :
+    IO (BenchGroup × StdGen) := do
+  let (values, gen) := (babyBearArray 256 false).run gen
+  runExt4Op "fields-extension-babybear-ext4-mul"
+    "Degree-4 extension multiplication (BabyBear)" "extension-mul" "mul" "BabyBear.Ext4"
+    checksumBabyBearExt4 (ext4Sampler (P := BabyBear.ext4Params) values) (· * ·)
+    (preset.selectNat 200000 30000 6000) preset gen
+
+/-- Run the BabyBear degree-4 inversion benchmark. -/
+private def runBabyBearExt4Inv (preset : BenchPreset) (gen : StdGen) :
+    IO (BenchGroup × StdGen) := do
+  let (values, gen) := (babyBearArray 256 false).run gen
+  runExt4Op "fields-extension-babybear-ext4-inv"
+    "Degree-4 extension inversion (BabyBear)" "extension-inv" "inv (Fermat)" "BabyBear.Ext4"
+    checksumBabyBearExt4 (ext4Sampler (P := BabyBear.ext4Params) values) (fun a _ ↦ a⁻¹)
+    (preset.selectNat 2000 300 60) preset gen
+
+/-- Registry entries for the degree-4 extension benchmarks. -/
+def extensionTasks : List BenchTask := [
+  BenchTask.fromGroupRunner
+    ⟨"fields-extension-koalabear-ext4-mul", "Degree-4 extension multiplication (KoalaBear)"⟩
+    runKoalaBearExt4Mul,
+  BenchTask.fromGroupRunner
+    ⟨"fields-extension-koalabear-ext4-inv", "Degree-4 extension inversion (KoalaBear)"⟩
+    runKoalaBearExt4Inv,
+  BenchTask.fromGroupRunner
+    ⟨"fields-extension-babybear-ext4-mul", "Degree-4 extension multiplication (BabyBear)"⟩
+    runBabyBearExt4Mul,
+  BenchTask.fromGroupRunner
+    ⟨"fields-extension-babybear-ext4-inv", "Degree-4 extension inversion (BabyBear)"⟩
+    runBabyBearExt4Inv
+]
+
+end CompPolyBench

--- a/bench/CompPolyBench/Setup.lean
+++ b/bench/CompPolyBench/Setup.lean
@@ -8,6 +8,7 @@ import CompPolyBench.Bivariate.Basic
 import CompPolyBench.Bivariate.Factor
 import CompPolyBench.Bivariate.GuruswamiSudan
 import CompPolyBench.Fields.Binary.AdditiveNTT.Impl
+import CompPolyBench.Fields.Extension
 import CompPolyBench.Multilinear.Basic
 import CompPolyBench.Multivariate.CMvPolynomial
 import CompPolyBench.Univariate
@@ -23,7 +24,7 @@ namespace CompPolyBench
 /-- Runnable benchmark registry. -/
 def allTasks : List BenchTask :=
   univariateTasks ++ multivariateTasks ++ multilinearTasks ++ bivariateTasks ++ factorTasks ++
-    guruswamiSudanTasks ++ additiveNttTasks
+    guruswamiSudanTasks ++ additiveNttTasks ++ extensionTasks
 
 /-- Metadata for every benchmark group accepted by the command-line selector. -/
 def allGroupInfos : List BenchGroupInfo :=

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -17,6 +17,8 @@ are too specific or too changeable to keep at the repo root.
   typeclass discipline and minimal-assumption examples.
 - [`binary-fields-and-ntt.md`](binary-fields-and-ntt.md) - the binary-field stack,
   GHASH model, and additive-NTT architecture.
+- [`field-extensions.md`](field-extensions.md) - the computable binomial
+  field-extension framework and its irreducibility criterion.
 
 ## Maintenance Contract
 
@@ -30,6 +32,7 @@ are too specific or too changeable to keep at the repo root.
   - `typeclass-minimization.md` for minimal typeclass assumptions and avoiding
     blanket instance scopes.
   - `binary-fields-and-ntt.md` for the specialized field and NTT stack.
+  - `field-extensions.md` for the odd-characteristic field-extension framework.
 - Add new pages when a recurring topic no longer fits cleanly in an existing page.
 - If a PR changes commands, repo structure, generated-file behavior, or recurring
   architecture guidance, update the matching page in the same PR.

--- a/docs/wiki/field-extensions.md
+++ b/docs/wiki/field-extensions.md
@@ -29,10 +29,36 @@ to binomials buys two things that matter a great deal:
 | Bridge and `CommRing` | [`../../CompPoly/Fields/Extension/Bridge.lean`](../../CompPoly/Fields/Extension/Bridge.lean) | `toQuot`, `toQuot_mul`, `instCommRing` |
 | Bijectivity and `Field` | [`../../CompPoly/Fields/Extension/Field.lean`](../../CompPoly/Fields/Extension/Field.lean) | `ringEquivQuot`, `card_ext`, `inv`, `instField` |
 
+`Data/Polynomial/Rabin.lean` generalizes the degree-128/GF(2) specialization
+`irreducible_of_rabin_128_passed_over_GF2` in `Fields/Binary/BF128Ghash/Basic.lean`, but does not
+yet replace it — `Binary/` is deliberately untouched, so there are currently **two** Rabin
+soundness proofs in the repo. Rebasing the GHASH one onto `irreducible_of_rabin` is a named
+follow-up; until then, a fix to the argument needs applying in both places.
+
 Concrete instances live next to their base field:
 [`KoalaBear/Ext4.lean`](../../CompPoly/Fields/KoalaBear/Ext4.lean) (`X^4 - 3`),
 [`BabyBear/Ext4.lean`](../../CompPoly/Fields/BabyBear/Ext4.lean) (`X^4 - 11`), and
 [`Hachi/Ext4.lean`](../../CompPoly/Fields/Hachi/Ext4.lean) (`X^4 - 2`).
+
+## What The Interface Provides
+
+Concretely, for `P : BinomialParams F`:
+
+| Surface | Declarations |
+|---|---|
+| Ring / field | `CommRing (Ext P)`, `Field (Ext P)` (the latter given `[Fact (Irreducible P.poly)]`) |
+| Base field | `Ext.ofBase : F → Ext P`, `Ext.ofBaseRingHom`, `Algebra F (Ext P)` (hence `Module F (Ext P)` via `Algebra.toModule`) |
+| Adjoined root | `Ext.gen`, `Ext.gen_pow_d : gen ^ d = ofBase W`, `Ext.aeval_gen_poly : aeval gen P.poly = 0` |
+| Specification | `Ext.toQuot`, `Ext.ringEquivQuot : Ext P ≃+* AdjoinRoot P.poly` |
+| Cardinality | `Fintype (Ext P)`, `Ext.card_ext : Fintype.card (Ext P) = q ^ d` |
+| Coefficients | `Ext.coeff`, `Ext.ofFn`, `Ext.equivFn : Ext P ≃ (Fin d → F)` |
+
+With the `Algebra` instance in place, ordinary Mathlib machinery — `aeval`, scalar towers,
+`Subalgebra`, `Module` — applies directly.
+
+**Still missing**, and the natural next step: tower support. There is no `AlgebraTower` instance
+(`CompPoly/Data/RingTheory/AlgebraTower.lean`), so `F ⊂ Ext F 2 ⊂ Ext F 4` does not compose and
+the Mersenne31 CM31/QM31 Circle-STARK stack is out of reach.
 
 ## Irreducibility: Rabin, Collapsed
 
@@ -67,11 +93,19 @@ That is about 60 lines.
 
 ## Representation And Computability
 
-`Ext P` is `Vector F P.d`: dense, little-endian, length exactly `d`. Degree bounds are **not**
-re-derived — the existing `CPolynomial.degreeLT` theory already provides
-`degreeLTEquiv : ↥(degreeLT d) ≃ₗ[F] (Fin d → F)`
-([`Univariate/Linear.lean`](../../CompPoly/Univariate/Linear.lean),
-[`Univariate/ToPoly/Degree.lean`](../../CompPoly/Univariate/ToPoly/Degree.lean)).
+`Ext P` is `Vector F P.d`: dense, little-endian, length exactly `d`. There is no degree-bound
+invariant to maintain — the bound is *structural*, a consequence of the length, not a proposition
+carried alongside the data. As a result this subtree is **independent of the `CPolynomial`
+stack**: nothing under `CompPoly/Fields/Extension/` imports `CompPoly/Univariate/`.
+
+The one place a degree bound is needed on the *polynomial* side — showing that the representative
+`Ext.toQuot` picks is the canonical degree-`< d` one — is proved directly in
+[`Extension/Bridge.lean`](../../CompPoly/Fields/Extension/Bridge.lean) as `degree_repr_lt`, from
+`Polynomial.degree_sum_le` and `Polynomial.degree_C_mul_X_pow_le`. If you want the
+`CPolynomial`-side theory instead (`degreeLT`, `degreeLTEquiv` in
+[`Univariate/Linear.lean`](../../CompPoly/Univariate/Linear.lean) and
+[`Univariate/ToPoly/Degree.lean`](../../CompPoly/Univariate/ToPoly/Degree.lean)), it exists but is
+**not** wired to this framework; connecting them would be new work.
 
 `BinomialParams` carries `d`, `W`, and the base-field cardinality `q` as a *type index*, so
 two different extensions of the same base field are different types whose instances cannot be
@@ -107,13 +141,25 @@ this framework as performance-ready until the items below are done.
 
 The three causes, in order of size:
 
-1. **`Ext.mul` uses a nested `Finset.sum` over `Fin P.d`.** Because `P` is a runtime parameter,
-   nothing monomorphises: `Finset.univ` is rebuilt and `Fin` values are boxed on every call.
-   `@[specialize]` recovers only about 6%. The fix is an allocation-free `Array`/`Fin.foldl`
-   implementation proved equal to the current sum-based definition — either as a separate
-   backend behind an agreement lemma, following the `MulContext` idiom in
-   [`Univariate/Context.lean`](../../CompPoly/Univariate/Context.lean), or via `@[csimp]` so
-   the compiled code is swapped while every existing proof keeps referring to `Ext.mul`.
+1. **`Ext.mul` is O(d³), and separately allocates.** Two distinct problems, and a rewrite must
+   fix both.
+
+   *Asymptotics.* The definition is `ofFn` over `d` output coefficients, each a `d × d` double
+   sum with `if`-tests — so `d³` term visits, nearly all of them contributing zero. Schoolbook
+   binomial reduction is **O(d²)**: for each output index, one sum of `d` products with the
+   partner index computed rather than searched. At `d = 4` that is 64 visits versus 16. A
+   rewrite that only swaps in faster containers while keeping the triple sum leaves a factor of
+   `d` on the table, so specify the target as **O(d²) *and* allocation-free**.
+
+   *Allocation.* Because `P` is a runtime parameter nothing monomorphises: `Finset.univ` is
+   rebuilt and `Fin` values boxed on every call. `@[specialize]` recovers only about 6%.
+
+   The fix is an `Array`-loop implementation proved equal to the current sum-based definition —
+   either as a separate backend behind an agreement lemma, following the `MulContext` idiom in
+   [`Univariate/Context.lean`](../../CompPoly/Univariate/Context.lean), or via `@[csimp]` so the
+   compiled code is swapped while every existing proof keeps referring to `Ext.mul`. Keep the
+   current O(d³) double sum as the *spec*: it is what `toQuot_mul` is proved against, and its
+   symmetry in `(i, j)` is why that proof is short.
 2. **The base field is `ZMod p`**, i.e. boxed `Nat` arithmetic. Instantiating over
    `KoalaBear.Fast.Field` (`UInt32` Montgomery,
    [`Montgomery/Native32Field.lean`](../../CompPoly/Fields/Montgomery/Native32Field.lean))

--- a/docs/wiki/field-extensions.md
+++ b/docs/wiki/field-extensions.md
@@ -1,0 +1,111 @@
+# Field Extensions
+
+`CompPoly/Fields/Extension/` is the computable field-extension framework for odd
+characteristic. It models `F[X] / (X^d - W)` as a dense coefficient vector and proves
+it equal to `AdjoinRoot (X^d - W)`, so Mathlib field theory applies to it.
+
+This page owns extension-field architecture. The characteristic-2 stack is a separate,
+independent development — see [`binary-fields-and-ntt.md`](binary-fields-and-ntt.md).
+
+## Why Binomials
+
+Every extension field used in practice by a STARK or zkVM is a binomial extension: a
+degree-2 to degree-8 extension of a 31- or 32-bit prime, defined by `X^d - W`. Restricting
+to binomials buys two things that matter a great deal:
+
+- **Cheap irreducibility.** Rabin's test collapses to two exponentiations in the *base*
+  field (see below).
+- **Cheap multiplication.** `X^d = W` means the high half of the schoolbook product folds
+  back with a single scalar multiply, with no polynomial remainder step.
+
+## Layering
+
+| Layer | File | Owns |
+|---|---|---|
+| Rabin's test, general | [`../../CompPoly/Data/Polynomial/Rabin.lean`](../../CompPoly/Data/Polynomial/Rabin.lean) | `irreducible_of_rabin`, `irreducible_iff_rabin` for any degree over any finite field |
+| Factor-degree bound | [`../../CompPoly/ToMathlib/Polynomial/Irreducible.lean`](../../CompPoly/ToMathlib/Polynomial/Irreducible.lean) | `exists_factor_natDegree_le_of_reducible` |
+| Binomial criterion | [`../../CompPoly/Fields/Extension/Binomial.lean`](../../CompPoly/Fields/Extension/Binomial.lean) | the collapse to base-field exponentiations; `irreducible_X_pow_four_sub_C_iff` |
+| Carrier and ring ops | [`../../CompPoly/Fields/Extension/Defs.lean`](../../CompPoly/Fields/Extension/Defs.lean) | `BinomialParams`, `Ext P`, `Ext.mul` |
+| Bridge and `CommRing` | [`../../CompPoly/Fields/Extension/Bridge.lean`](../../CompPoly/Fields/Extension/Bridge.lean) | `toQuot`, `toQuot_mul`, `instCommRing` |
+| Bijectivity and `Field` | [`../../CompPoly/Fields/Extension/Field.lean`](../../CompPoly/Fields/Extension/Field.lean) | `ringEquivQuot`, `card_ext`, `inv`, `instField` |
+
+Concrete instances live next to their base field:
+[`KoalaBear/Ext4.lean`](../../CompPoly/Fields/KoalaBear/Ext4.lean) (`X^4 - 3`),
+[`BabyBear/Ext4.lean`](../../CompPoly/Fields/BabyBear/Ext4.lean) (`X^4 - 11`), and
+[`Hachi/Ext4.lean`](../../CompPoly/Fields/Hachi/Ext4.lean) (`X^4 - 2`).
+
+## Irreducibility: Rabin, Collapsed
+
+Rabin's test says a degree-`d` polynomial `f` over `F_q` is irreducible exactly when
+`f ∣ X^(q^d) - X` and `f` is coprime to `X^(q^(d/l)) - X` for every prime `l ∣ d`.
+
+For a binomial, `X^d = W` gives `X^(q^j) ≡ W^((q^j - 1)/d) * X (mod X^d - W)` whenever
+`d ∣ q^j - 1`. Both conditions therefore become conditions on `W` alone:
+
+> `X^d - W` is irreducible over `F_q` **iff** `W^((q^d - 1)/d) = 1` and
+> `W^((q^(d/l) - 1)/d) ≠ 1` for every prime `l ∣ d`.
+
+For `d = 4` that is two exponentiations, discharged by `reduce_mod_char`, which does modular
+repeated squaring during elaboration. Contrast the roughly 2100 lines of generated `BitVec`
+step certificates that the same test needs for the non-binomial GHASH polynomial
+(`Fields/Binary/BF128Ghash/XPowTwoPow{Mod,Gcd}Certificate.lean`).
+
+Nothing here uses `native_decide`, per the TCB policy in [`AGENTS.md`](../../AGENTS.md).
+
+### Adding a new extension
+
+1. Pick `W`. For `d = 4` over `q ≡ 1 mod 4`, any non-square works; prefer the smallest, so
+   that multiplying by `W` is cheap.
+2. Write the `BinomialParams`, supplying `card_eq := ZMod.card _`.
+3. Prove irreducibility with `irreducible_X_pow_four_sub_C_of_card`. The two exponentiation
+   goals need the type presented as `ZMod <numeral>`, because `reduce_mod_char` reads the
+   modulus syntactically and `fieldSize` is an expression like `2 ^ 31 - 2 ^ 24 + 1`. Use a
+   `show` — see any of the three `Ext4.lean` files.
+4. Register `instance : Fact (Irreducible ...)` and define the `abbrev`.
+
+That is about 60 lines.
+
+## Representation And Computability
+
+`Ext P` is `Vector F P.d`: dense, little-endian, length exactly `d`. Degree bounds are **not**
+re-derived — the existing `CPolynomial.degreeLT` theory already provides
+`degreeLTEquiv : ↥(degreeLT d) ≃ₗ[F] (Fin d → F)`
+([`Univariate/Linear.lean`](../../CompPoly/Univariate/Linear.lean),
+[`Univariate/ToPoly/Degree.lean`](../../CompPoly/Univariate/ToPoly/Degree.lean)).
+
+`BinomialParams` carries `d`, `W`, and the base-field cardinality `q` as a *type index*, so
+two different extensions of the same base field are different types whose instances cannot be
+confused. `q` is data rather than `Fintype.card F` because Fermat inversion evaluates the
+exponent at runtime, and `Fintype.card (ZMod p)` would enumerate all of `Fin p`.
+
+**The instances are assembled field-by-field, not by `Function.Injective.commRing` /
+`.field`.** Those transports take `toQuot` as data, which forces the resulting instance
+`noncomputable`. That is not merely cosmetic: `Monoid.toNatPow` then outranks `Ext.instPow`, and
+compiled `x ^ n` fails to build. This was observed, not hypothesized. If you add structure to
+`Ext P`, keep it computable and keep a `#guard` in
+[`tests/CompPolyTests/Fields/Extension/Arithmetic.lean`](../../tests/CompPolyTests/Fields/Extension/Arithmetic.lean)
+that exercises the operation, since only compiled evaluation catches this class of regression.
+
+The load-bearing correctness lemma is `Ext.toQuot_mul`: `root ^ d = W` is exactly the
+wrap-around factor in `Ext.mul`, so the double sum defining the product regroups into the
+product of sums.
+
+## Known Performance Gaps
+
+Both are correctness-complete but slower than the state of the art. Neither is hidden behind an
+abstraction that would make replacing them awkward.
+
+- **Inversion is Fermat** (`x ^ (q^d - 2)`), about `d · log q` extension multiplications. A
+  norm-based inverse would be roughly an order of magnitude faster: when `d ∣ q - 1` the
+  Frobenius map is a coordinate-wise scaling by powers of `W^((q-1)/d)`, so
+  `N(x) = ∏_j φ^j(x)` lands in the base field and `x⁻¹ = (∏_{j≥1} φ^j(x)) · N(x)⁻¹`.
+- **`Ext.mul` uses a nested `Finset.sum`**, which allocates. An `Array`-loop implementation
+  behind an agreement lemma — the `MulContext` idiom from
+  [`Univariate/Context.lean`](../../CompPoly/Univariate/Context.lean) — would avoid that.
+
+## Base Field Caveats
+
+`Hachi` (`2^32 - 99`) has no `FastField` Montgomery path: `Mont32Field` requires
+`modulus < 2^31`, since radix-`2^32` reduction needs `x + m * p < 2^64`. It also has two-adicity
+2, so it admits no radix-2 NTT domain. The extension layer is generic over the base-field
+carrier, so a future 64-bit Montgomery layer would be picked up unchanged.

--- a/docs/wiki/field-extensions.md
+++ b/docs/wiki/field-extensions.md
@@ -90,18 +90,44 @@ The load-bearing correctness lemma is `Ext.toQuot_mul`: `root ^ d = W` is exactl
 wrap-around factor in `Ext.mul`, so the double sum defining the product regroups into the
 product of sums.
 
-## Known Performance Gaps
+## Performance: Measured, And Not Yet Competitive
 
-Both are correctness-complete but slower than the state of the art. Neither is hidden behind an
-abstraction that would make replacing them awkward.
+The framework is correctness-complete, and its *design* is ready for fast arithmetic — `Ext P`
+is generic over the base-field carrier precisely so a Montgomery representation can be dropped
+in. The current instantiation over `ZMod`, however, is **not** fast. Measured with
+`lake exe CompPolyBench --small` on a developer laptop:
 
-- **Inversion is Fermat** (`x ^ (q^d - 2)`), about `d · log q` extension multiplications. A
-  norm-based inverse would be roughly an order of magnitude faster: when `d ∣ q - 1` the
-  Frobenius map is a coordinate-wise scaling by powers of `W^((q-1)/d)`, so
-  `N(x) = ∏_j φ^j(x)` lands in the base field and `x⁻¹ = (∏_{j≥1} φ^j(x)) · N(x)⁻¹`.
-- **`Ext.mul` uses a nested `Finset.sum`**, which allocates. An `Array`-loop implementation
-  behind an agreement lemma — the `MulContext` idiom from
-  [`Univariate/Context.lean`](../../CompPoly/Univariate/Context.lean) — would avoid that.
+| Group | Operation | Average |
+|---|---|---|
+| `fields-extension-koalabear-ext4-mul` | `mul` | ~13.4 us |
+| `fields-extension-koalabear-ext4-inv` | `inv` | ~1.7 ms |
+
+For scale, a hand-written Rust degree-4 BabyBear multiply is a few nanoseconds. Do not quote
+this framework as performance-ready until the items below are done.
+
+The three causes, in order of size:
+
+1. **`Ext.mul` uses a nested `Finset.sum` over `Fin P.d`.** Because `P` is a runtime parameter,
+   nothing monomorphises: `Finset.univ` is rebuilt and `Fin` values are boxed on every call.
+   `@[specialize]` recovers only about 6%. The fix is an allocation-free `Array`/`Fin.foldl`
+   implementation proved equal to the current sum-based definition — either as a separate
+   backend behind an agreement lemma, following the `MulContext` idiom in
+   [`Univariate/Context.lean`](../../CompPoly/Univariate/Context.lean), or via `@[csimp]` so
+   the compiled code is swapped while every existing proof keeps referring to `Ext.mul`.
+2. **The base field is `ZMod p`**, i.e. boxed `Nat` arithmetic. Instantiating over
+   `KoalaBear.Fast.Field` (`UInt32` Montgomery,
+   [`Montgomery/Native32Field.lean`](../../CompPoly/Fields/Montgomery/Native32Field.lean))
+   needs only `Fintype` for that carrier plus irreducibility transported along
+   `Montgomery.Native32.ringEquiv` with `Polynomial.mapEquiv`. No change to the framework.
+3. **Inversion is Fermat** (`x ^ (q^d - 2)`), about `d · log q` extension multiplications — the
+   ~130x ratio to `mul` above. A norm-based inverse would be roughly an order of magnitude
+   faster: when `d ∣ q - 1` the Frobenius map is a coordinate-wise scaling by powers of
+   `W^((q-1)/d)`, so `N(x) = ∏_j φ^j(x)` lands in the base field and
+   `x⁻¹ = (∏_{j≥1} φ^j(x)) · N(x)⁻¹`.
+
+None of these is hidden behind an abstraction that makes replacing it awkward, and each is
+guarded by the `#guard` regressions in
+[`tests/CompPolyTests/Fields/Extension/Arithmetic.lean`](../../tests/CompPolyTests/Fields/Extension/Arithmetic.lean).
 
 ## Base Field Caveats
 

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -47,6 +47,9 @@ scripts/              repo utilities and validation helpers
   start in `CompPoly/Bivariate/`.
 - Adding concrete fields, GHASH lemmas, tower-field infrastructure, or additive NTT:
   start in `CompPoly/Fields/`.
+- Adding or changing a field extension (challenge fields, `F[X]/(X^d - W)`):
+  start in `CompPoly/Fields/Extension/` and read
+  [`field-extensions.md`](field-extensions.md).
 - Moving a reusable support lemma that should not live next to one specific feature:
   start in `CompPoly/Data/` or `CompPoly/ToMathlib/`.
 - Adding regression coverage: start in `tests/` and mirror the source namespace when

--- a/docs/wiki/representations-and-bridges.md
+++ b/docs/wiki/representations-and-bridges.md
@@ -10,6 +10,7 @@ usually the first architectural decision in a change.
 | Univariate | `CPolynomial.Raw R`, `CPolynomial R`, `QuotientCPolynomial R` | Canonical coefficient-sequence arithmetic, quotient reasoning, interpolation | `CompPoly/Univariate/README.md`, `CompPoly/Univariate/Basic.lean`, `CompPoly/Univariate/ToPoly.lean` |
 | Multivariate | `CMvPolynomial n R` | Sparse computable multivariate operations and `MvPolynomial` interop | `CompPoly/Multivariate/CMvPolynomial.lean`, `CompPoly/Multivariate/Operations.lean`, `CompPoly/Multivariate/MvPolyEquiv.lean` |
 | Multilinear | `CMlPolynomial R n`, `CMlPolynomialEval R n` | Boolean-hypercube evaluation form, basis conversion, multilinear extensions | `CompPoly/Multilinear/Basic.lean`, `CompPoly/Multilinear/Equiv.lean` |
+| Field extensions | `Extension.Ext P` | Computable `F[X]/(X^d - W)` arithmetic for challenge fields | `CompPoly/Fields/Extension.lean`, `docs/wiki/field-extensions.md` |
 | Bivariate | `CBivariate R` | Specialized two-variable APIs and `R[X][Y]` transport | `CompPoly/Bivariate/README.md`, `CompPoly/Bivariate/Basic.lean`, `CompPoly/Bivariate/ToPoly.lean`, `CompPoly/ToMathlib/Polynomial/BivariateDegree.lean`, `CompPoly/ToMathlib/Polynomial/BivariateWeightedDegree.lean`, `CompPoly/ToMathlib/Polynomial/BivariateMultiplicity.lean` |
 
 ## Univariate Family
@@ -136,3 +137,19 @@ specific polynomial representation.
   `CMlPolynomial` or `CMlPolynomialEval`.
 - If the API is naturally two-variable and you want `X` / `Y`-specific operations,
   start with `CBivariate`.
+
+## Field Extensions
+
+`CompPoly.Extension.Ext P` is a *fixed-length* dense representation, unlike the
+polynomial surfaces above: `Vector F P.d`, where `P : BinomialParams F` pins the degree
+and the constant `W` of the defining binomial `X^d - W`.
+
+The bridge is
+[`../../CompPoly/Fields/Extension/Bridge.lean`](../../CompPoly/Fields/Extension/Bridge.lean),
+which maps into `AdjoinRoot P.poly` and proves the map bijective, and
+[`../../CompPoly/Fields/Extension/Field.lean`](../../CompPoly/Fields/Extension/Field.lean),
+which yields `Ext P ≃+* AdjoinRoot P.poly`.
+
+Degree bounds reuse the existing `CPolynomial.degreeLT` theory rather than introducing a
+new bound; see [`field-extensions.md`](field-extensions.md) for the full architecture,
+including why the ring and field instances must be built by hand rather than transported.

--- a/docs/wiki/representations-and-bridges.md
+++ b/docs/wiki/representations-and-bridges.md
@@ -150,6 +150,8 @@ which maps into `AdjoinRoot P.poly` and proves the map bijective, and
 [`../../CompPoly/Fields/Extension/Field.lean`](../../CompPoly/Fields/Extension/Field.lean),
 which yields `Ext P ≃+* AdjoinRoot P.poly`.
 
-Degree bounds reuse the existing `CPolynomial.degreeLT` theory rather than introducing a
-new bound; see [`field-extensions.md`](field-extensions.md) for the full architecture,
-including why the ring and field instances must be built by hand rather than transported.
+Because the representation has a fixed length, the degree bound is structural and no
+degree-bound invariant is carried; this subtree is independent of the `CPolynomial` stack
+and imports none of `CompPoly/Univariate/`. See
+[`field-extensions.md`](field-extensions.md) for the full architecture, including why the
+ring and field instances must be built by hand rather than transported.

--- a/tests/CompPolyTests.lean
+++ b/tests/CompPolyTests.lean
@@ -24,6 +24,8 @@ import CompPolyTests.Data.MvPolynomial.Notation
 import CompPolyTests.Fields.BabyBear.Fast
 import CompPolyTests.Fields.Binary.AdditiveNTT.NovelPolynomialBasis
 import CompPolyTests.Fields.Binary.BF128Ghash.Prelude
+import CompPolyTests.Fields.Extension.Arithmetic
+import CompPolyTests.Fields.Extension.Binomial
 import CompPolyTests.Fields.KoalaBear.Fast
 import CompPolyTests.Fields.PrattCertificate
 import CompPolyTests.LinearAlgebra.Dense

--- a/tests/CompPolyTests/Fields/Extension/Arithmetic.lean
+++ b/tests/CompPolyTests/Fields/Extension/Arithmetic.lean
@@ -69,6 +69,12 @@ private def bbX : Ext4 := Ext.ofFn fun i => (7 * (i : ℕ) + 3 : ℕ)
 private def bbY : Ext4 := Ext.ofFn fun i => ((i : ℕ) * (i : ℕ) + 2 : ℕ)
 
 #guard (ext4Gen ^ 4) == (11 : Ext4)
+
+-- Hand-computed product, as for KoalaBear: with `bbX = (3,10,17,24)`, `bbY = (2,3,6,11)` and
+-- `W = 11`, the schoolbook convolution is `(6,29,82,192,284,331,264)` and folding the high half
+-- back gives `c_k + 11 * c_{k+4}`.
+#guard (bbX * bbY).coeffs.toArray.map (·.val) == #[3130, 3670, 2986, 192]
+
 #guard (bbX + bbY) * (bbX - bbY) == bbX * bbX - bbY * bbY
 #guard bbX ^ 6 == (bbX * bbX * bbX) ^ 2
 #guard bbX * bbX⁻¹ == 1
@@ -94,5 +100,38 @@ private def haY : Ext4 := Ext.ofFn fun i => (3 * (i : ℕ) + 1 : ℕ)
 #guard (haX / haY) * haY == haX
 
 end Hachi
+
+/-! ### The `Algebra` surface
+
+`Algebra F (Ext P)` introduces a second `SMul F (Ext P)` path (`Algebra.toSMul`) on top of the
+one in `Extension/Defs.lean`. These guards confirm the new layer is computable and that the two
+scalar actions agree — the same class of regression as the `Monoid.toNatPow` / `Ext.instPow`
+shadowing that a `noncomputable` instance would cause.
+-/
+
+section Algebra
+open KoalaBear
+
+private def c : KoalaBear.Field := 5
+
+#guard (Ext.ofBase c : Ext4).coeffs.toArray.map (·.val) == #[5, 0, 0, 0]
+#guard (algebraMap KoalaBear.Field Ext4 c).coeffs.toArray.map (·.val) == #[5, 0, 0, 0]
+#guard (Ext.gen : Ext4).coeffs.toArray.map (·.val) == #[0, 1, 0, 0]
+
+-- `Algebra.smul_def` holds computationally, not just propositionally.
+#guard c • kbX == algebraMap KoalaBear.Field Ext4 c * kbX
+
+-- `ofBase` agrees with the numeral casts, so scalars and literals cannot diverge.
+#guard (Ext.ofBase (3 : KoalaBear.Field) : Ext4) == (3 : Ext4)
+
+-- The defining relation, as an executable check next to the `ext4Gen_pow_four` theorem.
+#guard (Ext.gen : Ext4) ^ 4 == Ext.ofBase (3 : KoalaBear.Field)
+
+-- The instances Mathlib consumers need actually resolve.
+example : Module KoalaBear.Field Ext4 := inferInstance
+example : Algebra KoalaBear.Field Ext4 := inferInstance
+example : IsScalarTower KoalaBear.Field Ext4 Ext4 := inferInstance
+
+end Algebra
 
 end CompPolyTests.Fields.Extension

--- a/tests/CompPolyTests/Fields/Extension/Arithmetic.lean
+++ b/tests/CompPolyTests/Fields/Extension/Arithmetic.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.BabyBear.Ext4
+import CompPoly.Fields.Hachi.Ext4
+import CompPoly.Fields.KoalaBear.Ext4
+
+/-!
+# Extension-field arithmetic tests
+
+Executable regressions for `CompPoly/Fields/Extension/`. These check that the *compiled*
+arithmetic works, not merely that the instances elaborate: a `Field` instance built by the
+`Function.Injective.field` transport would be `noncomputable` and every `#guard` below would
+fail to build.
+
+Each field is exercised for:
+
+* the defining relation `gen ^ d = W`, which pins down the wrap-around factor in `Ext.mul`;
+* ring identities, which cross-check `mul` against `add`/`sub`;
+* `x * x⁻¹ = 1` and `0⁻¹ = 0`, which exercise Fermat inversion;
+* agreement of binary `^` with repeated multiplication.
+-/
+
+namespace CompPolyTests.Fields.Extension
+
+open CompPoly.Extension
+
+/-! ### KoalaBear, `X^4 - 3` -/
+
+section KoalaBear
+open KoalaBear
+
+private def kbX : Ext4 := Ext.ofFn fun i => ((i : ℕ) + 1 : ℕ)
+private def kbY : Ext4 := Ext.ofFn fun i => (2 * (i : ℕ) + 5 : ℕ)
+
+-- The defining relation.
+#guard (ext4Gen ^ 4) == (3 : Ext4)
+
+-- Hand-computed product: with `kbX = (1,2,3,4)`, `kbY = (5,7,9,11)` and `W = 3`, the schoolbook
+-- convolution is `(5,17,38,70,77,69,44)` and folding gives `c_k + 3 * c_{k+4}`.
+#guard (kbX * kbY).coeffs.toArray.map (·.val) == #[236, 224, 170, 70]
+
+-- Ring identities.
+#guard (kbX + kbY) * (kbX - kbY) == kbX * kbX - kbY * kbY
+#guard (kbX + kbY) ^ 2 == kbX * kbX + 2 * kbX * kbY + kbY * kbY
+#guard kbX ^ 5 == kbX * kbX * kbX * kbX * kbX
+#guard (3 : Ext4) * kbX == kbX + kbX + kbX
+
+-- Inversion.
+#guard kbX * kbX⁻¹ == 1
+#guard kbY * kbY⁻¹ == 1
+#guard ext4Gen * ext4Gen⁻¹ == 1
+#guard (0 : Ext4)⁻¹ == 0
+#guard (kbX / kbY) * kbY == kbX
+
+-- The base field embeds as the constant coefficient.
+#guard Ext.coeff (7 : Ext4) ⟨0, by norm_num⟩ == (7 : KoalaBear.Field)
+
+end KoalaBear
+
+/-! ### BabyBear, `X^4 - 11` -/
+
+section BabyBear
+open BabyBear
+
+private def bbX : Ext4 := Ext.ofFn fun i => (7 * (i : ℕ) + 3 : ℕ)
+private def bbY : Ext4 := Ext.ofFn fun i => ((i : ℕ) * (i : ℕ) + 2 : ℕ)
+
+#guard (ext4Gen ^ 4) == (11 : Ext4)
+#guard (bbX + bbY) * (bbX - bbY) == bbX * bbX - bbY * bbY
+#guard bbX ^ 6 == (bbX * bbX * bbX) ^ 2
+#guard bbX * bbX⁻¹ == 1
+#guard bbY * bbY⁻¹ == 1
+#guard (0 : Ext4)⁻¹ == 0
+
+end BabyBear
+
+/-! ### Hachi, `X^4 - 2` -/
+
+section Hachi
+open Hachi
+
+private def haX : Ext4 := Ext.ofFn fun i => (7 * (i : ℕ) + 3 : ℕ)
+private def haY : Ext4 := Ext.ofFn fun i => (3 * (i : ℕ) + 1 : ℕ)
+
+#guard (ext4Gen ^ 4) == (2 : Ext4)
+#guard (haX + haY) * (haX - haY) == haX * haX - haY * haY
+#guard haX ^ 7 == haX * haX * haX * haX * haX * haX * haX
+#guard haX * haX⁻¹ == 1
+#guard haY * haY⁻¹ == 1
+#guard (0 : Ext4)⁻¹ == 0
+#guard (haX / haY) * haY == haX
+
+end Hachi
+
+end CompPolyTests.Fields.Extension

--- a/tests/CompPolyTests/Fields/Extension/Binomial.lean
+++ b/tests/CompPolyTests/Fields/Extension/Binomial.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+import CompPoly.Fields.Extension.Binomial
+import Mathlib.Tactic.NormNum.Prime
+import Mathlib.Tactic.ReduceModChar
+
+/-!
+# Binomial irreducibility criterion tests
+
+Cross-checks of `Polynomial.irreducible_X_pow_four_sub_C_iff_of_card` on `ZMod 5`, small enough
+that the answers can be confirmed independently by `decide`.
+
+Both directions are exercised: `X^4 - 2` is irreducible (`2` is a non-square mod `5`), while
+`X^4 - 1` is not. The second case is what makes the `iff` worth having — a failed check
+*proves* reducibility rather than merely failing to prove irreducibility.
+-/
+
+namespace CompPolyTests.Fields.Extension.Binomial
+
+open Polynomial
+
+instance : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+
+private theorem card_zmod5 : Fintype.card (ZMod 5) = 5 := ZMod.card _
+
+/-- `X^4 - 2` is irreducible over `ZMod 5`. -/
+theorem irreducible_X_pow_four_sub_two : Irreducible ((X : (ZMod 5)[X]) ^ 4 - C 2) :=
+  irreducible_X_pow_four_sub_C_of_card card_zmod5 (by decide) (by norm_num) (by norm_num)
+    (by reduce_mod_char) (by reduce_mod_char; decide)
+
+/-- Independent necessary-condition check: an irreducible quartic has no root in the base
+field. Confirms the criterion's verdict above is consistent with brute force. -/
+example : ∀ a : ZMod 5, a ^ 4 - 2 ≠ 0 := by decide
+
+/-- Conversely `X^4 - 1` is *reducible* over `ZMod 5`: the second Rabin condition fails,
+because `1` is a fourth power. -/
+theorem not_irreducible_X_pow_four_sub_one : ¬ Irreducible ((X : (ZMod 5)[X]) ^ 4 - C 1) := by
+  rw [irreducible_X_pow_four_sub_C_iff_of_card card_zmod5 (by decide) (by norm_num) (by norm_num)]
+  rintro ⟨-, hmid⟩
+  exact hmid (one_pow _)
+
+/-- And indeed `X^4 - 1` visibly has roots in `ZMod 5`, independently of the criterion. -/
+example : ((1 : ZMod 5) ^ 4 - 1 = 0) ∧ ((2 : ZMod 5) ^ 4 - 1 = 0) := by decide
+
+end CompPolyTests.Fields.Extension.Binomial


### PR DESCRIPTION
## Context

`ROADMAP.md` listed "computable field extensions with interface" as an unchecked Phase-1 item, and it blocks zkVM verification: modern STARK/AIR systems draw challenges and run DEEP/FRI queries in a degree-4 extension of a 31- or 32-bit prime, not in the base field.

`CompPoly/Fields/` previously had two disconnected halves — prime fields with no extensions at all, and a characteristic-2 stack whose irreducibility proofs are specific to char 2 (a quadratic trace-map criterion, or ~2100 lines of generated `BitVec` certificates for the single GHASH polynomial). Neither generalises.

This PR adds `CompPoly/Fields/Extension/`: a computable `F[X]/(X^d - W)` framework for odd characteristic, with a *general* irreducibility theorem in place of per-polynomial certificate grinding, plus three concrete degree-4 instances. `Binary/` is untouched.

## The key result

For a binomial, `X^d = W` reduces `X^(q^j) mod f` to a base-field power, so both of Rabin's conditions collapse to exponentiations **in the base field**:

> `X^d - W` is irreducible over `F_q` **iff** `W^((q^d - 1)/d) = 1` and `W^((q^(d/l) - 1)/d) != 1` for every prime `l | d`

(given the decidable side conditions `d | q^d - 1` and `d | q^(d/l) - 1`). Both directions are proved, so a failed check *proves* reducibility.

Each concrete extension's irreducibility is then two `reduce_mod_char` calls, which do modular repeated squaring during elaboration — no generated certificate files, no `native_decide`. The criterion was validated against brute-force Rabin on 1635 cases (`p <= 97`, `d` in {2,3,4,5,6,8}, zero mismatches) before any Lean was written.

## Layering

| Layer | File |
|---|---|
| Factor-degree pigeonhole | `ToMathlib/Polynomial/Irreducible.lean` |
| Rabin's test, any degree / any finite field | `Data/Polynomial/Rabin.lean` |
| Binomial collapse + `d = 4` corollaries | `Fields/Extension/Binomial.lean` |
| `BinomialParams`, carrier `Ext P`, ring ops | `Fields/Extension/Defs.lean` |
| `toQuot`, ring-hom + injectivity, `CommRing`, `Algebra` | `Fields/Extension/Bridge.lean` |
| Bijectivity, cardinality, inversion, `Field` | `Fields/Extension/Field.lean` |

`Data/Polynomial/Rabin.lean` generalises `irreducible_of_rabin_128_passed_over_GF2` from degree 128 over GF(2) to arbitrary degree over any finite field, reusing the existing `irreducible_dvd_X_pow_sub_X_iff_natDegree_dvd` in `Data/Polynomial/Frobenius.lean`. It does not yet *replace* it — `Binary/` is untouched, so two Rabin soundness proofs coexist; rebasing GHASH onto the general one is a named follow-up.

Concrete instances (~70 lines each): `KoalaBear/Ext4.lean` (`X^4 - 3`), `BabyBear/Ext4.lean` (`X^4 - 11`), and `Hachi.lean` + `Hachi/Ext4.lean` (`2^32 - 99`, `X^4 - 2`).

## What the interface provides

| Surface | Declarations |
|---|---|
| Ring / field | `CommRing (Ext P)`, `Field (Ext P)` (given `[Fact (Irreducible P.poly)]`) |
| Base field | `ofBase : F → Ext P`, `ofBaseRingHom`, `Algebra F (Ext P)` (hence `Module`) |
| Adjoined root | `gen`, `gen_pow_d : gen ^ d = ofBase W`, `aeval_gen_poly : aeval gen P.poly = 0` |
| Specification | `toQuot`, `ringEquivQuot : Ext P ≃+* AdjoinRoot P.poly` |
| Cardinality | `Fintype (Ext P)`, `card_ext : Fintype.card (Ext P) = q ^ d` |
| Coefficients | `coeff`, `ofFn`, `equivFn : Ext P ≃ (Fin d → F)` |

With `Algebra` in place, `aeval`, scalar towers and `Subalgebra` apply directly. The remaining interface gap is tower support: there is no `AlgebraTower` instance, so `F ⊂ Ext F 2 ⊂ Ext F 4` does not compose and the Mersenne31 CM31/QM31 stack is out of reach.

## Design notes

**The degree bound is structural, not a reused invariant.** `Ext P` has length exactly `d`, so there is no bound to carry. This subtree imports none of `CompPoly/Univariate/`; the one place a polynomial-side bound is needed (that `toQuot`'s representative is the canonical degree-`< d` one) is proved directly in `Bridge.lean` as `degree_repr_lt`. The `CPolynomial.degreeLT` theory exists but is *not* wired to this framework. *(An earlier revision of this description claimed it was reused — that was wrong and is corrected here and in the docs.)*

**`BinomialParams` is a type index**, so two different extensions of the same base field are different types whose instances cannot be confused. It carries the base-field cardinality as data because Fermat inversion evaluates the exponent at runtime and `Fintype.card (ZMod p)` would enumerate all of `Fin p`.

**Instances are assembled field-by-field, not via `Function.Injective.commRing` / `.field`.** Those transports take `toQuot` as *data*, which forces the instance `noncomputable`; `Monoid.toNatPow` then outranks `Ext.instPow` and compiled `x ^ n` fails to build. `*` and `+` kept working, so this only surfaced under `#eval` — which is why the tests exercise compiled evaluation specifically, and why the new `Algebra` layer (a second `SMul` path) was checked the same way.

The load-bearing lemma is `Ext.toQuot_mul`: `root ^ d = W` is exactly the wrap-around factor in `Ext.mul`, so the double sum defining the product regroups into the product of sums.

## Performance: measured, and not yet competitive

Please do not read this as performance-ready. Measured on KoalaBear degree 4 (`lake exe CompPolyBench --small`):

| Operation | Average |
|---|---|
| `mul` | ~13.5 us |
| `inv` | ~1.7 ms |

Causes, in priority order, all recorded in `docs/wiki/field-extensions.md` and `ROADMAP.md`:

1. **`Ext.mul` is O(d^3)** — `d` output coefficients x `d^2` pairs, nearly all zero — *and* separately allocates (nothing monomorphises since `P` is a runtime parameter; `@[specialize]` recovers ~6%). Schoolbook binomial reduction is **O(d^2)**: 16 term visits at `d = 4` rather than 64. A rewrite must drop the asymptotic shape, not just the allocations. The O(d^3) sum should stay as the spec, since `toQuot_mul` is proved against it.
2. **The base field is `ZMod p`**, i.e. boxed `Nat` arithmetic. `Ext P` is generic over the base carrier, so instantiating over the `FastField` Montgomery representation needs **no framework change**.
3. **Inversion is Fermat.** A norm-based inverse via Frobenius (a coordinate-wise scaling when `d | q - 1`) should be ~10x faster.

## Verification

- `lake build` and `lake test` pass; `lint-style.sh`, `check-imports.sh`, `check-docs-integrity.py` clean.
- No `sorry` and no `native_decide`. `#print axioms` on the irreducibility theorems, `toQuot_mul`, `instField`, `instAlgebra`, `gen_pow_d` and `aeval_gen_poly` shows only `propext`, `Classical.choice`, `Quot.sound` — no `Lean.ofReduceBool`, so the TCB policy holds.
- `tests/.../Extension/Arithmetic.lean`: `#guard` regressions over all three extensions — the defining relation, ring identities, `x * x⁻¹ = 1`, `0⁻¹ = 0`, `(x/y)*y = x`, binary `^` vs repeated multiplication, and hand-computed wrap-around products for **both** KoalaBear (`W = 3`) and BabyBear (`W = 11`). Plus guards that the `Algebra` layer is computable and that `c • x = algebraMap c * x` holds computationally.
- `tests/.../Extension/Binomial.lean`: validates the criterion on `ZMod 5` where ground truth is `decide`-able, both directions, each verdict cross-checked against brute-force root search.
- Four benchmark groups registered in `BENCH_CI_GROUPS`.

## Notes for review

- `Hachi` is a provisional name for `2^32 - 99`, and `Fields/README.md` frames it as a 32-bit *example* rather than a production target. Happy to rename or split it out.
- It has no `FastField` path: `Mont32Field` requires `modulus < 2^31` because radix-`2^32` reduction needs `x + m*p < 2^64`. Its two-adicity is also 2, so no radix-2 NTT domain exists for it. Both are in the module docstring.
- Deferred and recorded rather than dropped: O(d^2) mul, `FastField` base carrier, norm-based inversion, `AlgebraTower` towers, 64-bit Montgomery, and the GHASH Rabin rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
