### PR TITLE
ci: warm Lake builds by default with optional clean build

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -9,7 +9,8 @@ on:
       clean_build:
         description: >-
           Wipe .lake/build and run a full clean lake build before the warm path.
-          Default CI is warm/incremental (reuse cached oleans).
+          Default CI is warm/incremental (reuse cached oleans). Clean also runs
+          automatically when lean-toolchain or lake-manifest.json changes.
         type: boolean
         default: false
 
@@ -88,17 +89,59 @@ jobs:
             echo "BUILD_TIMING_MERGE_BASE_SHA=$merge_base_sha" >> "$GITHUB_ENV"
           fi
       # Default: warm/incremental builds (reuse oleans; Lake rebuilds only dirty modules).
-      # Clean full rebuild only when manually requested via workflow_dispatch.
+      # Clean full rebuild when:
+      #   - workflow_dispatch with clean_build: true, or
+      #   - lean-toolchain or lake-manifest.json differs from the comparison base
+      #     (PR base SHA, previous push tip, or merge-base with origin/main on dispatch).
       - name: Resolve clean-build flag
         run: |
           clean_build=false
+          clean_reason=""
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
              [ "${{ inputs.clean_build }}" = "true" ]; then
             clean_build=true
+            clean_reason="workflow_dispatch clean_build input"
           fi
+
+          # Version-lock bump: force a wipe even if a cache restore-key matched.
+          # Cache keys already isolate toolchain+manifest, so misses are cold in
+          # practice; explicit clean keeps timing/policy honest and defends against
+          # key drift.
+          if [ "$clean_build" != true ]; then
+            base_ref=""
+            case "${{ github.event_name }}" in
+              pull_request)
+                base_ref="${{ github.event.pull_request.base.sha }}"
+                ;;
+              push)
+                before="${{ github.event.before }}"
+                if [ -n "$before" ] && \
+                   [ "$before" != "0000000000000000000000000000000000000000" ]; then
+                  base_ref="$before"
+                fi
+                ;;
+              workflow_dispatch)
+                if git rev-parse --verify origin/main >/dev/null 2>&1; then
+                  base_ref="$(git merge-base origin/main HEAD 2>/dev/null || true)"
+                elif git rev-parse --verify origin/master >/dev/null 2>&1; then
+                  base_ref="$(git merge-base origin/master HEAD 2>/dev/null || true)"
+                fi
+                ;;
+            esac
+
+            if [ -n "$base_ref" ] && git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+              if ! git diff --quiet "$base_ref" HEAD -- lean-toolchain lake-manifest.json; then
+                clean_build=true
+                changed="$(git diff --name-only "$base_ref" HEAD -- lean-toolchain lake-manifest.json | tr '\n' ' ')"
+                clean_reason="version lock changed vs ${base_ref:0:12} (${changed% })"
+              fi
+            fi
+          fi
+
           echo "CLEAN_BUILD=$clean_build" >> "$GITHUB_ENV"
           if [ "$clean_build" = true ]; then
-            echo "Clean build requested: will wipe .lake/build before lake build."
+            echo "Clean build: will wipe .lake/build before lake build ($clean_reason)."
           else
             echo "Warm build (default): reuse cached .lake oleans; no wipe."
           fi

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, master]
   pull_request:
   workflow_dispatch:
+    inputs:
+      clean_build:
+        description: >-
+          Wipe .lake/build and run a full clean lake build before the warm path.
+          Default CI is warm/incremental (reuse cached oleans).
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -80,11 +87,28 @@ jobs:
           if [ -n "$merge_base_sha" ]; then
             echo "BUILD_TIMING_MERGE_BASE_SHA=$merge_base_sha" >> "$GITHUB_ENV"
           fi
