### PR TITLE
doc: correct ROADMAP Phase 2 status and stale doc references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,10 @@ Human contributors should usually start with [`README.md`](README.md),
   multilinear polynomials.
 - `CompPoly/Bivariate/` - specialized bivariate layer built from nested
   univariate polynomials.
-- `CompPoly/Fields/` - concrete field instances plus the binomial field-extension
-  framework (`Fields/Extension/`) and binary-field, GHASH, and additive-NTT
-  infrastructure.
+- `CompPoly/Fields/` - concrete field instances plus the computable
+  field-extension framework (`Fields/Extension/`, `F[X]/f` for an arbitrary monic
+  `f`, with binomials `X^d - W` as the ergonomic special case) and binary-field,
+  GHASH, and additive-NTT infrastructure.
 - `CompPoly/Data/` - reusable supporting lemmas and helper definitions.
 - `CompPoly/ToMathlib/` - local bridge lemmas and Mathlib-facing support code.
 - `tests/` - regression coverage under the `CompPolyTests` namespace.
@@ -62,7 +63,9 @@ Human contributors should usually start with [`README.md`](README.md),
 - [`docs/wiki/binary-fields-and-ntt.md`](docs/wiki/binary-fields-and-ntt.md) -
   binary-field stack, GHASH, and additive NTT.
 - [`docs/wiki/field-extensions.md`](docs/wiki/field-extensions.md) - computable
