### PR TITLE
doc: document the coding-theory stack and guard path drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,18 @@ Human contributors should usually start with [`README.md`](README.md),
 ## Where To Work
 
 - `CompPoly/Univariate/` - canonical univariate representation, quotient model,
-  interpolation, and Mathlib bridges.
+  interpolation, and Mathlib bridges, plus the NTT transforms, batch evaluation,
+  root finding (`Univariate/Roots/`), and Reed-Solomon encoding and Gao decoding
+  (`Univariate/ReedSolomon/`).
 - `CompPoly/Multivariate/` - sparse computable multivariate polynomials,
   operations, renaming, restriction, and `MvPolynomial` equivalences.
 - `CompPoly/Multilinear/` - coefficient and Boolean-hypercube evaluation forms for
   multilinear polynomials.
 - `CompPoly/Bivariate/` - specialized bivariate layer built from nested
-  univariate polynomials.
+  univariate polynomials, including the Guruswami-Sudan list decoder
+  (`Bivariate/GuruswamiSudan/`).
+- `CompPoly/LinearAlgebra/` - executable dense matrices and polynomial matrices
+  with shifted row reduction; the engines under the decoder.
 - `CompPoly/Fields/` - concrete field instances plus the computable
   field-extension framework (`Fields/Extension/`, `F[X]/f` for an arbitrary monic
   `f`, with binomials `X^d - W` as the ergonomic special case) and binary-field,
@@ -62,6 +67,8 @@ Human contributors should usually start with [`README.md`](README.md),
   minimal typeclass assumptions and no-blanket-scope guidance.
 - [`docs/wiki/binary-fields-and-ntt.md`](docs/wiki/binary-fields-and-ntt.md) -
   binary-field stack, GHASH, and additive NTT.
+- [`docs/wiki/coding-theory.md`](docs/wiki/coding-theory.md) - Reed-Solomon
+  encoding, unique and list decoding, root finding, and the matrix layer.
 - [`docs/wiki/field-extensions.md`](docs/wiki/field-extensions.md) - computable
   field extensions for an arbitrary monic modulus, and their two irreducibility
   paths: Rabin's test collapsed to base-field exponentiations for binomials,