+      # Default: warm/incremental builds (reuse oleans; Lake rebuilds only dirty modules).
+      # Clean full rebuild only when manually requested via workflow_dispatch.
+      - name: Resolve clean-build flag
+        run: |
+          clean_build=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
+             [ "${{ inputs.clean_build }}" = "true" ]; then
+            clean_build=true
+          fi
+          echo "CLEAN_BUILD=$clean_build" >> "$GITHUB_ENV"
+          if [ "$clean_build" = true ]; then
+            echo "Clean build requested: will wipe .lake/build before lake build."
+          else
+            echo "Warm build (default): reuse cached .lake oleans; no wipe."
+          fi
       - name: Restore Lake cache
         id: lake-cache
         uses: actions/cache/restore@v4
         with:
           path: .lake
+          # Exact key per commit; restore-keys fall back to latest compatible
+          # toolchain+manifest cache (typically main or a recent PR head).
           key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
           restore-keys: |
             lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
@@ -97,10 +121,11 @@ jobs:
           lint: false
           use-github-cache: false
       - name: Time clean build
+        if: env.CLEAN_BUILD == 'true'
         run: |
           bash scripts/build_timing_report.sh run clean_build "$BUILD_TIMING_RESULTS" -- \
             bash -eo pipefail -c 'rm -rf .lake/build && lake build'
-      - name: Time warm rebuild
+      - name: Time library build (warm)
         run: |
           bash scripts/build_timing_report.sh run warm_rebuild "$BUILD_TIMING_RESULTS" -- \
             bash -eo pipefail -c 'lake build'
@@ -143,6 +168,9 @@ jobs:
           path: ${{ env.EVALUATION_BENCH_ARTIFACT_DIR }}
           if-no-files-found: warn
           retention-days: 30
+      # Save after successful runs so the next PR can restore oleans via restore-keys.
+      # Skip exact cache-hit re-runs of the same commit (key already stored; save would fail).
+      # New main SHAs always miss the exact key, so tip oleans are refreshed for PRs.
       - name: Save Lake cache
         if: success() && steps.lake-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -159,6 +187,12 @@ jobs:
           fi
           if [ -f "$BUILD_TIMING_LOG_DIR/clean_build.log" ]; then
             cp "$BUILD_TIMING_LOG_DIR/clean_build.log" "$BUILD_TIMING_ARTIFACT_DIR/clean_build.log"
+          fi
+          if [ -f "$BUILD_TIMING_LOG_DIR/warm_rebuild.log" ]; then
+            cp "$BUILD_TIMING_LOG_DIR/warm_rebuild.log" "$BUILD_TIMING_ARTIFACT_DIR/warm_rebuild.log"
+          fi
+          if [ -f "$BUILD_TIMING_LOG_DIR/test_path.log" ]; then
+            cp "$BUILD_TIMING_LOG_DIR/test_path.log" "$BUILD_TIMING_ARTIFACT_DIR/test_path.log"
           fi
       - name: Upload timing artifact
         if: always()

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -145,16 +145,34 @@ jobs:
           else
             echo "Warm build (default): reuse cached .lake oleans; no wipe."
           fi
-      - name: Restore Lake cache
-        id: lake-cache
+      # Warm builds only pay off when the restore actually hits, so dependencies and our
+      # own build are cached separately.
+      #
+      # A single `path: .lake` entry carried both at ~2.6 GiB per commit. Keyed per
+      # commit against GitHub's 10 GB per-repo quota, that left room for roughly four
+      # entries, so consecutive pushes evicted one another and warm restores missed
+      # often — the repo was sitting at ~10.3 GiB active, permanently over quota.
+      # Splitting means the bulky dependency entry is written once per version-lock
+      # bump instead of once per push, leaving the quota free to hold many small
+      # per-commit build entries.
+      - name: Restore dependency cache
+        id: deps-cache
         uses: actions/cache/restore@v4
         with:
-          path: .lake
+          path: .lake/packages
+          # No commit component and no restore-keys: the version lock fully determines
+          # the dependency set, so a hit is always exact and a miss must be refetched.
+          key: lake-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .lake/build
           # Exact key per commit; restore-keys fall back to latest compatible
           # toolchain+manifest cache (typically main or a recent PR head).
-          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+          key: lake-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
           restore-keys: |
-            lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+            lake-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
       - name: Set up Lean environment
         uses: leanprover/lean-action@v1
         with:
@@ -163,6 +181,13 @@ jobs:
           test: false
           lint: false
           use-github-cache: false
+      # Fallback for a dependency-cache miss, which until now meant compiling all of
+      # Mathlib from source. Lake materializes the dependencies, then this pulls their
+      # prebuilt oleans from Mathlib's cache server. Skipped on a hit, where the oleans
+      # are already restored and this would only re-download them.
+      - name: Fetch Mathlib oleans
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: lake exe cache get
       - name: Time clean build
         if: env.CLEAN_BUILD == 'true'
         run: |
@@ -211,15 +236,22 @@ jobs:
           path: ${{ env.EVALUATION_BENCH_ARTIFACT_DIR }}
           if-no-files-found: warn
           retention-days: 30
-      # Save after successful runs so the next PR can restore oleans via restore-keys.
-      # Skip exact cache-hit re-runs of the same commit (key already stored; save would fail).
-      # New main SHAs always miss the exact key, so tip oleans are refreshed for PRs.
-      - name: Save Lake cache
-        if: success() && steps.lake-cache.outputs.cache-hit != 'true'
+      # Both saves skip on an exact cache hit, where the key is already stored and the
+      # save would fail. In practice the dependency entry is written only after a
+      # version-lock bump, while the build entry is written on every new commit so the
+      # next PR can restore tip oleans via restore-keys.
+      - name: Save dependency cache
+        if: success() && steps.deps-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: .lake
-          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+          path: .lake/packages
+          key: lake-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+      - name: Save build cache
+        if: success() && steps.build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .lake/build
+          key: lake-build-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
       - name: Prepare timing artifact
         if: always()
         run: |

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -181,13 +181,12 @@ jobs:
           test: false
           lint: false
           use-github-cache: false
-      # Fallback for a dependency-cache miss, which until now meant compiling all of
-      # Mathlib from source. Lake materializes the dependencies, then this pulls their
-      # prebuilt oleans from Mathlib's cache server. Skipped on a hit, where the oleans
-      # are already restored and this would only re-download them.
-      - name: Fetch Mathlib oleans
-        if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: lake exe cache get
+          # This step is what supplies Mathlib's oleans: lean-action detects the Mathlib
+          # dependency in `lake-manifest.json` and runs `lake exe cache get` itself, so a
+          # dependency-cache miss costs a download rather than compiling Mathlib. That is
+          # already the behaviour of the `auto` default; setting it explicitly documents
+          # the reliance and pins it against a future change of default.
+          use-mathlib-cache: true
       - name: Time clean build
         if: env.CLEAN_BUILD == 'true'
         run: |

--- a/docs/wiki/build-cache.md
+++ b/docs/wiki/build-cache.md
@@ -84,7 +84,8 @@ tar tzf .lake/CompPoly-oleans.tar.gz | head
 
 ## What this does not cover
 