-  binomial field extensions and their irreducibility criterion.
+  field extensions for an arbitrary monic modulus, and their two irreducibility
+  paths: Rabin's test collapsed to base-field exponentiations for binomials,
+  kernel-checked Rabin certificates otherwise.
 
 ## Canonical Project Docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ The description should include:
 
 ## Style and Naming Guidelines
 We aim to adhere to the [Lean community's contribution guidelines](https://github.com/leanprover-community/leanprover-community.github.io/tree/lean4/templates/contribute).
-Our [linting script](`./scripts/lint-style.sh`) helps enforce some aspects of these guidelines.
+Our [linting script](scripts/lint-style.sh) helps enforce some aspects of these guidelines.
 
 ### Naming Conventions
 
@@ -233,7 +233,7 @@ When referencing papers in Lean docstrings:
   ```
   Format: `* [Author Last Name, First Initial, *Title*][citation_key]`.
 
-* **Add BibTeX entries**: All academic papers must have entries in `blueprint/src/references.bib`. When adding a new paper, add the BibTeX entry, use the citation key in your Lean file, and list it in the References section.
+* **Add BibTeX entries**: All academic papers must have entries in [`blueprint/src/references.bib`](blueprint/src/references.bib). When adding a new paper, add the BibTeX entry, use the citation key in your Lean file, and list it in the References section. That file is currently a standalone bibliography — there is no rendered leanblueprint project yet — and its header records the `grep` that lists cited-but-missing keys.
 
 * **Non-academic references**: Implementation references (GitHub repos, specifications) may include URLs directly and typically don't need BibTeX entries.
 

--- a/CompPoly/Univariate/README.md
+++ b/CompPoly/Univariate/README.md
@@ -18,8 +18,8 @@ Formally verified computable univariate polynomials for [CompPoly](../../README.
 - **Raw/Division.lean** — Raw polynomial division APIs (`divByMonic`, `modByMonic`, `div`, `mod`).
 - **Raw/Proofs.lean** — Proof layer for the raw API (algebraic laws and operation correctness).
 - **Basic.lean** — Canonical `CPolynomial` with ring structure (Add, Mul, Zero, One, etc.).
-- **Quotient.lean** — Quotient type and operations descending from `Raw`.
-- **QuotientEquiv.lean** — Equivalence between the quotient representation and canonical `CPolynomial`.
+- **Quotient/Core.lean** — Quotient type and operations descending from `Raw`.
+- **Quotient/Equiv.lean** — Equivalence between the quotient representation and canonical `CPolynomial`.
 - **ToPoly.lean** — Umbrella import for conversion/equivalence with Mathlib's `Polynomial R`.
 - **ToPoly/Core.lean** — Core conversion maps and API lemmas.
 - **ToPoly/Equiv.lean** — Round-trip theorems and ring equivalence with Mathlib polynomials.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,7 +99,21 @@ CompPoly aims to be the premier formally verified library for computable polynom
 
 #### Priorities
 1. **Fast field arithmetic**
-   - Optimized implementations of off-the-shelf available Field instances to enable performance, including for prime and other finite fields
+   - ✅ Radix-generic Montgomery reduction shared by every fast prime field
+     (`Fields/Montgomery/Basic.lean`)
+   - ✅ Single-word `UInt32` Montgomery carrier for 31-bit primes
+     (`Montgomery/Native32.lean`, `Montgomery/Native32Field.lean`, `Mont32Field`),
+     instantiated by `BabyBear/Fast.lean` and `KoalaBear/Fast.lean`
+   - ✅ Eight-limb Montgomery carrier with CIOS multiplication for moduli below
+     `2^255` (`Montgomery/Native64x8*.lean`, `Mont64x8Field`), instantiated by
+     `BN254/Fast.lean`, `BLS12_381/Fast.lean`, and `BLS12_377/Fast.lean`
+   - ✅ Checked binary-GCD inversion for the eight-limb fields
+     (`Montgomery/Native64x8Inv.lean`, [eprint 2020/972](https://eprint.iacr.org/2020/972)),
+     benchmarked against `ZMod` extended Euclid and Fermat in `fields-mont64x8-*-inv`
+   - 🔄 64-bit-radix Montgomery layer, so Goldilocks and Hachi (`2^32 - 99`) gain a
+     `FastField` base; `Mont32Field` requires modulus < `2^31`
+   - 🔄 Instantiate `Extension.Ext` over a Montgomery carrier rather than `ZMod`
+     (see the extension performance notes under Phase 1)
 
 2. **Polynomial multiplication**
    - ✅ Radix-2 NTT domain, forward/inverse transforms, and reference fast multiply (`Univariate/NTT/`)
@@ -118,7 +132,9 @@ CompPoly aims to be the premier formally verified library for computable polynom
    - ✅ Batch evaluation at multiple points: naive, Horner, and subproduct-tree algorithms (`Univariate/BatchEval/`)
    - ✅ Subproduct-tree batch eval with configurable multiply/remainder backends (naive, NTT, NTTFast)
    - ✅ Add Horner's method where beneficial
-   - Optimize for common ZK evaluation patterns
+   - ✅ Many-polynomial, one-shared-point evaluation — the common commitment-opening
+     shape — with correctness proofs (`Univariate/ManyEval/`, `Multilinear/ManyEval/`)
+   - 🔄 Optimize for further common ZK evaluation patterns
 
 5. **Complete multilinear transform functions**
    - ✅ Complete documentation of zeta/Möbius transform formulas
@@ -131,15 +147,64 @@ CompPoly aims to be the premier formally verified library for computable polynom
    - 🔄 Expand regression coverage and published performance baselines
 
 7. **Bivariate polynomial operations**
-   - Optimize the existing bivariate polynomial type `CPolynomial (CPolynomial R)` and evaluate whether a more specialized representation is beneficial
-   - Efficient factorization algorithms for bivariate polynomials
+   - ✅ Optimize the existing bivariate polynomial type `CPolynomial (CPolynomial R)`:
+     Kronecker substitution (`Bivariate/Kronecker.lean`) turns a bivariate
+     multiplication into a single univariate one (`kroneckerPack_mul`,
+     `kroneckerUnpack_mul`), with linear-time `kroneckerPackFast` /
+     `kroneckerUnpackFast` proved equal to the spec versions and NTT-backed
+     `kroneckerUnpack_withFallback`. Benchmarked as `bivariate-full-*`. The nested
+     representation was kept; no more specialized one proved necessary.
+   - 🔄 Efficient factorization algorithms for bivariate polynomials. What exists
+     is linear-factor deflation rather than general factorization:
+     `Bivariate/Factor.lean` defines `divByLinearY` (the computable factor theorem,
+     over any `CommRing`) and `Bivariate/FactorMonic.lean` proves
+     `divByLinearY_eq_divByMonic`, tying it to general monic Euclidean division.
+     Benchmarked as `bivariate-deflate-*`.
    - ✅ Integration with existing `CMvPolynomial 2 R` with equivalence proofs
 
-7. **Error-correcting interpolation algorithms**
-   - Implement Berlekamp-Welch algorithm for Reed-Solomon decoding
-   - Implement Guruswami-Sudan list-decoding algorithm
-   - Proofs of correctness
+8. **Error-correcting interpolation algorithms**
+   - ✅ Reed-Solomon encoding through the forward NTT
+     (`Univariate/ReedSolomon/NTTEncode.lean`): `forwardImpl_eq_encode` and
+     `nttCodeword_eq_encode` identify the `O(n log n)` transform with
+     `ReedSolomon.encode` exactly, with no padding required
+   - ✅ Unique decoding via Gao's key-equation decoder
+     (`ReedSolomon/GaoDecoder.lean`, [Gao02]) with `GaoCorrectness.lean`:
+     `decode_sound`, `decode_eq_some`, `decode_eq_none_iff`, and
+     `decode_none_farness`, which reads decoder refusal as a farness certificate
+   - ✅ Implement Guruswami-Sudan list-decoding algorithm
+     (`Bivariate/GuruswamiSudan/`), following the interpolation-and-root-finding
+     decomposition of [GS99]: a backend-parametric `Core` / `Context` with dense
+     and Lee-O'Sullivan ([LOS06]) interpolation and Roth-Ruckenstein ([RR00]) and
+     Alekhnovich ([Ale05]) root search, instantiated in `Implementations` and
+     `Executable`
+   - ✅ Proofs of correctness: `gsCore_sound`, `gsCore_complete_of_interpolate`,
+     and `gsCore_complete_of_roots_all_valid_witnesses` in `CoreCorrectness.lean`,
+     stated against the context contracts so they hold for every backend
+   - Berlekamp-Welch decoding. Gao's decoder already covers the same
+     unique-decoding regime, so this is worth adding only as a cross-check, or if a
+     downstream specification asks for it by name.
    - Integration with FRI commitments and polynomial commitment schemes
+
+9. **Univariate root finding**
+   - ✅ Backend-parametric root pipeline (`Univariate/Roots/`): the `Backend`,
+     `Context`, and `Splitter` interfaces, candidate extraction / validation /
+     deduplication (`Extraction.lean`), `RootProduct.lean`, and `Correctness.lean`
+   - ✅ Smooth multiplicative-subgroup refinement splitting for finite fields whose
+     multiplicative group admits a smooth schedule ([MOV92],
+     `Roots/SmoothSubgroup/`), benchmarked as `univariate-roots-finite-field-*`
+   - 🔄 Splitting strategies for fields with no smooth refinement schedule
+
+10. **Computable linear algebra**
+    - ✅ Dense row-major matrices with row operations, RREF shape and semantics, and
+      kernel extraction, each with a `*Correctness.lean` companion
+      (`LinearAlgebra/Dense/`)
+    - ✅ In-place kernel solver (`Dense/KernelInPlace.lean`) with correctness, used
+      by the dense Guruswami-Sudan interpolation backend
+    - ✅ Polynomial matrices with shifted degrees and row spans, plus
+      Mulders-Storjohann shifted row reduction ([MS03],
+      `LinearAlgebra/PolynomialMatrix/`). The fast variants are proved extensionally
+      equal to the direct ones in `MuldersStorjohannCorrectness/Fast.lean`, so every
+      correctness result transfers.
 
 **Success Criteria**: notable speedup for large polynomial operations, verified correctness, benchmarks demonstrating competitive performance with industry-standard implementations.
 

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -1,0 +1,177 @@
+% CompPoly bibliography.
+%
+% Every citation key used in a Lean docstring must have an entry here; see the
+% "Citation Standards" section of CONTRIBUTING.md. Keys are cited from Lean as
+% `[Author, *Title*][Key]` inside a `## References` block.
+%
+% To find keys that are cited but missing from this file:
+%
+%   grep -rho '\]\[[A-Za-z][A-Za-z0-9+]*\]' --include='*.lean' CompPoly/ \
+%     | sort -u
+%
+% (That grep also matches `[...][Y]` and `[...][x]` from ordinary Lean indexing
+% notation; ignore those two.)
+
+% ---------------------------------------------------------------------------
+% Coding theory: Reed-Solomon encoding and decoding
+% ---------------------------------------------------------------------------
+
+@article{GS99,
+  author  = {Guruswami, Venkatesan and Sudan, Madhu},
+  title   = {Improved decoding of {Reed--Solomon} and algebraic-geometry codes},
+  journal = {IEEE Transactions on Information Theory},
+  volume  = {45},
+  number  = {6},
+  pages   = {1757--1767},
+  year    = {1999},
+  doi     = {10.1109/18.782097}
+}
+
+@incollection{Gao02,
+  author    = {Gao, Shuhong},
+  title     = {A new algorithm for decoding {Reed--Solomon} codes},
+  booktitle = {Communications, Information and Network Security},
+  editor    = {Bhargava, Vijay K. and Poor, H. Vincent and Tarokh, Vahid and
+               Yoon, Seokho},
+  series    = {The Springer International Series in Engineering and Computer
+               Science},
+  volume    = {712},
+  pages     = {55--68},
+  publisher = {Springer},
+  year      = {2003},
+  doi       = {10.1007/978-1-4757-3789-9_5},
+  note      = {Manuscript circulated from 2002; cited as \texttt{Gao02}}
+}
+
+@article{RR00,
+  author  = {Roth, Ron M. and Ruckenstein, Gitit},
+  title   = {Efficient decoding of {Reed--Solomon} codes beyond half the minimum
+             distance},
+  journal = {IEEE Transactions on Information Theory},
+  volume  = {46},
+  number  = {1},
+  pages   = {246--257},
+  year    = {2000},
+  doi     = {10.1109/18.817522}
+}
+
+@article{Ale05,
+  author  = {Alekhnovich, Michael},
+  title   = {Linear {Diophantine} equations over polynomials and soft decoding of
+             {Reed--Solomon} codes},
+  journal = {IEEE Transactions on Information Theory},
+  volume  = {51},
+  number  = {7},
+  pages   = {2257--2265},
+  year    = {2005},
+  doi     = {10.1109/TIT.2005.850102}
+}
+
+@article{LOS06,
+  author  = {Lee, Kwankyu and O'Sullivan, Michael E.},
+  title   = {List decoding of {Reed--Solomon} codes from a {Gr\"obner} basis
+             perspective},
+  journal = {Journal of Symbolic Computation},
+  volume  = {43},
+  number  = {9},
+  pages   = {645--658},
+  year    = {2008},
+  doi     = {10.1016/j.jsc.2008.01.002},
+  note    = {Preprint \texttt{arXiv:math/0601022} (2006); cited as \texttt{LOS06}}
+}
+
+@inproceedings{LCH14,
+  author    = {Lin, Sian-Jheng and Chung, Wei-Ho and Han, Yunghsiang S.},
+  title     = {Novel polynomial basis and its application to {Reed--Solomon}
+               erasure codes},
+  booktitle = {55th Annual IEEE Symposium on Foundations of Computer Science
+               (FOCS)},
+  pages     = {316--325},
+  year      = {2014},
+  doi       = {10.1109/FOCS.2014.41}
+}
+
+% ---------------------------------------------------------------------------
+% Root finding, polynomial arithmetic, and linear algebra
+% ---------------------------------------------------------------------------
+
+@article{MOV92,
+  author  = {Menezes, Alfred J. and van Oorschot, Paul C. and
+             Vanstone, Scott A.},
+  title   = {Subgroup refinement algorithms for root finding in {$GF(q)$}},
+  journal = {SIAM Journal on Computing},
+  volume  = {21},
+  number  = {2},
+  pages   = {228--239},
+  year    = {1992},
+  doi     = {10.1137/0221017}
+}
+
+@article{MS03,
+  author  = {Mulders, Thom and Storjohann, Arne},
+  title   = {On lattice reduction for polynomial matrices},
+  journal = {Journal of Symbolic Computation},
+  volume  = {35},
+  number  = {4},
+  pages   = {377--401},
+  year    = {2003},
+  doi     = {10.1016/S0747-7171(02)00139-6}
+}
+
+@inproceedings{GGJ96,
+  author    = {von zur Gathen, Joachim and Gerhard, J\"urgen},
+  title     = {Arithmetic and factorization of polynomials over {$\mathbb{F}_2$}
+               (extended abstract)},
+  booktitle = {Proceedings of the 1996 International Symposium on Symbolic and
+               Algebraic Computation (ISSAC '96)},
+  pages     = {1--9},
+  publisher = {ACM},
+  year      = {1996},
+  doi       = {10.1145/236869.236882},
+  note      = {Cited in the Lean sources as \texttt{GGJ96}}
+}
+
+@book{Lan02,
+  author    = {Lang, Serge},
+  title     = {Algebra},
+  edition   = {3},
+  series    = {Graduate Texts in Mathematics},
+  volume    = {211},
+  publisher = {Springer},
+  year      = {2002},
+  doi       = {10.1007/978-1-4613-0041-0}
+}
+
+% ---------------------------------------------------------------------------
+% Binary towers
+% ---------------------------------------------------------------------------
+
+@misc{DP23,
+  author       = {Diamond, Benjamin E. and Posen, Jim},
+  title        = {Succinct arguments over towers of binary fields},
+  howpublished = {Cryptology ePrint Archive, Paper 2023/1784},
+  year         = {2023},
+  url          = {https://eprint.iacr.org/2023/1784}
+}
+
+@misc{DP24,
+  author       = {Diamond, Benjamin E. and Posen, Jim},
+  title        = {Polylogarithmic proofs for multilinears over binary towers},
+  howpublished = {Cryptology ePrint Archive, Paper 2024/504},
+  year         = {2024},
+  url          = {https://eprint.iacr.org/2024/504}
+}
+
+% ---------------------------------------------------------------------------
+% Cited from docs/wiki/field-extensions.md rather than a Lean docstring.
+% TODO: fill in author and title from the ePrint before relying on this entry.
+% ---------------------------------------------------------------------------
+
+@misc{ABF26,
+  title        = {Cryptology ePrint Archive, Paper 2026/680},
+  howpublished = {Cryptology ePrint Archive, Paper 2026/680},
+  year         = {2026},
+  url          = {https://eprint.iacr.org/2026/680},
+  note         = {Parameter point behind ArkLib's \texttt{KoalaSextic};
+                  author list and title not yet transcribed}
+}

--- a/docs/wiki/representations-and-bridges.md
+++ b/docs/wiki/representations-and-bridges.md
@@ -10,7 +10,7 @@ usually the first architectural decision in a change.
 | Univariate | `CPolynomial.Raw R`, `CPolynomial R`, `QuotientCPolynomial R` | Canonical coefficient-sequence arithmetic, quotient reasoning, interpolation | `CompPoly/Univariate/README.md`, `CompPoly/Univariate/Basic.lean`, `CompPoly/Univariate/ToPoly.lean` |
 | Multivariate | `CMvPolynomial n R` | Sparse computable multivariate operations and `MvPolynomial` interop | `CompPoly/Multivariate/CMvPolynomial.lean`, `CompPoly/Multivariate/Operations.lean`, `CompPoly/Multivariate/MvPolyEquiv.lean` |
 | Multilinear | `CMlPolynomial R n`, `CMlPolynomialEval R n` | Boolean-hypercube evaluation form, basis conversion, multilinear extensions | `CompPoly/Multilinear/Basic.lean`, `CompPoly/Multilinear/Equiv.lean` |
-| Field extensions | `Extension.Ext P` | Computable `F[X]/(X^d - W)` arithmetic for challenge fields | `CompPoly/Fields/Extension.lean`, `docs/wiki/field-extensions.md` |
+| Field extensions | `Extension.Ext P` | Computable `F[X]/f` arithmetic for challenge fields, `f` an arbitrary monic modulus | `CompPoly/Fields/Extension.lean`, `docs/wiki/field-extensions.md` |
 | Bivariate | `CBivariate R` | Specialized two-variable APIs and `R[X][Y]` transport | `CompPoly/Bivariate/README.md`, `CompPoly/Bivariate/Basic.lean`, `CompPoly/Bivariate/ToPoly.lean`, `CompPoly/ToMathlib/Polynomial/BivariateDegree.lean`, `CompPoly/ToMathlib/Polynomial/BivariateWeightedDegree.lean`, `CompPoly/ToMathlib/Polynomial/BivariateMultiplicity.lean` |
 
 ## Univariate Family
@@ -141,8 +141,10 @@ specific polynomial representation.
 ## Field Extensions
 
 `CompPoly.Extension.Ext P` is a *fixed-length* dense representation, unlike the
-polynomial surfaces above: `Vector F P.d`, where `P : BinomialParams F` pins the degree
-and the constant `W` of the defining binomial `X^d - W`.
+polynomial surfaces above: `Vector F P.d`, where `P : ExtensionParams F` carries the
+degree `d`, the lower coefficients of the monic modulus `f`, and the base-field
+cardinality `q` as a type index. Binomials `X^d - W` are the ergonomic special case,
+entered through `BinomialParams.toExtensionParams`.
 
 The bridge is
 [`../../CompPoly/Fields/Extension/Bridge.lean`](../../CompPoly/Fields/Extension/Bridge.lean),

--- a/docs/wiki/typeclass-minimization.md
+++ b/docs/wiki/typeclass-minimization.md
@@ -55,7 +55,7 @@ theorem support_spec {R : Type*} [Zero R] [BEq R] (p : Foo R) : ... := ...
 
 These examples come directly from the recent typeclass-tightening refactor.
 
-- `CompPoly/Univariate/Quotient.lean` now defines the quotient carrier at
+- `CompPoly/Univariate/Quotient/Core.lean` now defines the quotient carrier at
   `Zero` level because coefficientwise equivalence only needs zero-padding:
 
 ```lean
@@ -85,15 +85,17 @@ lemma neg_coeff {R : Type*} [NegZeroClass R] (p : CPolynomial.Raw R) (i : ℕ) :
 ```
 
 - `CompPoly/Univariate/Raw/Division.lean` no longer carries a blanket `Ring`
-  assumption at section scope because every definition already has its own
-  `[Field R]` requirement:
+  assumption at section scope. Only `[BEq R]` is shared; each definition then
+  states what it actually needs, and the three monic-division definitions turn out
+  to need no inverses at all:
 
 ```lean
 section Division
 
 variable [BEq R]
 
-def divModByMonicAux [Field R] ...
+def divModByMonicAux [CommRing R] ...   -- also divByMonic, modByMonic
+def subScaledShift [Field R] ...        -- the rest genuinely need inverses
 ```
 
 ## Review Checklist

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,7 +10,9 @@ For example:
 - library module: `CompPoly/Univariate/Raw.lean`
 - test module: `tests/CompPolyTests/Univariate/Raw.lean`
 
-Some tests are cross-cutting rather than one-to-one mirrors (for example, `CompPolyTests/BF128GhashPrelude.lean`).
+Some tests are cross-cutting rather than one-to-one mirrors, and some mirror a
+whole subtree rather than a single module (for example,
+`tests/CompPolyTests/Fields/Binary/BF128Ghash/`).
 
 ## Running tests
 


### PR DESCRIPTION
A documentation audit against the current source tree found that `ROADMAP.md` Phase 2 lists work as not-yet-started that is implemented and proved. Someone planning from it would duplicate finished work. This PR fixes the status claims and the dead references found alongside them; a follow-up PR covers the subtrees that have no docs at all.

## ROADMAP Phase 2

Every ✅ added below names a declaration that exists — see the verification section.

| Item | Was | Now |
|---|---|---|
| 1. Fast field arithmetic | unmarked | ✅ ×4, 🔄 ×2 |
| 4. Evaluation optimizations | 3 ✅ | + ✅ `ManyEval` |
| 7. Bivariate optimization | unmarked | ✅ Kronecker substitution |
| 7. Bivariate factorization | unmarked | 🔄, scope corrected |
| 8. GS list decoding | unmarked | ✅ |
| 8. GS correctness proofs | unmarked | ✅ |
| 8. Gao decoder, NTT-as-encoder | absent | ✅ (new) |
| 8. Berlekamp-Welch | unmarked | unmarked, with a note |
| 9. Root finding | absent | new item |
| 10. Computable linear algebra | absent | new item |

Notes on the judgment calls:

- **Fast field arithmetic** is marked done for the fields that have it — the radix-generic Montgomery reduction, `Mont32Field` for BabyBear/KoalaBear, and the eight-limb `Mont64x8Field` with CIOS multiplication and checked binary-GCD inversion for BN254/BLS12-381/BLS12-377. Two 🔄 items remain: a 64-bit-radix layer so Goldilocks and Hachi get a `FastField` base, and instantiating `Extension.Ext` over a Montgomery carrier instead of `ZMod`.
- **Bivariate factorization** stays 🔄, but the bullet now says what exists. `Bivariate/Factor.lean` is linear-factor deflation (`divByLinearY`, the computable factor theorem), not general factorization. The old unqualified bullet read as though nothing had been done.
- **Berlekamp-Welch** stays unticked because it genuinely does not exist, with a note that Gao's decoder already covers the same unique-decoding regime — so it is worth adding only as a cross-check or if a downstream spec asks for it by name.
- Also fixes the duplicate `7.` list numbering.

**Left for a maintainer to decide:** V1.0 criterion "at least one real integration example" stays unticked. `KoalaBear/Ext6/GaloisField.lean` *enables* ArkLib's `KoalaSextic`, but enabling is not demonstrating, so I did not tick it.

## Dead references

None of these were visible to CI: `check-docs-integrity.py` validates markdown link syntax only, and backticked paths are how the docs mostly cite files. The follow-up PR closes that hole.

| Reference | Problem | Fix |
|---|---|---|
| `blueprint/src/references.bib` | Required by CONTRIBUTING.md; **did not exist**, leaving 12 citation keys unresolvable | Created, covering every key cited from a Lean docstring |
| `CompPoly/Univariate/Quotient.lean` | Split into `Quotient/Core.lean` + `Quotient/Equiv.lean` | Repointed in the wiki and the subtree README |
| `CompPolyTests/BF128GhashPrelude.lean` | Now a subtree | Repointed to `tests/CompPolyTests/Fields/Binary/BF128Ghash/` |
| `divModByMonicAux [Field R]` | Is `[CommRing R]` | Snippet corrected |
| CONTRIBUTING.md linter link | Backticks inside the URL, renders broken on GitHub | Fixed |

On the bibliography: this adds `src/references.bib` only, not a rendered leanblueprint project, and CONTRIBUTING now says so. The file header records the `grep` that lists cited-but-missing keys. One entry, `ABF26`, is a **stub** — `field-extensions.md` cites it as ePrint 2026/680 without naming authors, and I would rather leave a TODO than invent them.

## Stale "binomial" wording

`Fields/Extension/` took arbitrary monic moduli as of the degree-5 and degree-6 KoalaBear extensions. `Fields/README.md` and `field-extensions.md` already describe it correctly; `AGENTS.md` and `representations-and-bridges.md` still said "binomial". Since `CLAUDE.md` symlinks to `AGENTS.md`, that was the first thing every agent read.

## Verification

- `python3 ./scripts/check-docs-integrity.py` passes.
- Every declaration named in the new ROADMAP text exists (`gsCore_sound`, `decode_eq_none_iff`, `forwardImpl_eq_encode`, `kroneckerUnpack_mul`, `divByLinearY_eq_divByMonic`, `Mont32Field`, `Mont64x8Field`, …).
- Every citation key cited from a Lean docstring resolves against the new bib.
- Confirmed the ROADMAP's zero-`sorry` criterion still holds: the five `sorry`s in `Fields/PrattCertificate.lean` are all inside commented-out blocks.

No `.lean` files are touched, so no rebuild is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)