--- a/CompPoly/Bivariate/README.md
+++ b/CompPoly/Bivariate/README.md
@@ -12,7 +12,21 @@ Formally verified computable bivariate polynomials for [CompPoly](../../README.m
 
 - **Basic.lean** — Type definition, constructors (`CC`, `C_X`, `Y`, `monomialXY`), operations (`coeff`, `evalX`, `evalY`, `evalEval`, `natDegreeX`, `natDegreeY`, `totalDegree`, `natWeightedDegree`, `leadingCoeffY`, `leadingCoeffX`, `swap`, `support`).
 - **ToPoly.lean** — Conversion to/from Mathlib's `R[X][Y]` via `toPoly` and `ofPoly`, with round-trip theorems, ring equivalence, and correctness lemmas for coefficients, evaluation, support, and degree APIs.
-- **Kronecker.lean** — Kronecker substitution (`kroneckerPack`, `kroneckerUnpack`) reducing bivariate multiplication to one univariate multiplication, with multiplicativity of packing and round-trip correctness under an X-degree bound (`kroneckerUnpack_mul`).
+- **Kronecker.lean** — Kronecker substitution (`kroneckerPack`, `kroneckerUnpack`) reducing bivariate multiplication to one univariate multiplication, with multiplicativity of packing and round-trip correctness under an X-degree bound (`kroneckerUnpack_mul`). Linear-time `*Fast` variants are proved equal to these, and `kroneckerUnpack_withFallback` routes the inner multiply through an NTT when a domain fits.
+- **CoeffRows.lean** — Conversions between finite `Y`-coefficient rows and `CBivariate`.
+- **CMvEquiv.lean** — Ring equivalence `CBivariate R ≃+* CMvPolynomial 2 R`, composing `CBivariate.ringEquiv` with `finSuccEquiv` and `isEmptyRingEquiv`.
+- **Deriv.lean** — Partial derivatives (`partialDerivX`, `partialDerivY`, iterated and mixed) and the multiplicity condition `hasMultiplicity`, defined through the Taylor shift `shiftC a b Q = Q(X + a, Y + b)`. This is the multiplicity used by the Guruswami-Sudan interpolation step.
+- **Factor.lean** — `evalYPoly`, `isLinearYFactor`, and `divByLinearY`: the computable factor theorem for the nested representation, deflating by a linear factor `Y - f(X)` over an arbitrary commutative ring.
+- **FactorMonic.lean** — `divByLinearY_eq_divByMonic`, showing the bespoke synthetic division agrees with general monic Euclidean division at the coefficient ring `CPolynomial R`, so `divByLinearY` is a verified fast path.
+
+## Guruswami-Sudan list decoder
+
+**GuruswamiSudan/** is a 40-file subtree implementing Reed-Solomon list decoding on
+top of this representation: a backend-parametric `Core` with dense and
+Lee-O'Sullivan interpolation, Roth-Ruckenstein and Alekhnovich root search, and
+soundness and completeness for each. It has its own wiki page —
+[`../../docs/wiki/coding-theory.md`](../../docs/wiki/coding-theory.md) — and is the
+main consumer of `Deriv.lean` and `Factor.lean` above.
 
 Mathlib-facing helper files for `R[X][Y]` live under `CompPoly/ToMathlib/Polynomial/`:
 - [`../ToMathlib/Polynomial/BivariateDegree.lean`](../ToMathlib/Polynomial/BivariateDegree.lean)

--- a/CompPoly/LinearAlgebra/README.md
+++ b/CompPoly/LinearAlgebra/README.md
@@ -1,0 +1,92 @@
+# Computable Linear Algebra
+
+Executable matrices for [CompPoly](../../README.md), in two independent flavours:
+dense matrices over a field, and row-oriented matrices whose entries are
+univariate polynomials. Both exist to serve the Guruswami-Sudan interpolation
+backends (see [`../../docs/wiki/coding-theory.md`](../../docs/wiki/coding-theory.md)),
+but neither depends on the decoder and both are usable on their own.
+
+## Types
+
+| Type | Description |
+|------|-------------|
+| `DenseMatrix F` | Dense row-major storage: a flat `Array F` plus `rows` and `cols`. `WellFormed` asserts `data.size = rows * cols`. |
+| `RrefResult F` | The output of row reduction: the reduced matrix together with its pivot columns. |
+| `PolynomialRow F` | A row of univariate polynomials, `Array (CPolynomial F)`. |
+| `PolynomialMatrix F` | An array of `PolynomialRow`s, with no shape invariant baked in. |
+
+## Dense matrices (`Dense/`)
+
+| Module | Description |
+|--------|-------------|
+| **Basic.lean** | `DenseMatrix`, `WellFormed`, `index`/`get`/`set`, and the homogeneous-system predicates. |
+| **RowOps.lean** | Executable row operations (`swapRows`, `scaleRow`, `addScaledRow`, `findPivotRow`, `normalizeAndEliminate`) and Gauss-Jordan reduction `rref`, returning an `RrefResult`. |
+| **RowOpsCorrectness.lean** | Proof layer for the individual row operations. |
+| **RrefSemantics.lean** | Semantic preservation and reflection lemmas for row reduction — what `rref` preserves about the solution set. |
+| **RrefShape.lean** | The shape invariants: `PivotColumnsShaped`, `PivotColumnsStrict`, `ProcessedColumnsZeroBelow`. |
+| **Kernel.lean** | Homogeneous-kernel extraction from a reduced matrix: `freeColumns`, `basisVectorForFreeColumn`, `homogeneousKernelBasis`, `homogeneousWitness`. |
+| **KernelCorrectness.lean** | `homogeneousWitness_eq_none_iff` and `homogeneousWitness_exists_of_rows_lt_cols` — a wide homogeneous system always has a nonzero solution. |
+| **KernelInPlace.lean** | Allocation-efficient variant: `rrefInPlace`, `homogeneousKernelBasisInPlace`, `homogeneousWitnessInPlace`. |
+| **KernelInPlaceCorrectness.lean** | `rrefInPlace_eq` and `homogeneousWitnessInPlace_eq`, proving the fast path returns exactly what the direct path does. |
+
+### Why the in-place variant exists
+
+`RowOps.lean` threads a whole `DenseMatrix` through every operation. Because
+`scaleRow` / `addScaledRow` / `swapRows` read through `M.get` while the structure
+`M` is still live, the backing array is multiply-referenced at the first write, so
+`Array.setIfInBounds` copies the entire array on every call. Gauss-Jordan does
+`Θ(rows)` row operations per pivot over `Θ(min rows cols)` pivots, which turns an
+`O(n³)` algorithm into `O(n⁴)` work plus `Θ(n⁴)` words of short-lived allocation.
+
+`KernelInPlace.lean` performs the same arithmetic in the same order, threading a
+bare `Array F` with the dimensions passed separately. The array stays uniquely
+referenced as it flows between operations, so writes mutate in place after at most
+one fork from a shared input. The results are bit-for-bit identical, which is
+exactly what `rrefInPlace_eq` says — so use the in-place path in executable code
+and reason with `rref`.
+
+## Polynomial matrices (`PolynomialMatrix/`)
+
+| Module | Description |
+|--------|-------------|
+| **Basic.lean** | `PolynomialRow`, `PolynomialMatrix`, and row-level accessors. |
+| **Degree.lean** | Degree helpers for polynomial rows. |
+| **Shifted.lean** | Shifted degrees: the degree of a row measured against a per-column shift vector. |
+| **RowSpan.lean** | `rowLinearCombination`, `RowSpan`, `RowSpanEq`, and `matrix_row_mem_rowSpan` — the invariant reduction must preserve. |
+| **ShiftedReduction.lean** | The shifted row-reduction context. |
+| **MuldersStorjohann.lean** | The reducer: `shiftedLeadingConflict?`, `cancelShiftedLeadingTerm`, `muldersStorjohannStep`, `muldersStorjohannReduceWithFuel`, and `muldersStorjohannReduce` with its termination measure `muldersStorjohannFuel`. Also the fast variants. |
+| **MuldersStorjohannCorrectness.lean** | Umbrella for the correctness contract; the argument itself is split across `MuldersStorjohannCorrectness/`. |
+
+### The correctness subtree
+
+`MuldersStorjohannCorrectness/` splits the proof by concern: `Conflict`,
+`Leading`, `RowOps`, `MatrixRows`, `Combinations`, `Reduction`, `Measure`,
+`Minimal`, and `Fast`. The results worth knowing:
+
+- `muldersStorjohannStep_rowSpan_subset` / `_superset` (`Reduction.lean`) — each
+  step preserves the row span, so the reduced matrix generates the same module.
+- `muldersStorjohannReduce_least_row_minimal` (`Minimal.lean`) — the output is
+  shift-minimal, which is what the Lee-O'Sullivan interpolation backend consumes.
+- `Measure.lean` — the decreasing measure justifying the fuel bound.
+
+### Direct versus fast
+
+The direct loop recomputes every row's shifted leading position for each scanned
+row pair and cancels leading terms through a generic monomial-times-row multiply.
+The fast variants compute each row's leading position once per scan and use the
+fused `rowSubScaledShift` update.
+
+`MuldersStorjohannCorrectness/Fast.lean` proves them extensionally equal —
+`muldersStorjohannStepFast_eq`, `muldersStorjohannReduceWithFuelFast_eq`,
+`muldersStorjohannReduceFast_eq` — so every correctness result stated for the
+direct definitions transfers to the fast ones. Write proofs against the direct
+version; call the fast one.
+
+## Conventions
+
+- Both layers are `Array`-backed and index with plain `Nat`, with out-of-bounds
+  reads returning a default rather than requiring a proof at the call site. Shape
+  facts are separate propositions (`WellFormed`, the `RrefShape` predicates), not
+  invariants carried in the type.
+- Nothing here depends on `CompPoly/Multivariate/` or on Mathlib's `Matrix`; there
+  is no bridge to `Matrix` yet, and adding one would be new work.

--- a/CompPoly/Univariate/README.md
+++ b/CompPoly/Univariate/README.md
@@ -2,6 +2,11 @@
 
 Formally verified computable univariate polynomials for [CompPoly](../../README.md), built on array-backed coefficient representation.
 
+This is the largest subtree in the library. It is grouped below by role rather
+than listed flat: the representation and its Mathlib bridge come first, then
+arithmetic, interpolation, the fast transforms, and finally the algorithms built
+on top (root finding and Reed-Solomon coding).
+
 ## Types
 
 | Type | Description |
@@ -10,25 +15,62 @@ Formally verified computable univariate polynomials for [CompPoly](../../README.
 | `CPolynomial R` | Canonical polynomials: `{ p : Raw R // p.trim = p }`. Unique representation, no trailing zeros. |
 | `QuotientCPolynomial R` | Quotient of `Raw R` by coefficient-wise equivalence; intended equivalent of Mathlib's `Polynomial R`. |
 
-## Modules
+## Representation
 
 - **Raw.lean** — Umbrella import for the raw array-backed representation and its split implementation files.
 - **Raw/Core.lean** — Raw datatype and core operations (`coeff`, `C`, `X`, `monomial`, `trim`, `degree`, `eval`).
 - **Raw/Ops.lean** — Raw algebraic operations and related operational lemmas.
-- **Raw/Division.lean** — Raw polynomial division APIs (`divByMonic`, `modByMonic`, `div`, `mod`).
+- **Raw/Division.lean** — Raw polynomial division APIs (`divByMonic`, `modByMonic`, `div`, `mod`). Only `[BEq R]` is shared at section scope; the monic-division definitions need just `[CommRing R]`.
+- **Raw/Modular.lean** — Raw modular arithmetic.
+- **Raw/Context.lean** — Raw-level algorithm dictionaries backing the canonical contexts.
 - **Raw/Proofs.lean** — Proof layer for the raw API (algebraic laws and operation correctness).
 - **Basic.lean** — Canonical `CPolynomial` with ring structure (Add, Mul, Zero, One, etc.).
 - **Quotient/Core.lean** — Quotient type and operations descending from `Raw`.
 - **Quotient/Equiv.lean** — Equivalence between the quotient representation and canonical `CPolynomial`.
+
+## Mathlib bridge
+
 - **ToPoly.lean** — Umbrella import for conversion/equivalence with Mathlib's `Polynomial R`.
 - **ToPoly/Core.lean** — Core conversion maps and API lemmas.
 - **ToPoly/Equiv.lean** — Round-trip theorems and ring equivalence with Mathlib polynomials.
-- **ToPoly/Degree.lean** — Degree/support transport lemmas for conversions.
-- **Lagrange.lean** — Lagrange interpolation: `nodal`, `interpolate` at roots of unity.
-- **Barycentric.lean** — Fixed-domain barycentric interpolation with precomputed weights and
-  correctness lemmas comparing repeated-query evaluation against `Lagrange.interpolate` and
-  `CLagrange.interpolate`.
+- **ToPoly/Degree.lean** — Degree/support transport lemmas for conversions, plus `degreeLT` / `degreeLTEquiv`.
+- **ToPoly/Impl.lean** — Implementation-facing transport lemmas.
+- **CMvEquiv.lean** — Ring equivalence `CPolynomial R ≃+* CMvPolynomial 1 R`, via `CPolynomial R ≃ R[X] ≃ (CMvPolynomial 0 R)[X] ≃ CMvPolynomial 1 R`.
+
+## Arithmetic and structure
+
 - **Linear.lean** — Linear-factor and affine helper lemmas for univariate workflows.
+- **Deriv.lean** — Formal derivative `CPolynomial.derivative` and the Taylor shift `CPolynomial.taylor`.
+- **Modular.lean** — Executable modular arithmetic over the `MulContext` / `ModContext` backends.
+- **DivisionCorrectness.lean** — Correctness theorems for the division-style algorithms.
+- **EuclideanAlgorithm.lean** — Extended Euclid: `xgcd p q` returns `(r, s, t)` with `r = s * p + t * q`, with an early stop once `r.natDegree < threshold` (characterized by `xgcd_stopSpec` / `BezoutStopSpec`). Threshold `0` gives the plain gcd; positive thresholds are what the Gao decoder needs.
+- **Vanishing.lean** — Executable `∏ x in xs, (X - x)` for an array of nodes.
+- **Context.lean** — Algorithm dictionaries (`MulContext`, `ModContext`, …) with canonical, NTT, and NTTFast-backed implementations. This is how a caller swaps a multiplication backend without changing proofs.
+
+## Interpolation and evaluation
+
+- **Lagrange.lean** — Lagrange interpolation: `nodal`, `interpolate`, `interpolatePow`.
+- **LagrangeArray.lean** — Finite-index array adapters for `CLagrange.interpolate`.
+- **CoefficientInterpolation.lean** — Coefficient-form interpolation from the node vanishing polynomial, via `R = ∑ᵢ yᵢ / G'(xᵢ) · G / (X - xᵢ)`.
+- **Barycentric.lean** — Fixed-domain barycentric interpolation with precomputed weights, for repeated queries over one node set.
+- **BatchEval/** — Batch evaluation at many points: `Naive`, `SubproductTree`, a `Context` for pluggable multiply/remainder backends, and `Correctness`.
+- **ManyEval/** — The transposed workload: many dense polynomials at one shared point (`Basic`, `Correctness`).
+
+## Fast transforms
+
+- **NTT/** — Radix-2 root-of-unity transforms: `Domain`, `Forward`, `Inverse`, `Transform`, `Kernel`, the `Evaluation` and `Interpolation` bridge theorems, `FastMul` and `FastMulLow`, and the concrete `BabyBear` / `KoalaBear` domains.
+- **NTTFast/** — The optimized path: `Plan` (cached twiddle plans, DIF and radix-4 stages), `Evaluation`, `Interpolation`, `FastMul`, `FastMulLow`, and `Correctness/` proving refinement against the `NTT` specifications.
+
+Write proofs against `NTT`; call `NTTFast`.
+
+## Root finding and coding
+
+- **Roots/** — Backend-parametric univariate root finding over finite fields: the `Context` / `Backend` / `Splitter` interfaces, `Extraction`, `RootProduct`, `Correctness`, and `SmoothSubgroup/` for fields with a smooth multiplicative-subgroup schedule.
+- **ReedSolomon.lean** — The code itself: `Domain`, `messagePoly`, `encode`.
+- **ReedSolomon/NTTEncode.lean** — The forward NTT *is* the encoder (`forwardImpl_eq_encode`).
+- **ReedSolomon/GaoDecoder.lean**, **ReedSolomon/GaoCorrectness.lean** — Gao's unique decoder, with soundness, completeness, and `decode_none_farness`.
+
+Both are covered in depth by [`../../docs/wiki/coding-theory.md`](../../docs/wiki/coding-theory.md).
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,17 @@ import CompPoly
 - [`AGENTS.md`](AGENTS.md) is the canonical root handbook for AI agents and
   agent-oriented tooling.
 - [`docs/wiki/README.md`](docs/wiki/README.md) is the deeper repo wiki for
-  quickstart commands, repo structure, generated files, representation choice, and
-  the binary-field / additive-NTT stack.
+  quickstart commands, repo structure, generated files, representation choice, the
+  binary-field / additive-NTT stack, computable field extensions, and the
+  coding-theory stack.
 - Human contributors should usually start with [`CONTRIBUTING.md`](CONTRIBUTING.md)
   and this wiki, then consult `AGENTS.md` when working with agent tooling or when
   the AI-specific guardrails are relevant.
 - Existing subtree READMEs also provide focused entrypoints:
   [`CompPoly/Univariate/README.md`](CompPoly/Univariate/README.md),
-  [`CompPoly/Bivariate/README.md`](CompPoly/Bivariate/README.md), and
-  [`CompPoly/Fields/README.md`](CompPoly/Fields/README.md).
+  [`CompPoly/Bivariate/README.md`](CompPoly/Bivariate/README.md),
+  [`CompPoly/Fields/README.md`](CompPoly/Fields/README.md), and
+  [`CompPoly/LinearAlgebra/README.md`](CompPoly/LinearAlgebra/README.md).
 
 ## Current status and plans
 
@@ -79,10 +81,12 @@ import CompPoly
 - **Multilinear (`CMlPolynomial`, `CMlPolynomialEval`)**: coefficient and Boolean-hypercube evaluation representations, basis conversions, and equivalence to Mathlib's multilinear polynomial surface.
 - **Univariate (`CPolynomial`)**: full ring structure, core operations (`C`, `X`, `monomial`, `coeff`, `eval`, `eval₂`, degree/leading/support), `ringEquiv` to Mathlib `Polynomial`, Lagrange interpolation (`basis`, `interpolate`, `interpolatePow`), and fixed-domain barycentric interpolation for repeated-query evaluation.
 - **Bivariate (`CBivariate`)**: specialized `CPolynomial (CPolynomial R)` API with `X`, `Y`, `monomialXY`, evaluation, leading coefficients, `swap`, and equivalence to `Polynomial (Polynomial R)`.
-- **Fields**: broad set of finite-field instances and extensions (including BabyBear/Goldilocks/BN254/BLS12 family), binary tower support, and additive NTT infrastructure.
+- **Fields**: broad set of finite-field instances (BabyBear, KoalaBear, Goldilocks, Mersenne31, Secp256k1, and the BN254/BLS12-381/BLS12-377 scalar fields), native-word Montgomery arithmetic for the 31-bit and 255-bit-and-below primes, computable extension fields `F[X]/f` for an arbitrary monic modulus, binary tower support, and additive NTT infrastructure.
+- **Coding theory**: Reed-Solomon encoding identified with the forward NTT, Gao's unique decoder with soundness/completeness and a farness certificate on refusal, and a Guruswami-Sudan list decoder with pluggable interpolation and root-finding backends, all proved correct.
+- **Linear algebra**: executable dense matrices (Gauss-Jordan, homogeneous kernels) and polynomial matrices with Mulders-Storjohann shifted row reduction, each with a proven-equal allocation-efficient fast path.
 
 ### Current focus: Phase 2
 
-Primary roadmap focus is now shifting to **Performance & Efficiency**: optimized field arithmetic, FFT/NTT-based multiplication, faster exponentiation, and improved evaluation/interpolation pathways, with proof-first correctness maintained throughout.
+Primary roadmap focus is **Performance & Efficiency**: optimized field arithmetic, FFT/NTT-based multiplication, faster exponentiation, and improved evaluation/interpolation pathways, with proof-first correctness maintained throughout. See [`ROADMAP.md`](ROADMAP.md) for what is done and what is open.
 
-*Last updated: March 2026*
+*Last updated: August 2026*

--- a/bench/README.md
+++ b/bench/README.md
@@ -60,9 +60,23 @@ run by every implementation in that group.
 
 ## What Is Measured
 
-The benchmark covers evaluation paths, direct and NTT-backed univariate
-multiplication, additive NTT implementations, and scalar-field inversion
-(`fields-mont64x8-*-inv`: `ZMod` extended Euclid vs checked binary GCD vs Fermat).
+Roughly by area, with representative group prefixes:
+
+| Area | Groups |
+|---|---|
+| Univariate evaluation and multiplication | `univariate-dense-*`, `univariate-sparse-*`, `univariate-mul-*`, `univariate-low-product-*` |
+| Modular reduction | `univariate-mod-by-monic-*`, `univariate-monic-remainder-*` |
+| Batch and many-polynomial evaluation | `univariate-batch-*`, `univariate-many-one-point-*` |
+| Multilinear and multivariate | `multilinear-coeff-*`, `multilinear-hypercube-*`, `multilinear-many-mle-*`, `multivariate-dense-*`, `multivariate-sparse-*` |
+| Bivariate | `bivariate-full-*` (evaluation and Kronecker-backed multiply), `bivariate-divlinear-*` and `bivariate-deflate-*` (linear-factor deflation) |
+| Guruswami-Sudan decoding | `guruswami-sudan-core-*`, across dense / Lee-O'Sullivan interpolation and Roth-Ruckenstein / Alekhnovich root search |
+| Univariate root finding | `univariate-roots-finite-field-*` |
+| Additive NTT | `additive-ntt-btf*` |
+| Extension fields | `fields-extension-*-mul`, `fields-extension-*-inv` |
+| Scalar-field inversion | `fields-mont64x8-*-inv`: `ZMod` extended Euclid vs checked binary GCD vs Fermat |
+
+Use `--list` for the authoritative set; the prefixes above drift as groups are
+added.
 
 Some groups run each implementation over both the canonical `ZMod`
 representation and the native-word Montgomery representation, so the two appear as

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -21,6 +21,8 @@ are too specific or too changeable to keep at the repo root.
   GHASH model, and additive-NTT architecture.
 - [`field-extensions.md`](field-extensions.md) - the computable field-extension
   framework for arbitrary monic moduli and its irreducibility criteria.
+- [`coding-theory.md`](coding-theory.md) - Reed-Solomon encoding, unique and list
+  decoding, univariate root finding, and the linear-algebra engines beneath them.
 
 ## Maintenance Contract
 
@@ -36,6 +38,8 @@ are too specific or too changeable to keep at the repo root.
     blanket instance scopes.
   - `binary-fields-and-ntt.md` for the specialized field and NTT stack.
   - `field-extensions.md` for the odd-characteristic field-extension framework.
+  - `coding-theory.md` for Reed-Solomon coding, the decoders, root finding, and
+    the matrix layer.
 - Add new pages when a recurring topic no longer fits cleanly in an existing page.
 - If a PR changes commands, repo structure, generated-file behavior, or recurring
   architecture guidance, update the matching page in the same PR.

--- a/docs/wiki/binary-fields-and-ntt.md
+++ b/docs/wiki/binary-fields-and-ntt.md
@@ -5,51 +5,42 @@ specialized characteristic-2 stack used for GHASH and additive-NTT work.
 
 ## Top-Level Layout
 
+This page owns `CompPoly/Fields/Binary/` only:
+
 ```text
-CompPoly/Fields/
-  Basic.lean
-  BabyBear.lean, KoalaBear.lean, Goldilocks.lean, BN254.lean, ...
-  BabyBear/
+CompPoly/Fields/Binary/
+  Common.lean
+  BF128Ghash/
+    Prelude.lean
     Basic.lean
-    Fast.lean
-    Fast/ (Prelude.lean, Montgomery.lean, Convert.lean)
-  KoalaBear/
+    Impl.lean
+    XPowTwoPowGcdCertificate.lean
+    XPowTwoPowModCertificate.lean
+  Tower/
+    Abstract/*
+    Concrete/*
+    Support/*
     Basic.lean
-    Fast.lean
-    Fast/ (Prelude.lean, Montgomery.lean, Convert.lean)
-  Montgomery/
-    Basic.lean
-    Native32.lean
-    Native32Field.lean
-  Binary/
-    Common.lean
-    BF128Ghash/
-      Prelude.lean
-      Basic.lean
-      Impl.lean
-      XPowTwoPowGcdCertificate.lean
-      XPowTwoPowModCertificate.lean
-    Tower/
-      Abstract/*
-      Concrete/*
-      Support/*
-      Basic.lean
-      Equiv.lean
-      Impl.lean
-      Prelude.lean
-      TensorAlgebra.lean
-    AdditiveNTT/
-      AdditiveNTT.lean
-      Domain.lean
-      NovelPolynomialBasis.lean
-      Intermediate.lean
-      Algorithm.lean
-      Impl.lean
-      Correctness.lean
+    Equiv.lean
+    Impl.lean
+    Prelude.lean
+    TensorAlgebra.lean
+  AdditiveNTT/
+    AdditiveNTT.lean
+    Domain.lean
+    NovelPolynomialBasis.lean
+    Intermediate.lean
+    Algorithm.lean
+    Impl.lean
+    Correctness.lean
 ```
 
-Use [`../../CompPoly/Fields/README.md`](../../CompPoly/Fields/README.md) as the
-directory-level overview for the broader field catalog.
+For everything else under `CompPoly/Fields/` — the prime-field catalog, the
+Montgomery fast paths, and the extension framework — see
+[`../../CompPoly/Fields/README.md`](../../CompPoly/Fields/README.md), which is the
+per-module source of truth, and
+[`field-extensions.md`](field-extensions.md) for the odd-characteristic extension
+architecture. That catalog is deliberately not duplicated here.
 
 ## Common Binary Infrastructure
 

--- a/docs/wiki/coding-theory.md
+++ b/docs/wiki/coding-theory.md
@@ -1,0 +1,220 @@
+# Coding Theory
+
+Reed-Solomon encoding and decoding, and the two computational engines the
+decoders are built on: univariate root finding and computable linear algebra.
+
+This page owns the decoding stack. It spans four subtrees that are easy to miss
+because none of them is named after coding theory:
+
+```text
+CompPoly/Univariate/ReedSolomon/    encoding, and unique decoding (Gao)
+CompPoly/Bivariate/GuruswamiSudan/  list decoding
+CompPoly/Univariate/Roots/          univariate root finding
+CompPoly/LinearAlgebra/             dense and polynomial matrices
+```
+
+The last two are general-purpose and useful on their own; they live outside
+`ReedSolomon/` and `GuruswamiSudan/` for that reason. See
+[`../../CompPoly/LinearAlgebra/README.md`](../../CompPoly/LinearAlgebra/README.md)
+for the matrix layer in detail.
+
+## Two Decoding Regimes
+
+A Reed-Solomon code of block length `n` and message length `k` has minimum
+distance `n - k + 1`. That splits decoding into two regimes, and CompPoly
+implements one algorithm for each.
+
+| | Unique decoding | List decoding |
+|---|---|---|
+| Radius | up to `(n - k) / 2` errors | beyond it, up to the Johnson bound |
+| Output | at most one message | a list of candidates |
+| Algorithm here | Gao's key-equation decoder ([Gao02]) | Guruswami-Sudan ([GS99]) |
+| Entry point | `ReedSolomon.Gao.decode` | `GuruswamiSudan.decode` |
+| Cost | one extended-Euclid run | interpolation plus root finding |
+
+Use Gao unless you genuinely need to decode past half the minimum distance: it
+is far cheaper, it returns a decisive answer, and its refusal carries
+information (see `decode_none_farness` below). Reach for Guruswami-Sudan when
+the application is proximity testing or soft decoding, where a candidate list is
+the point.
+
+## Encoding
+
+[`Univariate/ReedSolomon.lean`](../../CompPoly/Univariate/ReedSolomon.lean) fixes
+the code itself: `Domain` (an array of distinct evaluation points), `messagePoly`,
+and `encode`, which evaluates the message polynomial on the domain. For
+`1 ≤ k < n ≤ #F` that is an `(n, k, n - k + 1)` code.
+
+[`ReedSolomon/NTTEncode.lean`](../../CompPoly/Univariate/ReedSolomon/NTTEncode.lean)
+then identifies the forward NTT with that encoder. Over the domain induced
+by a radix-2 NTT domain — the node array `#[ω⁰, ω¹, …, ω^(n-1)]`, nodup because
+powers of a primitive `n`-th root below `n` are pairwise distinct — the forward
+transform of a message polynomial's coefficients **is** the codeword:
+
+- `forwardImpl_eq_encode` ties `NTT.Forward.forwardImpl` (natural order,
+  `O(n log n)`) to the definitional `ReedSolomon.encode`, exactly, for every
+  message of length at most the domain size. No padding is needed, because
+  `messagePoly` trims and so the degree bound `k ≤ D.n` suffices.
+- `nttCodeword_eq_encode` is the same statement for the length-indexed packaging.
+
+So the fast encoder needs no separate correctness argument: it is the
+specification, transported.
+
+## Unique Decoding: Gao
+
+| Layer | File | Owns |
+|---|---|---|
+| Decoder | [`ReedSolomon/GaoDecoder.lean`](../../CompPoly/Univariate/ReedSolomon/GaoDecoder.lean) | `nodalPoly`, `receivedInterpolant`, `partialGcd`, `decode` |
+| Correctness | [`ReedSolomon/GaoCorrectness.lean`](../../CompPoly/Univariate/ReedSolomon/GaoCorrectness.lean) | `decode_sound`, `decode_eq_some`, `decode_eq_none_iff`, `decode_none_farness` |
+
+The algorithm interpolates the received word, then runs a partial extended
+Euclid against the nodal polynomial and stops at the degree threshold; the
+message falls out of the resulting Bézout relation. `decode` returns
+`Option (CPolynomial F)`.
+
+The correctness layer is stronger than plain soundness, and the extra results
+are the reason to prefer this decoder:
+
+- `decode_sound` — a returned polynomial really is within the decoding radius.
+- `decode_eq_some` / `decode_unique` — completeness and uniqueness inside the
+  radius.
+- `decode_eq_none_iff` — an iff, so refusal is characterized, not merely allowed.
+- `decode_none_farness` — refusal is a *certificate* that the received word is
+  far from every codeword. A verifier can use a failed decode as positive
+  evidence, which is what proximity testing needs.
+
+Supporting uniqueness machinery (`bezout_solutions_cross_mul`, error locators,
+Hamming distance) lives in the same correctness file, sectioned by role.
+
+## List Decoding: Guruswami-Sudan
+
+The 40-file `GuruswamiSudan/` subtree follows the interpolation-and-root-finding
+decomposition of [GS99]: fit a bivariate `Q(X, Y)` vanishing to prescribed
+multiplicity at every received point, then recover every `Y = f(X)` root of `Q`
+with `deg f < k`. Each candidate is then checked against the received word.
+
+**The important structural fact: the core is backend-parametric.** Interpolation
+and root finding are each supplied as a context carrying both the operation and
+the contract the correctness proofs consume. `Core.lean` and
+`CoreCorrectness.lean` never mention a concrete algorithm, so a new backend costs
+a context instance and inherits every theorem.
+
+| Layer | File | Owns |
+|---|---|---|
+| Contexts | [`GuruswamiSudan/Context.lean`](../../CompPoly/Bivariate/GuruswamiSudan/Context.lean) | `GSInterpParams`, `LinearKernelContext`, `GSInterpContext`, `FieldRootContext`, `GSRootContext`, `ValidInterpolationWitness`, `DistinctXCoordinates` |
+| Core | [`GuruswamiSudan/Core.lean`](../../CompPoly/Bivariate/GuruswamiSudan/Core.lean) | `gsCore`, backend-parametric |
+| Core correctness | [`GuruswamiSudan/CoreCorrectness.lean`](../../CompPoly/Bivariate/GuruswamiSudan/CoreCorrectness.lean) | `gsCore_sound`, `gsCore_complete_of_interpolate`, `gsCore_complete_of_roots_all_valid_witnesses` |
+| Candidate filtering | `Filter.lean`, `FilterCorrectness.lean` | `gsFilteredCore_sound`, `mem_gsFilteredCore_iff`, `gsFilteredCore_complete_of_enough_matches` |
+| Concrete instances | `Implementations.lean` | named dense / Lee-O'Sullivan / Roth-Ruckenstein combinations with specialized correctness theorems |
+| Executable API | `Executable.lean` | `GSReceivedWord`, `GSExecParams`, `GSParamSelector`, `decodeWithParams`, `decode` |
+| Shared helpers | `Polynomial.lean`, `PolynomialCorrectness.lean`, `Util.lean` | polynomial operations used by both kernels |
+
+### Interpolation backends
+
+Both produce a valid witness in the sense of `ValidInterpolationWitness`; they
+differ in how the constrained linear system is solved.
+
+| Backend | Files | When to use |
+|---|---|---|
+| Dense | `Interpolation/Dense/{Algorithm,Correctness}.lean` | Small parameters. Builds the constraint matrix explicitly and calls the dense kernel solver. Simple, and the easiest to reason about. |
+| Lee-O'Sullivan | `Interpolation/LeeOSullivan/` ([LOS06]) | Larger parameters. Works from a Gröbner-basis perspective: build a module basis, then shift-reduce it with Mulders-Storjohann. `leeOSullivanInterpolate_sound` and `leeOSullivanInterpolate_complete`, with the argument split across nine files under `Correctness/`. |
+
+`Interpolation/Basic.lean` holds the constraints and normalized-witness helpers
+shared by both, and `Interpolation/Correctness.lean` the shared results
+(`interpolationWitnessIsValidBool_iff`, `lowMessageDegreeInterpolation_sound`).
+
+### Root-finding backends
+
+Both find the `Y`-roots of the interpolated `Q` that are polynomials of bounded
+degree, and both come with soundness *and* completeness.
+
+| Backend | Files | Character |
+|---|---|---|
+| Roth-Ruckenstein | `Root/RothRuckenstein/` ([RR00]) | Coefficient-by-coefficient recursion; the classical choice. `rothRuckensteinRootsYDegreeLt_sound` / `_complete`. |
+| Alekhnovich | `Root/Alekhnovich/` ([Ale05]) | Divide-and-conquer over polynomial Diophantine equations; better asymptotics. `alekhnovichRootsYDegreeLt_sound`, `alekhnovichRootPrefixesWithFuel_complete`. |
+
+Shared infrastructure: `Root/Common/` (helpers for bounded bivariate root
+backends), `Root/ShiftedSubstitution/` (substituting `Y = f(X) + X^t Y`, the step
+both recursions are built from), and `Root/FieldRoots/` — the univariate
+field-root dependency, behind an explicit `FieldRootContext` so it can be
+replaced for large concrete fields. `Root/FieldRoots/FiniteField.lean` is the
+generic instance and `Root/FieldRoots/KoalaBear.lean` a concrete one.
+
+That context is where this subtree meets `Univariate/Roots/`.
+
+## Univariate Root Finding
+
+[`CompPoly/Univariate/Roots/`](../../CompPoly/Univariate/Roots) is a
+general-purpose root finder, used by the Guruswami-Sudan root search but not
+specific to it.
+
+| File | Owns |
+|---|---|
+| `Context.lean` | `FiniteFieldContext`, `LinearFactorProductSplitter`, `IsLinearFactor` and the candidate predicates |
+| `Backend.lean` | `rootsInFiniteFieldWith`, `rootsInFiniteField` — the pipeline entry points |
+| `Splitter.lean` | represented-linear-factor helpers and `xPowModWith` |
+| `Extraction.lean` | candidate extraction, validation, and deduplication |
+| `RootProduct.lean` | the product of linear factors over a root set |
+| `Correctness.lean` | `monicNormalize_root_iff`, `gcdMonic_root_iff_left_right`, and the divisibility transport lemmas |
+| `SmoothSubgroup/` | subgroup-refinement splitting ([MOV92]) for fields whose multiplicative group admits a smooth schedule |
+
+The pipeline consumes a `LinearFactorProductSplitter`; `SmoothSubgroup/` supplies
+a contract-bearing smooth context plus an adapter to that interface. A field with
+no smooth refinement schedule needs a different splitter — that is the open work
+here. Benchmarked as `univariate-roots-finite-field-*`.
+
+## Where To Start By Task
+
+- Encoding, or tying a transform to `ReedSolomon.encode`: `ReedSolomon/NTTEncode.lean`
+- Unique decoding, or using decode failure as a proximity certificate:
+  `ReedSolomon/GaoCorrectness.lean`
+- Changing what the GS decoder *does* without touching proofs: add a context
+  instance in `GuruswamiSudan/Context.lean` and register it in `Implementations.lean`
+- A new interpolation or root-finding algorithm: implement against the context
+  interface; `Core`/`CoreCorrectness` should need no change
+- Root finding over a new field: supply a `LinearFactorProductSplitter`, or a
+  `FieldRootContext` if the caller is the GS root search
+- Matrix-level work underneath any of this:
+  [`../../CompPoly/LinearAlgebra/README.md`](../../CompPoly/LinearAlgebra/README.md)
+
+## Reading Order
+
+- Gao: `GaoDecoder` → `GaoCorrectness` (soundness → completeness → farness)
+- Guruswami-Sudan: `Context` → `Core` → `CoreCorrectness` → one interpolation
+  backend → one root backend → `Filter` → `Executable`
+- Root finding: `Context` → `Backend` → `Extraction` → `Correctness`, then
+  `SmoothSubgroup/` if the field admits it
+
+Read `Context.lean` first for GS. The contexts are the interface the rest of the
+subtree is written against, and the correctness theorems are unreadable without
+knowing which contracts they assume.
+
+## Gaps
+
+- **No Berlekamp-Welch.** Gao's decoder covers the same unique-decoding regime,
+  so this is only worth adding as a cross-check, or if a downstream specification
+  asks for it by name.
+- **No FRI or polynomial-commitment integration.** `decode_none_farness` is the
+  hook a proximity test would use, but nothing consumes it yet.
+- **Root finding needs a smooth multiplicative group** for the only splitter that
+  currently exists.
+- **List-size bounds are not formalized.** Soundness and completeness are proved
+  relative to the supplied parameters; the Johnson-bound analysis that says how
+  many candidates can survive is not.
+
+## References
+
+* [Gao, S., *A New Algorithm for Decoding Reed-Solomon Codes*][Gao02]
+* [Guruswami, V., and Sudan, M., *Improved decoding of Reed-Solomon and
+    algebraic-geometry codes*][GS99]
+* [Lee, K., and O'Sullivan, M. E., *List decoding of Reed-Solomon codes from a
+    Groebner basis perspective*][LOS06]
+* [Roth, R. M., and Ruckenstein, G., *Efficient decoding of Reed-Solomon codes
+    beyond half the minimum distance*][RR00]
+* [Alekhnovich, M., *Linear Diophantine Equations Over Polynomials and Soft
+    Decoding of Reed-Solomon Codes*][Ale05]
+* [Menezes, A. J., van Oorschot, P. C., and Vanstone, S. A., *Subgroup
+    Refinement Algorithms for Root Finding in GF(q)*][MOV92]
+
+BibTeX entries for these keys are in
+[`../../blueprint/src/references.bib`](../../blueprint/src/references.bib).

--- a/docs/wiki/generated-files.md
+++ b/docs/wiki/generated-files.md
@@ -8,7 +8,7 @@ This page records which paths are source of truth and which are derived outputs.
 |---|---|---|
 | `CompPoly.lean` | Generated and committed | Regenerate with `./scripts/update-lib.sh` after adding, renaming, or deleting `CompPoly/**/*.lean` files. Emitted in module form: `module`, blank line, one `public import` per file. |
 | `CompPoly/Fields/*/Ext*/`*`CertData.lean` | Generated and committed | Rabin irreducibility certificate data for non-binomial extension moduli. Regenerate with `scripts/gen_rabin_certificate.py --p <p> --f <coeffs> --lean <path> --namespace <NS>`; the exact command is recorded in each file's docstring. Do not hand-edit. Nothing in them is trusted — the kernel re-checks every step through `CompPoly.RabinCert.runChain`. |
-| `bench/report-*.md`, `bench/results-*.jsonl` | Generated, not source | Produced by `lake exe CompPolyBench`; keep reports as local or CI artifacts. |
+| `bench/report-*.md`, `bench/results-*.jsonl`, `bench/evaluation-bench-*` | Generated, not source | Produced by `lake exe CompPolyBench`; keep reports as local or CI artifacts. All three patterns are ignored — the first two by `bench/.gitignore`, `evaluation-bench-*` by the root `.gitignore` — so a benchmark run leaves the working tree clean. |
 | `CLAUDE.md` | Compatibility symlink | Must remain a symlink to `AGENTS.md`; do not replace it with a separate copy. |
 | `.lake/` | Derived, not source | Local dependency cache and build output produced by Lake. Do not edit files here by hand. |
 | `.lake/build/` | Derived, not source | Build artifacts from `lake build` and `lake test`. Safe to delete and regenerate. |

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -84,7 +84,23 @@ to be covered there. See [`../../bench/README.md`](../../bench/README.md).
 - [`../../.github/workflows/check_imports.yml`](../../.github/workflows/check_imports.yml)
   checks that `CompPoly.lean` matches the tracked source tree.
 - [`../../.github/workflows/docs-integrity.yml`](../../.github/workflows/docs-integrity.yml)
-  checks the `CLAUDE.md` symlink and local markdown links.
+  checks the `CLAUDE.md` symlink, local markdown links, and backticked file paths
+  in the docs.
+
+Four further workflows exist that are not part of the pass/fail gate:
+
+- [`../../.github/workflows/summary.yml`](../../.github/workflows/summary.yml)
+  posts a PR summary on open and on every new commit. It runs under
+  `pull_request_target` and never builds or executes PR code — it reads the diff
+  and committed source as data — which is what makes that safe for fork PRs.
+- [`../../.github/workflows/review.yml`](../../.github/workflows/review.yml) runs a
+  PR review **on demand only**, triggered by a `/review` comment from a repo
+  member. It is deliberately not run on PR open, because the review path builds and
+  elaborates the PR's Lean code with secrets in scope.
+- [`../../.github/workflows/update_lean_project.yml`](../../.github/workflows/update_lean_project.yml)
+  bumps the Lean toolchain and dependencies nightly, and can be dispatched manually.
+- [`../../.github/workflows/lean_release_tag.yml`](../../.github/workflows/lean_release_tag.yml)
+  adds a release tag when `lean-toolchain` changes on `main`.
 
 ## Lower-Level Commands
 

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -10,9 +10,15 @@ CompPoly/
   Data/               shared helper lemmas and small support definitions
   ToMathlib/          local bridge lemmas and upstream-facing support code
   Univariate/         canonical computable univariate polynomials
+    NTT/, NTTFast/      root-of-unity transforms, spec and optimized
+    BatchEval/          batch and many-point evaluation
+    Roots/              univariate root finding
+    ReedSolomon/        Reed-Solomon encoding and Gao decoding
   Multivariate/       sparse computable multivariate polynomials
   Multilinear/        multilinear coefficient and evaluation representations
   Bivariate/          specialized `CPolynomial (CPolynomial R)` layer
+    GuruswamiSudan/     list decoder: interpolation and root-finding backends
+  LinearAlgebra/      dense matrices and polynomial matrices with row reduction
   Fields/             concrete fields plus binary-field and additive-NTT stack
 tests/                regression modules under `CompPolyTests`
 bench/                benchmark executable, runner docs, and local reports
@@ -28,6 +34,10 @@ scripts/              repo utilities and validation helpers
   `CompPoly/Bivariate/` are the main user-facing polynomial surfaces.
 - `CompPoly/Fields/` contains both the general field catalog and the more specialized
   binary-field, GHASH, tower, and additive-NTT developments.
+- The coding-theory stack cuts across three of those: `Univariate/ReedSolomon/` and
+  `Bivariate/GuruswamiSudan/` are the decoders, `Univariate/Roots/` and
+  `CompPoly/LinearAlgebra/` the engines they are built on. It is documented as one
+  subject in [`coding-theory.md`](coding-theory.md) rather than by subtree.
 - `tests/` mirrors the source tree when possible, but also contains cross-cutting
   regression modules for specialized subsystems.
 - `bench/` contains the compiled benchmark entrypoint and benchmark-specific docs.
@@ -50,6 +60,15 @@ scripts/              repo utilities and validation helpers
 - Adding or changing a field extension (challenge fields, `F[X]/(X^d - W)`):
   start in `CompPoly/Fields/Extension/` and read
   [`field-extensions.md`](field-extensions.md).
+- Reed-Solomon encoding, or unique decoding and its farness certificate:
+  start in `CompPoly/Univariate/ReedSolomon/` and read
+  [`coding-theory.md`](coding-theory.md).
+- Guruswami-Sudan list decoding, or adding an interpolation or root-finding
+  backend: start in `CompPoly/Bivariate/GuruswamiSudan/Context.lean` — the core is
+  backend-parametric, so a new backend is a context instance.
+- Univariate root finding over a finite field: start in `CompPoly/Univariate/Roots/`.
+- Dense or polynomial-matrix work, including shifted row reduction: start in
+  `CompPoly/LinearAlgebra/`.
 - Moving a reusable support lemma that should not live next to one specific feature:
   start in `CompPoly/Data/` or `CompPoly/ToMathlib/`.
 - Adding regression coverage: start in `tests/` and mirror the source namespace when
@@ -67,7 +86,13 @@ scripts/              repo utilities and validation helpers
   - [`../../CompPoly/Univariate/README.md`](../../CompPoly/Univariate/README.md)
   - [`../../CompPoly/Bivariate/README.md`](../../CompPoly/Bivariate/README.md)
   - [`../../CompPoly/Fields/README.md`](../../CompPoly/Fields/README.md)
+  - [`../../CompPoly/LinearAlgebra/README.md`](../../CompPoly/LinearAlgebra/README.md)
 - Large feature edits usually require reading one layer outward from the current
   file: for example, a multivariate API change often touches `MvPolyEquiv/`,
   while an additive-NTT change often spans `Domain`, `Intermediate`, `Algorithm`,
   `Impl`, and `Correctness`.
+- Several subtrees split an algorithm from its proof by file-name convention
+  (`Algorithm.lean` / `Correctness.lean`, or `Foo.lean` / `FooCorrectness.lean`).
+  Where a fast variant exists, it is usually proved equal to the direct one rather
+  than reproved — so state proofs against the direct definition and call the fast
+  one.

--- a/docs/wiki/representations-and-bridges.md
+++ b/docs/wiki/representations-and-bridges.md
@@ -12,6 +12,8 @@ usually the first architectural decision in a change.
 | Multilinear | `CMlPolynomial R n`, `CMlPolynomialEval R n` | Boolean-hypercube evaluation form, basis conversion, multilinear extensions | `CompPoly/Multilinear/Basic.lean`, `CompPoly/Multilinear/Equiv.lean` |
 | Field extensions | `Extension.Ext P` | Computable `F[X]/f` arithmetic for challenge fields, `f` an arbitrary monic modulus | `CompPoly/Fields/Extension.lean`, `docs/wiki/field-extensions.md` |
 | Bivariate | `CBivariate R` | Specialized two-variable APIs and `R[X][Y]` transport | `CompPoly/Bivariate/README.md`, `CompPoly/Bivariate/Basic.lean`, `CompPoly/Bivariate/ToPoly.lean`, `CompPoly/ToMathlib/Polynomial/BivariateDegree.lean`, `CompPoly/ToMathlib/Polynomial/BivariateWeightedDegree.lean`, `CompPoly/ToMathlib/Polynomial/BivariateMultiplicity.lean` |
+| Dense matrices | `DenseMatrix F` | Row-major matrices over a field: Gauss-Jordan reduction and homogeneous kernels | `CompPoly/LinearAlgebra/README.md`, `CompPoly/LinearAlgebra/Dense/Basic.lean` |
+| Polynomial matrices | `PolynomialMatrix F`, `PolynomialRow F` | Rows of univariate polynomials, shifted degrees, and shifted row reduction | `CompPoly/LinearAlgebra/README.md`, `CompPoly/LinearAlgebra/PolynomialMatrix/Basic.lean` |
 
 ## Univariate Family
 
@@ -137,6 +139,28 @@ specific polynomial representation.
   `CMlPolynomial` or `CMlPolynomialEval`.
 - If the API is naturally two-variable and you want `X` / `Y`-specific operations,
   start with `CBivariate`.
+- If you need to solve a linear system or reduce a matrix rather than manipulate a
+  polynomial, start with `DenseMatrix` or `PolynomialMatrix`. These are `Array`-backed
+  and carry no shape invariant in the type; there is no bridge to Mathlib's `Matrix`.
+
+## Matrix Surfaces
+
+`CompPoly/LinearAlgebra/` is the one family here with no Mathlib bridge layer, by
+design: it exists to run, and its correctness statements are phrased against
+row-span and pivot-shape predicates defined locally (`RowSpan`, `PivotColumnsShaped`)
+rather than transported to `Matrix`. Both layers ship a direct definition and a
+faster variant proved equal to it — `rrefInPlace_eq` for dense matrices,
+`muldersStorjohannReduceFast_eq` for polynomial ones — so proofs go against the
+direct version and executable code calls the fast one. See
+[`../../CompPoly/LinearAlgebra/README.md`](../../CompPoly/LinearAlgebra/README.md).
+
+## Coding Theory
+
+Reed-Solomon codewords are not a separate representation — they are arrays of field
+elements produced by evaluating a `CPolynomial` on a domain — but the decoders are a
+substantial surface spanning `Univariate/ReedSolomon/`, `Bivariate/GuruswamiSudan/`,
+`Univariate/Roots/`, and `LinearAlgebra/`. They are documented together in
+[`coding-theory.md`](coding-theory.md).
 
 ## Field Extensions
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,8 +8,8 @@ This directory contains the main helper scripts for local validation and CI supp
 - `./scripts/check-imports.sh` - verify that `CompPoly.lean` is up to date.
 - `./scripts/lint-style.sh` - run the Lean style linter and repo-wide Lean-file
   checks.
-- `python3 ./scripts/check-docs-integrity.py` - verify the `CLAUDE.md` symlink and
-  local markdown links across the handbook.
+- `python3 ./scripts/check-docs-integrity.py` - verify the `CLAUDE.md` symlink,
+  local markdown links, and backticked source paths across the handbook.
 
 ## Script Inventory
 
@@ -67,6 +67,23 @@ script doubles as a checker.
 Run `python3 scripts/gen_rabin_certificate.py --self-test` to check the generator
 against known-answer cases, including a reducible sextic that the prime-degree form of
 the test would wrongly accept.
+
+### `check-docs-integrity.py`
+
+Three checks over every tracked `.md` file:
+
+1. `CLAUDE.md` exists and is a symlink to `AGENTS.md`.
+2. Local markdown links resolve.
+3. Backticked source paths — `` `CompPoly/Univariate/Basic.lean` `` and friends,
+   with extensions `.lean`, `.py`, `.sh`, `.yml`, `.bib` — point at files that
+   exist.
+
+The third check is the one that catches module splits and renames, since the docs
+cite far more paths in backticks than in markdown links. Bare filenames with no
+directory, glob patterns, and paths ending in `/` are skipped as prose. Paths may
+be written relative to the repo root, to the citing file's directory, or to one of
+the subtree roots in `PATH_PREFIXES` — so a page about `Fields/` may write
+`KoalaBear/Ext4.lean`. Adding a prefix weakens the check; prefer fixing the doc.
 
 ### `build_timing_report.sh`
 

--- a/scripts/check-docs-integrity.py
+++ b/scripts/check-docs-integrity.py
@@ -4,6 +4,11 @@
 Checks:
 1. `CLAUDE.md` exists and is a symlink to `AGENTS.md`
 2. Local markdown links in tracked repo docs resolve
+3. Backticked source paths in those docs (`CompPoly/Foo/Bar.lean`) point at files
+   that exist
+
+Check 3 exists because the docs cite far more paths in backticks than in markdown
+links, and those are the ones that rot silently when a module is split or renamed.
 
 Exit code 0 if all checks pass, 1 otherwise.
 """
@@ -20,6 +25,37 @@ AGENTS_PATH = REPO_ROOT / "AGENTS.md"
 
 MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 IGNORED_DIRS = {".git", ".lake"}
+
+# Backticked source paths, e.g. `CompPoly/Univariate/Basic.lean`.
+BACKTICK_PATH_RE = re.compile(r"`([A-Za-z0-9_./\-]+\.(?:lean|py|sh|yml|bib))`")
+
+# Docs routinely cite paths relative to a subtree rather than to the repo root
+# (`field-extensions.md` writes `KoalaBear/Ext4.lean`, `coding-theory.md` writes
+# `Interpolation/Basic.lean`). A backticked path counts as resolved if it exists
+# under any of these roots, or under the directory of the file citing it.
+#
+# Add a prefix only for a subtree that a doc page is genuinely written *about*, so
+# its prose can name files relatively. Every added prefix weakens the check, so
+# keep the list short and prefer fixing the doc.
+PATH_PREFIXES = (
+    "",
+    "CompPoly",
+    "CompPoly/Fields",
+    "CompPoly/Fields/Binary",
+    "CompPoly/Fields/KoalaBear",
+    "CompPoly/Univariate",
+    "CompPoly/Bivariate",
+    "CompPoly/Bivariate/GuruswamiSudan",
+    "CompPoly/LinearAlgebra",
+    "CompPoly/LinearAlgebra/PolynomialMatrix",
+    "tests",
+    "bench",
+)
+
+# Paths that are illustrative rather than real: glob patterns, and the `Foo/*`
+# shorthand the wiki uses for "everything in this directory".
+def _is_illustrative(path: str) -> bool:
+    return "*" in path or path.endswith("/")
 
 
 def markdown_files() -> list[Path]:
@@ -88,6 +124,23 @@ def check_markdown_links() -> list[str]:
     return errors
 
 
+def check_backtick_paths() -> list[str]:
+    errors: list[str] = []
+    for doc_file in markdown_files():
+        text = doc_file.read_text(encoding="utf-8")
+        for raw_target in BACKTICK_PATH_RE.findall(text):
+            # A bare filename with no directory is almost always prose
+            # ("regenerate `update-lib.sh`"), not a path claim.
+            if "/" not in raw_target or _is_illustrative(raw_target):
+                continue
+            candidates = [REPO_ROOT / prefix / raw_target for prefix in PATH_PREFIXES]
+            candidates.append(doc_file.parent / raw_target)
+            if not any(candidate.exists() for candidate in candidates):
+                rel_doc = doc_file.relative_to(REPO_ROOT)
+                errors.append(f"Broken path in {rel_doc}: `{raw_target}`")
+    return errors
+
+
 def main() -> int:
     all_errors: list[str] = []
 
@@ -96,6 +149,9 @@ def main() -> int:
 
     print("Checking markdown links...")
     all_errors.extend(check_markdown_links())
+
+    print("Checking backticked source paths...")
+    all_errors.extend(check_backtick_paths())
 
     if all_errors:
         print(f"\n{len(all_errors)} issue(s) found:\n")


### PR DESCRIPTION
> **Stacked on #287.** Base is `docs/fix-roadmap-and-stale-references`; review that one first, and this diff will shrink to its own commit once #287 merges.

#287 fixed the docs that were *wrong*. This one fixes the docs that are *missing*, and adds the check that would have caught both.

## The gap

Four subtrees appeared in **zero** documentation — no wiki page, no subtree README, no mention in `AGENTS.md` or `repo-map.md`:

| Subtree | Files | What it is |
|---|---|---|
| `Bivariate/GuruswamiSudan/` | 40 | List decoder: dense + Lee-O'Sullivan interpolation, Roth-Ruckenstein + Alekhnovich root search, soundness and completeness |
| `LinearAlgebra/` | 27 | Dense RREF/kernel solver, polynomial matrices, Mulders-Storjohann |
| `Univariate/Roots/` | 13 | Root extraction, smooth-subgroup search |
| `Univariate/ReedSolomon/` | 3 | Gao decoder, NTT-as-encoder |

83 of 274 `.lean` files — about 30% of the library — landed between June and August 2026.

## New pages

**`docs/wiki/coding-theory.md`**, a third specialized page beside `binary-fields-and-ntt.md` and `field-extensions.md`, structured like the latter (layering tables, where-to-start, honest gaps). It documents the two decoding regimes and when to reach for each, NTT-as-encoder, the Gao decoder and what `decode_none_farness` buys you, the GS pipeline, the engines beneath it, reading order, and four real gaps.

The fact most worth surfacing, and the reason the page leads with it: **the GS core is backend-parametric.** Interpolation and root finding are supplied as contexts carrying both the operation and the contract the proofs consume, so `Core.lean` and `CoreCorrectness.lean` never name a concrete algorithm. A new backend costs a context instance and inherits every theorem. That is invisible from the file tree, and it is the thing a contributor most needs to know before touching the subtree.

**`CompPoly/LinearAlgebra/README.md`**, a fourth subtree README. Includes why the in-place kernel variant exists (the direct one is multiply-referenced at the first write, turning an `O(n³)` algorithm into `O(n⁴)` work plus `Θ(n⁴)` words of allocation) and the direct-vs-fast rule that recurs across the repo: state proofs against the direct definition, call the fast one, because the fast variants are proved equal rather than reproved.

## Routing and refreshes

`AGENTS.md` (Where To Work + Deeper Docs), `repo-map.md` (tree, layering, routing, navigation), `representations-and-bridges.md` (matrix rows and two new sections), `docs/wiki/README.md` (hub + maintenance-contract owner list).

- **`Univariate/README.md`** listed 13 modules for a subtree with 19 top-level files and 8 directories. Regrouped by role — representation, bridge, arithmetic, interpolation, transforms, roots and coding — rather than extended flat.
- **`Bivariate/README.md`** gains `GuruswamiSudan/` and five modules.
- **`README.md`**: stale date, field catalog listing only half the fields, and no mention of decoding or linear algebra.
- **`quickstart.md`** CI mapping covered 4 of 8 workflows. The omissions included `review.yml`, which contributors need to know is triggered by a `/review` comment rather than on PR open.
- **`bench/README.md`** "What Is Measured" omitted the GS, extension-field, bivariate, multilinear, multivariate, and roots groups.
- **`binary-fields-and-ntt.md`** duplicated the `Fields/` catalog and had gone stale (`Montgomery/` showed 3 files; there are 9). Trimmed to the `Binary/` subtree it actually owns, pointing at `Fields/README.md` for the rest — duplicating the catalog is what let it rot.

## The check that prevents recurrence

`check-docs-integrity.py` gains a third check: backticked source paths must exist. The docs cite far more paths in backticks than in markdown links, and those are the ones that rot silently when a module is split — which is exactly why all four dead paths in #287 passed CI indefinitely.

Paths may be written relative to the repo root, the citing file's directory, or a short list of subtree roots, since a page about a subtree naturally names files relatively. Bare filenames, globs, and directory paths are skipped as prose.

Two things worth reporting about it:

1. It **immediately caught 6 bad paths in the two new pages in this PR**, which is a decent argument for its value.
2. I verified it fires on a real regression by reintroducing `CompPoly/Univariate/Quotient.lean` into a doc — it failed with exit 1 and named the file, then passed again on revert.

## A correction

One finding from the original audit was wrong and is not carried into this PR: bench report artifacts **are** already gitignored, by `bench/.gitignore` rather than the root one, which I had missed. `generated-files.md` now records where the rules actually live instead of implying a gap.

## Verification

`check-docs-integrity.py`, `check-imports.sh`, and `lint-style.sh` all pass. Every directory under `CompPoly/` now appears in at least one doc. No `.lean` files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)