-CI's own per-commit build reuse is a separate mechanism — a GitHub Actions cache of
-`.lake` plus `lake exe cache get`, described in
+CI's own per-commit build reuse is a separate mechanism — two GitHub Actions caches,
+one for `.lake/packages` and one for `.lake/build`, with `lean-action` supplying
+Mathlib's oleans via `lake exe cache get`. See
 [`quickstart.md`](quickstart.md#ci-mapping). The release archive is cut once per
 release tag and plays no part in it.

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -80,9 +80,11 @@ to be covered there. See [`../../bench/README.md`](../../bench/README.md).
   oleans so only dirty modules rebuild — then `lake test`, and posts a
   build-timing report. It also builds and runs `CompPolyBench --medium` over the curated
   `BENCH_CI_GROUPS` selection, then uploads benchmark reports as CI artifacts.
-  For a full cold rebuild, use **Actions → Lean Action CI → Run workflow** and
-  enable the `clean_build` input (wipes `.lake/build` first). Default PR/push
-  runs do not wipe the cache.
+  A full cold rebuild (`rm -rf .lake/build && lake build`) runs automatically
+  when `lean-toolchain` or `lake-manifest.json` differs from the comparison base
+  (PR base, previous push tip, or merge-base with `main` on manual dispatch).
+  You can also force a clean via **Actions → Lean Action CI → Run workflow** with
+  the `clean_build` input. Ordinary source-only PR/push runs stay warm.
 - [`../../.github/workflows/linting.yml`](../../.github/workflows/linting.yml) runs
   the style linter on changed `.lean` files in PRs and push builds.
 - [`../../.github/workflows/check_imports.yml`](../../.github/workflows/check_imports.yml)

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -76,9 +76,13 @@ to be covered there. See [`../../bench/README.md`](../../bench/README.md).
 ## CI Mapping
 
 - [`../../.github/workflows/lean_action_ci.yml`](../../.github/workflows/lean_action_ci.yml)
-  runs a clean build, warm rebuild, and `lake test`, then posts a build-timing
-  report. It also builds and runs `CompPolyBench --medium` over the curated
+  runs a **warm** (incremental) `lake build` by default — reusing cached Lake
+  oleans so only dirty modules rebuild — then `lake test`, and posts a
+  build-timing report. It also builds and runs `CompPolyBench --medium` over the curated
   `BENCH_CI_GROUPS` selection, then uploads benchmark reports as CI artifacts.
+  For a full cold rebuild, use **Actions → Lean Action CI → Run workflow** and
+  enable the `clean_build` input (wipes `.lake/build` first). Default PR/push
+  runs do not wipe the cache.
 - [`../../.github/workflows/linting.yml`](../../.github/workflows/linting.yml) runs
   the style linter on changed `.lean` files in PRs and push builds.
 - [`../../.github/workflows/check_imports.yml`](../../.github/workflows/check_imports.yml)

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -92,8 +92,9 @@ to be covered there. See [`../../bench/README.md`](../../bench/README.md).
   the `clean_build` input. Ordinary source-only PR/push runs stay warm.
   Two Actions caches feed the warm path: `.lake/packages` keyed on
   `lean-toolchain` plus `lake-manifest.json`, and `.lake/build` keyed additionally
-  per commit. On a dependency-cache miss the workflow runs `lake exe cache get`, so
-  a miss costs a download rather than a full Mathlib compile.
+  per commit. A dependency-cache miss is not expensive, because `lean-action` runs
+  `lake exe cache get` for us, so Mathlib's oleans are downloaded rather than
+  compiled.
 - [`../../.github/workflows/linting.yml`](../../.github/workflows/linting.yml) runs
   the style linter on changed `.lean` files in PRs and push builds.
 - [`../../.github/workflows/check_imports.yml`](../../.github/workflows/check_imports.yml)

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -85,6 +85,10 @@ to be covered there. See [`../../bench/README.md`](../../bench/README.md).
   (PR base, previous push tip, or merge-base with `main` on manual dispatch).
   You can also force a clean via **Actions → Lean Action CI → Run workflow** with
   the `clean_build` input. Ordinary source-only PR/push runs stay warm.
+  Two Actions caches feed the warm path: `.lake/packages` keyed on
+  `lean-toolchain` plus `lake-manifest.json`, and `.lake/build` keyed additionally
+  per commit. On a dependency-cache miss the workflow runs `lake exe cache get`, so
+  a miss costs a download rather than a full Mathlib compile.
 - [`../../.github/workflows/linting.yml`](../../.github/workflows/linting.yml) runs
   the style linter on changed `.lean` files in PRs and push builds.
 - [`../../.github/workflows/check_imports.yml`](../../.github/workflows/check_imports.yml)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -87,10 +87,17 @@ the subtree roots in `PATH_PREFIXES` — so a page about `Fields/` may write
 
 ### `build_timing_report.sh`
 
-Helper used by CI to measure and render build timings for clean builds, warm
-rebuilds, and the `lake test` path. The CI workflow also uploads timing-data
-artifacts so PR runs can compare against a previously recorded baseline without
-rerunning that baseline in the same job. This supports
+Helper used by CI to measure and render build timings. Labels:
+
+- `warm_rebuild` — default library gate: `lake build` with cached oleans
+  (incremental; only dirty modules rebuild).
+- `test_path` — `lake test`.
+- `clean_build` — optional: `rm -rf .lake/build && lake build`, only when the
+  Lean Action CI workflow is run manually with the `clean_build` input.
+
+The CI workflow uploads timing-data artifacts so PR runs can compare against a
+previously recorded baseline without rerunning that baseline in the same job.
+This supports
 [`../.github/workflows/lean_action_ci.yml`](../.github/workflows/lean_action_ci.yml).
 
 ## Typical Workflows

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -92,8 +92,9 @@ Helper used by CI to measure and render build timings. Labels:
 - `warm_rebuild` — default library gate: `lake build` with cached oleans
   (incremental; only dirty modules rebuild).
 - `test_path` — `lake test`.
-- `clean_build` — optional: `rm -rf .lake/build && lake build`, only when the
-  Lean Action CI workflow is run manually with the `clean_build` input.
+- `clean_build` — `rm -rf .lake/build && lake build`, when Lean Action CI
+  detects a `lean-toolchain` or `lake-manifest.json` change vs the comparison
+  base, or when the workflow is run manually with the `clean_build` input.
 
 The CI workflow uploads timing-data artifacts so PR runs can compare against a
 previously recorded baseline without rerunning that baseline in the same job.

--- a/scripts/build_timing_report.sh
+++ b/scripts/build_timing_report.sh
@@ -284,8 +284,10 @@ if measured_labels:
     )
 if "clean_build" not in current_records:
     print(
-        "- Clean build was skipped (default warm/incremental CI). "
-        "Trigger via Actions → Lean Action CI → Run workflow with `clean_build`."
+        "- Clean build was skipped (warm/incremental CI; no toolchain or "
+        "lake-manifest change). Runs automatically when `lean-toolchain` or "
+        "`lake-manifest.json` changes, or via Actions → Lean Action CI → "
+        "Run workflow with `clean_build`."
     )
 print()
 

--- a/scripts/build_timing_report.sh
+++ b/scripts/build_timing_report.sh
@@ -8,8 +8,8 @@ Usage:
   build_timing_report.sh render <results-file> [baseline-artifact-dir]
 
 Labels:
-  clean_build
-  warm_rebuild
+  clean_build   (optional; full cold build after wiping .lake/build)
+  warm_rebuild  (default library gate; incremental when oleans are cached)
   test_path
 EOF
 }
@@ -114,7 +114,7 @@ display = {
         "command": "`rm -rf .lake/build && lake build`",
     },
     "warm_rebuild": {
-        "name": "Warm rebuild",
+        "name": "Library build (warm)",
         "command": "`lake build`",
     },
     "test_path": {
@@ -161,11 +161,15 @@ def module_to_source_path(target: str) -> str | None:
     return None
 
 
-def extract_clean_build_targets(log_path: pathlib.Path | None) -> list[dict]:
+def extract_build_targets(log_path: pathlib.Path | None) -> list[dict]:
+    """Parse lake `Built Target (Ns)` lines from a build log."""
     if log_path is None or not log_path.exists():
         return []
 
-    pattern = re.compile(r"Built\s+(.+?)\s+\((\d+(?:\.\d+)?)s\)")
+    # Match seconds or milliseconds as lake reports both.
+    pattern = re.compile(
+        r"Built\s+(.+?)\s+\((\d+(?:\.\d+)?)(ms|s)\)"
+    )
     entries = []
     seen = set()
     for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -176,10 +180,13 @@ def extract_clean_build_targets(log_path: pathlib.Path | None) -> list[dict]:
         if target in seen:
             continue
         seen.add(target)
+        value = float(match.group(2))
+        unit = match.group(3)
+        seconds = value / 1000.0 if unit == "ms" else value
         entries.append(
             {
                 "target": target,
-                "seconds": float(match.group(2)),
+                "seconds": seconds,
                 "source": module_to_source_path(target),
             }
         )
@@ -195,15 +202,38 @@ def target_key(entry: dict) -> str:
     return entry["source"] or entry["target"]
 
 
+def resolve_build_log(
+    log_dir: pathlib.Path | None, artifact_dir: pathlib.Path | None
+) -> tuple[pathlib.Path | None, str]:
+    """Prefer clean build log; fall back to warm library build log."""
+    candidates: list[tuple[str, str]] = [
+        ("clean_build.log", "clean build"),
+        ("warm_rebuild.log", "warm library build"),
+    ]
+    search_roots: list[pathlib.Path] = []
+    if log_dir is not None:
+        search_roots.append(log_dir)
+    if artifact_dir is not None:
+        search_roots.append(artifact_dir)
+    for root in search_roots:
+        for name, label in candidates:
+            path = root / name
+            if path.exists():
+                return path, label
+    return None, "build"
+
+
 current_records = load_records(results_path)
 baseline_records = load_records(baseline_dir / "results.jsonl") if baseline_dir else {}
 
-current_log_dir = os.environ.get("BUILD_TIMING_LOG_DIR")
-current_log_path = pathlib.Path(current_log_dir) / "clean_build.log" if current_log_dir else None
-current_clean_build_targets = extract_clean_build_targets(current_log_path)
-baseline_clean_build_targets = (
-    extract_clean_build_targets(baseline_dir / "clean_build.log") if baseline_dir else []
+current_log_dir_env = os.environ.get("BUILD_TIMING_LOG_DIR")
+current_log_dir = pathlib.Path(current_log_dir_env) if current_log_dir_env else None
+current_build_log, current_build_log_label = resolve_build_log(current_log_dir, None)
+current_build_targets = extract_build_targets(current_build_log)
+baseline_build_log, baseline_build_log_label = resolve_build_log(
+    None, baseline_dir
 )
+baseline_build_targets = extract_build_targets(baseline_build_log)
 
 source_sha = os.environ.get("BUILD_TIMING_SOURCE_SHA")
 source_subject = os.environ.get("BUILD_TIMING_SOURCE_SUBJECT")
@@ -242,13 +272,21 @@ if baseline_records:
     elif baseline_label:
         print(f"- Comparison baseline: {baseline_label}.")
 print("- Measured on `ubuntu-latest` with `/usr/bin/time -p`.")
-print(
-    "- Commands: "
-    + "; ".join(
-        f"{display[label]['name'].lower()} {display[label]['command']}" for label in ordered_labels
+measured_labels = [label for label in ordered_labels if label in current_records]
+if measured_labels:
+    print(
+        "- Commands: "
+        + "; ".join(
+            f"{display[label]['name'].lower()} {display[label]['command']}"
+            for label in measured_labels
+        )
+        + "."
     )
-    + "."
-)
+if "clean_build" not in current_records:
+    print(
+        "- Clean build was skipped (default warm/incremental CI). "
+        "Trigger via Actions → Lean Action CI → Run workflow with `clean_build`."
+    )
 print()
 
 if not current_records:
@@ -294,42 +332,47 @@ if clean and warm:
     delta = clean["real"] - warm["real"]
     ratio = clean["real"] / warm["real"] if warm["real"] else None
     if ratio is None:
-        print(f"- Warm rebuild saved `{delta:.2f}s` vs clean.")
-        print("- Clean:warm ratio is unavailable because `warm rebuild` reported `0.00s`.")
+        print(f"- Warm library build saved `{delta:.2f}s` vs clean.")
+        print("- Clean:warm ratio is unavailable because warm build reported `0.00s`.")
     elif delta > 0:
-        print(f"- Warm rebuild saved `{delta:.2f}s` vs clean (`{ratio:.2f}x` faster).")
+        print(f"- Warm library build saved `{delta:.2f}s` vs clean (`{ratio:.2f}x` faster).")
     elif delta < 0:
         slowdown = warm["real"] - clean["real"]
         slowdown_ratio = warm["real"] / clean["real"] if clean["real"] else None
         if slowdown_ratio is None:
-            print(f"- Warm rebuild took `{slowdown:.2f}s` longer than clean in this run.")
+            print(f"- Warm library build took `{slowdown:.2f}s` longer than clean in this run.")
         else:
             print(
-                f"- Warm rebuild took `{slowdown:.2f}s` longer than clean in this run "
+                f"- Warm library build took `{slowdown:.2f}s` longer than clean in this run "
                 f"(`{slowdown_ratio:.2f}x` slower)."
             )
     else:
-        print("- Warm rebuild matched clean build wall-clock in this run.")
+        print("- Warm library build matched clean build wall-clock in this run.")
+    print()
+    print(
+        "This compares a clean project build against a follow-up `lake build` in the same CI job "
+        "(only meaningful when `clean_build` was requested)."
+    )
+elif warm and not clean:
+    print(
+        "- Warm-only run: default CI reuses cached oleans and rebuilds dirty modules only. "
+        "No same-job clean:warm ratio."
+    )
 else:
     print("- Clean:warm comparison is unavailable because one of the build measurements is missing.")
 
 print()
-print(
-    "This compares a clean project build against an incremental rebuild in the same CI job; "
-    "it is a lightweight variability signal, not a full cross-run benchmark."
-)
-
+print(f"### Slowest Current Build Files ({current_build_log_label})")
 print()
-print("### Slowest Current Clean-Build Files")
-print()
-if current_clean_build_targets:
-    shown = current_clean_build_targets[:20]
-    if baseline_clean_build_targets:
+if current_build_targets:
+    shown = current_build_targets[:20]
+    if baseline_build_targets:
         baseline_targets_by_key = {
-            target_key(entry): entry for entry in baseline_clean_build_targets
+            target_key(entry): entry for entry in baseline_build_targets
         }
         print(
-            f"Showing {len(shown)} slowest current targets, with comparison against the selected baseline when available."
+            f"Showing {len(shown)} slowest current targets from the {current_build_log_label} log, "
+            f"with comparison against the baseline {baseline_build_log_label} log when available."
         )
         print()
         print("| Current (s) | Baseline (s) | Delta (s) | Path |")
@@ -346,7 +389,8 @@ if current_clean_build_targets:
             print(f"| {fmt(entry['seconds'])} | {baseline_time} | {delta} | `{key}` |")
     else:
         print(
-            f"Showing {len(shown)} slowest of {len(current_clean_build_targets)} repo targets parsed from the current clean build log."
+            f"Showing {len(shown)} slowest of {len(current_build_targets)} repo targets "
+            f"parsed from the current {current_build_log_label} log."
         )
         print()
         print("| Wall (s) | Path |")
@@ -354,7 +398,7 @@ if current_clean_build_targets:
         for entry in shown:
             print(f"| {fmt(entry['seconds'])} | `{target_key(entry)}` |")
 else:
-    print("No per-target timings were parsed from the current clean build log.")
+    print(f"No per-target timings were parsed from the current {current_build_log_label} log.")
 PY
 }
 


### PR DESCRIPTION
## Summary

Make Lean Action CI **warm/incremental by default** so PR builds reuse cached Lake oleans and only recompile dirty modules (Lake + module system already do this once artifacts exist), and fix the cache layer that warmth depends on.

### Default path (PR / push / dispatch)

1. Restore the dependency cache (`.lake/packages`) and the build cache (`.lake/build`).
2. On a dependency-cache miss, `lake exe cache get`.
3. **`lake build`** — no `rm -rf .lake/build`.
4. `lake test`, benches, timing report (unchanged otherwise).

### Optional clean build

**Actions → Lean Action CI → Run workflow** and set **`clean_build: true`**. That run:

1. Wipes `.lake/build` and times a full cold `lake build`.
2. Continues with the normal warm `lake build` + `lake test`.

A clean build also runs automatically when `lean-toolchain` or `lake-manifest.json` differs from the comparison base (PR base, previous push tip, or merge-base with `main` on dispatch).

### Timing report

- Warm-only runs no longer require a clean measurement.
- Slowest-module table uses the clean log when present, otherwise the warm build log.
- Notes when clean was skipped and how to request it.

## Cache split and Mathlib fallback

Warm builds only pay off when the restore actually hits, and it often did not.

The old single `path: .lake` entry carried the dependencies *and* our own build at **~2.6 GiB per commit**. Keyed per commit against GitHub's **10 GB** per-repo quota, that left room for roughly four entries, so consecutive pushes evicted one another. The repo was sitting at **~10.3 GiB active — permanently over quota**, which is exactly the condition that makes a warm-by-default strategy fall back to cold. (An earlier revision of this PR also added a `lake exe cache get` step, on the mistaken belief that CI never fetched Mathlib's cache. It does — via lean-action's `use-mathlib-cache: auto` default. That step was redundant and has been removed; see the correction comment below.)

- **`.lake/packages` cached on its own**, keyed only on `lean-toolchain` + `lake-manifest.json` — no commit component, no restore-keys. The version lock fully determines the dependency set, so a hit is always exact, and the bulky entry is written **once per version-lock bump** instead of once per push.
- **`.lake/build` cached separately**, still keyed per commit with restore-keys. Many small per-commit entries now fit in the quota the dependency entry used to churn through.
- **`use-mathlib-cache: true` set explicitly on `lean-action`.** Mathlib's oleans already arrive this way — lean-action detects the Mathlib dependency and runs `lake exe cache get` itself, which is the `auto` default. Setting it explicitly documents the reliance and pins it against a future change of default, so a dependency-cache miss keeps costing a download rather than a Mathlib compile.

`.lake/config` (~1.7 MB of elaborated lakefile artifacts) is no longer cached; Lake regenerates it in about a second.

### Docs

- `docs/wiki/quickstart.md` CI mapping — including the two cache entries and the fallback.
- `scripts/README.md` timing labels.

No new timing labels were introduced, so `build_timing_report.sh` and the workflow's per-label artifact allowlist are untouched.

## Note on baselines

The first few warm PR timing comments may compare against older **clean-default** baselines (apples-to-oranges once). After `main` has a few warm successful runs, comparisons re-align on warm vs warm.

## Test plan

- [x] `bash -n scripts/build_timing_report.sh`
- [x] Smoke render warm-only and clean+warm synthetic results
- [x] Docs integrity
- [x] YAML parses; step order and `if:` conditions verified; no dangling references to the removed `lake-cache` step id
- [ ] CI on this PR: no wipe step; warm build runs
- [ ] First run after merge is a cold miss on both new keys (the key names changed, so old entries are unreachable) — expect one full `lake exe cache get` + build, then warm runs after
- [ ] Confirm cache usage drops below quota afterwards: `gh api repos/Verified-zkEVM/CompPoly/actions/cache/usage`
- [ ] Manual dispatch with `clean_build: true` (optional smoke after merge)