### PR TITLE
refactor: pilot opaque Univariate.Raw modules

### DIFF
--- a/CompPoly/Bivariate/CoeffRows.lean
+++ b/CompPoly/Bivariate/CoeffRows.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Bivariate.Basic
 public import CompPoly.LinearAlgebra.PolynomialMatrix.Shifted
 

--- a/CompPoly/Bivariate/Factor.lean
+++ b/CompPoly/Bivariate/Factor.lean
@@ -5,6 +5,7 @@ Authors: Dimitris Mitsios
 -/
 module
 
+import all CompPoly.Bivariate.ToPoly
 public import CompPoly.Bivariate.Basic
 public import CompPoly.Bivariate.ToPoly
 

--- a/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Combinations.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Combinations.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.LeeOSullivan.Correctness.Common
 
 /-!

--- a/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Rows.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Rows.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.LeeOSullivan.Correctness.Basis
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.LeeOSullivan.Correctness.Combinations
 public import CompPoly.LinearAlgebra.PolynomialMatrix.MuldersStorjohannCorrectness

--- a/CompPoly/Bivariate/GuruswamiSudan/PolynomialCorrectness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/PolynomialCorrectness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Bivariate.Deriv
 public import CompPoly.Bivariate.GuruswamiSudan.Polynomial
 public import CompPoly.Data.List.Lemmas

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/Alekhnovich/Correctness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/Alekhnovich/Correctness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Root.Alekhnovich.Lemmas
 public import CompPoly.Bivariate.GuruswamiSudan.Root.RothRuckenstein.Lemmas
 

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/Common/Lemmas.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/Common/Lemmas.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Root.Common
 public import CompPoly.Bivariate.GuruswamiSudan.PolynomialCorrectness
 

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Correctness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Correctness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Root.RothRuckenstein.Lemmas
 
 /-!

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Lemmas.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Lemmas.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Root.RothRuckenstein.Algorithm
 public import CompPoly.Bivariate.GuruswamiSudan.Root.Common.Lemmas
 public import CompPoly.Bivariate.GuruswamiSudan.PolynomialCorrectness

--- a/CompPoly/Bivariate/Kronecker.lean
+++ b/CompPoly/Bivariate/Kronecker.lean
@@ -5,6 +5,7 @@ Authors: Dimitris Mitsios
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Impl
 public import CompPoly.Bivariate.Basic
 public import CompPoly.Univariate.ToPoly
 public import CompPoly.Univariate.NTT.FastMul

--- a/CompPoly/Bivariate/ToPoly.lean
+++ b/CompPoly/Bivariate/ToPoly.lean
@@ -5,6 +5,7 @@ Authors: Derek Sorensen
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Impl
 public import CompPoly.Bivariate.Basic
 public import CompPoly.Univariate.ToPoly.Impl
 public import Mathlib.Algebra.Polynomial.Bivariate

--- a/CompPoly/LinearAlgebra/PolynomialMatrix/MuldersStorjohannCorrectness/Leading.lean
+++ b/CompPoly/LinearAlgebra/PolynomialMatrix/MuldersStorjohannCorrectness/Leading.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.LinearAlgebra.PolynomialMatrix.MuldersStorjohannCorrectness.Conflict
 
 /-!

--- a/CompPoly/Univariate/Basic.lean
+++ b/CompPoly/Univariate/Basic.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles, Valerii
 -/
 module
 
+import all CompPoly.Univariate.Raw.Proofs
 public import Mathlib.Algebra.Tropical.Basic
 public import Mathlib.RingTheory.Polynomial.Basic
 public import CompPoly.Data.Array.Lemmas

--- a/CompPoly/Univariate/Deriv.lean
+++ b/CompPoly/Univariate/Deriv.lean
@@ -5,6 +5,7 @@ Authors: Dimitris Mitsios
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Impl
 public import CompPoly.Univariate.Basic
 public import CompPoly.Univariate.ToPoly.Impl
 public import Mathlib.Algebra.Polynomial.Taylor

--- a/CompPoly/Univariate/DivisionCorrectness.lean
+++ b/CompPoly/Univariate/DivisionCorrectness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin, Juan Conejero
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Impl
 public import Mathlib.Algebra.Polynomial.Div
 public import Mathlib.Algebra.Polynomial.FieldDivision
 public import Mathlib.Algebra.Polynomial.Reverse

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -5,6 +5,7 @@ Authors: Juan Conejero, Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.DivisionCorrectness
 public import CompPoly.Univariate.Basic
 public import CompPoly.Univariate.DivisionCorrectness
 public import CompPoly.ToMathlib.Order.WithBot

--- a/CompPoly/Univariate/Lagrange.lean
+++ b/CompPoly/Univariate/Lagrange.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Katerina Hristova, Jul
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Impl
 public import Mathlib.LinearAlgebra.Lagrange
 public import CompPoly.Univariate.Basic
 public import CompPoly.Univariate.ToPoly.Impl

--- a/CompPoly/Univariate/Linear.lean
+++ b/CompPoly/Univariate/Linear.lean
@@ -5,6 +5,7 @@ Authors: Desmond Coles, Derek Sorensen
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.Basic
 
 /-!

--- a/CompPoly/Univariate/NTT/Evaluation.lean
+++ b/CompPoly/Univariate/NTT/Evaluation.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Core
 public import CompPoly.Univariate.BatchEval.Naive
 public import CompPoly.Univariate.NTT.Forward
 public import CompPoly.Univariate.ToPoly.Core

--- a/CompPoly/Univariate/NTT/FastMul.lean
+++ b/CompPoly/Univariate/NTT/FastMul.lean
@@ -5,6 +5,7 @@ Authors: Salih Erdem Koçak, Doran Pamukçu
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.NTT.Evaluation
 public import CompPoly.Univariate.NTT.Forward
 public import CompPoly.Univariate.NTT.Inverse

--- a/CompPoly/Univariate/NTT/FastMulLow.lean
+++ b/CompPoly/Univariate/NTT/FastMulLow.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.NTT.FastMul
 public import CompPoly.Univariate.NTT.FastMul
 
 /-!

--- a/CompPoly/Univariate/NTT/Interpolation.lean
+++ b/CompPoly/Univariate/NTT/Interpolation.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.Lagrange
 public import CompPoly.Univariate.NTT.Evaluation
 public import CompPoly.Univariate.NTT.Inverse

--- a/CompPoly/Univariate/NTTFast/FastMulLow.lean
+++ b/CompPoly/Univariate/NTTFast/FastMulLow.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Raw.Proofs
 public import CompPoly.Univariate.NTTFast.Correctness.Pipeline
 public import CompPoly.Univariate.Raw.Proofs
 

--- a/CompPoly/Univariate/Quotient/Core.lean
+++ b/CompPoly/Univariate/Quotient/Core.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen
 -/
 module
 
+import all CompPoly.Univariate.Raw.Proofs
 public import Mathlib.Algebra.Tropical.Basic
 public import Mathlib.RingTheory.Polynomial.Basic
 public import CompPoly.Data.Array.Lemmas

--- a/CompPoly/Univariate/Quotient/Equiv.lean
+++ b/CompPoly/Univariate/Quotient/Equiv.lean
@@ -5,6 +5,8 @@ Authors: Aristotle (Harmonic), Elias Judin
 -/
 module
 
+import all CompPoly.Univariate.Quotient.Core
+import all CompPoly.Univariate.ToPoly.Equiv
 public import CompPoly.Univariate.Quotient.Core
 public import CompPoly.Univariate.ToPoly.Equiv
 

--- a/CompPoly/Univariate/Raw/Core.lean
+++ b/CompPoly/Univariate/Raw/Core.lean
@@ -15,7 +15,7 @@ public import CompPoly.Data.Array.Lemmas
 Core definitions for array-backed computable univariate polynomials.
 -/
 
-@[expose] public section
+public section
 
 open Polynomial
 
@@ -28,17 +28,17 @@ namespace CompPoly
   Two arrays may represent the same polynomial via zero-padding,
   for example `#[1,2,3] = #[1,2,3,0,0,0,...]`.
 -/
-@[reducible, inline, specialize]
+@[expose, reducible, inline, specialize]
 def CPolynomial.Raw (R : Type*) := Array R
 
 namespace CPolynomial.Raw
 
 /-- Construct a `CPolynomial.Raw` from an array of coefficients. -/
-@[reducible]
+@[expose, reducible]
 def mk {R : Type*} (coeffs : Array R) : CPolynomial.Raw R := coeffs
 
 /-- Extract the underlying array of coefficients. -/
-@[reducible]
+@[expose, reducible]
 def coeffs {R : Type*} (p : CPolynomial.Raw R) : Array R := p
 
 variable {R : Type*}

--- a/CompPoly/Univariate/Raw/Division.lean
+++ b/CompPoly/Univariate/Raw/Division.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles, Valerii
 -/
 module
 
+import all CompPoly.Univariate.Raw.Ops
 public import CompPoly.Univariate.Raw.Ops
 
 /-!
@@ -13,7 +14,7 @@ public import CompPoly.Univariate.Raw.Ops
 Division algorithms for raw computable univariate polynomials.
 -/
 
-@[expose] public section
+public section
 
 namespace CompPoly
 
@@ -26,6 +27,7 @@ section Division
 variable [BEq R]
 
 /-- Division with remainder by a monic polynomial using polynomial long division. -/
+@[expose]
 def divModByMonicAux [CommRing R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
     CPolynomial.Raw R × CPolynomial.Raw R :=
   go p.size p q
@@ -68,7 +70,7 @@ Unlike `modByMonic`, this does not compute the quotient and avoids the general
 polynomial multiplications used by each cancellation step. It is intended as an
 executable implementation for the canonical `modByMonic` specification.
 -/
-@[inline, specialize]
+@[expose, inline, specialize]
 def modByMonicRemainderOnly [Field R] (p : CPolynomial.Raw R) (q : CPolynomial.Raw R) :
     CPolynomial.Raw R :=
   go p.size p q
@@ -84,7 +86,7 @@ where
         go n p' q
 
 /-- Inverse modulo `X^k`, using Newton iteration and the supplied low-product backend. -/
-@[inline, specialize]
+@[expose, inline, specialize]
 def inverseModX [Field R] [LawfulBEq R] (M : MulLowContext R) (k : Nat)
     (p : CPolynomial.Raw R) : CPolynomial.Raw R :=
   if k = 0 then

--- a/CompPoly/Univariate/Raw/Ops.lean
+++ b/CompPoly/Univariate/Raw/Ops.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles,
 -/
 module
 
+import all CompPoly.Univariate.Raw.Core
 public import CompPoly.Univariate.Raw.Core
 
 /-!
@@ -14,7 +15,7 @@ public import CompPoly.Univariate.Raw.Core
 Operations and evaluation lemmas for raw computable univariate polynomials.
 -/
 
-@[expose] public section
+public section
 
 namespace CompPoly
 

--- a/CompPoly/Univariate/Raw/Proofs.lean
+++ b/CompPoly/Univariate/Raw/Proofs.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen, Desmond Coles,
 -/
 module
 
+import all CompPoly.Univariate.Raw.Division
 public import CompPoly.Univariate.Raw.Division
 
 /-!
@@ -14,7 +15,7 @@ public import CompPoly.Univariate.Raw.Division
 Proofs about operations on raw computable univariate polynomials.
 -/
 
-@[expose] public section
+public section
 
 namespace CompPoly
 

--- a/CompPoly/Univariate/ReedSolomon.lean
+++ b/CompPoly/Univariate/ReedSolomon.lean
@@ -5,6 +5,7 @@ Authors: Juan Conejero
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Impl
 public import CompPoly.Univariate.ToPoly.Impl
 
 /-!

--- a/CompPoly/Univariate/ReedSolomon/NTTEncode.lean
+++ b/CompPoly/Univariate/ReedSolomon/NTTEncode.lean
@@ -5,6 +5,7 @@ Authors: Abraxas1010 (IAOM / Apoth3osis)
 -/
 module
 
+import all CompPoly.Univariate.ReedSolomon
 public import CompPoly.Univariate.ReedSolomon
 public import CompPoly.Univariate.NTT.Evaluation
 

--- a/CompPoly/Univariate/Roots/Correctness.lean
+++ b/CompPoly/Univariate/Roots/Correctness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.EuclideanAlgorithm
 public import CompPoly.Univariate.Roots.Backend
 public import CompPoly.Univariate.Roots.Splitter
 public import CompPoly.Univariate.EuclideanAlgorithm

--- a/CompPoly/Univariate/Roots/RootProduct.lean
+++ b/CompPoly/Univariate/Roots/RootProduct.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.EuclideanAlgorithm
 public import CompPoly.Univariate.Raw.Modular
 public import CompPoly.Univariate.EuclideanAlgorithm
 public import CompPoly.Univariate.Roots.Context

--- a/CompPoly/Univariate/Roots/SmoothSubgroup/Correctness.lean
+++ b/CompPoly/Univariate/Roots/SmoothSubgroup/Correctness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.Roots.Correctness
 public import CompPoly.Univariate.Roots.RootProduct
 public import CompPoly.Univariate.Roots.SmoothSubgroup.Basic

--- a/CompPoly/Univariate/Roots/Splitter.lean
+++ b/CompPoly/Univariate/Roots/Splitter.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.Raw.Modular
 public import CompPoly.Univariate.Roots.Context
 

--- a/CompPoly/Univariate/ToPoly/Core.lean
+++ b/CompPoly/Univariate/ToPoly/Core.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import Mathlib.Algebra.Polynomial.Inductions
 public import Mathlib.Algebra.Ring.TransferInstance
 public import Mathlib.Algebra.Tropical.Basic

--- a/CompPoly/Univariate/ToPoly/Degree.lean
+++ b/CompPoly/Univariate/ToPoly/Degree.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Impl
 public import CompPoly.Univariate.ToPoly.Impl
 
 /-!

--- a/CompPoly/Univariate/ToPoly/Equiv.lean
+++ b/CompPoly/Univariate/ToPoly/Equiv.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Core
 public import CompPoly.Univariate.ToPoly.Core
 
 /-!

--- a/CompPoly/Univariate/ToPoly/Impl.lean
+++ b/CompPoly/Univariate/ToPoly/Impl.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao, Gregor Mitscha-Baude, Derek Sorensen
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Equiv
 public import CompPoly.Univariate.ToPoly.Equiv
 public import Mathlib.Algebra.Polynomial.Roots
 

--- a/docs/wiki/module-system.md
+++ b/docs/wiki/module-system.md
@@ -7,7 +7,8 @@ The reference for the module system is [here](https://lean-lang.org/doc/referenc
 
 ## File Header Shape
 
-After the migration to the module system library and bench files look like this:
+New library modules should use the narrowest import and exposure modifiers that
+their public API requires:
 
 ```lean
 /-
@@ -17,25 +18,47 @@ Authors: ...
 -/
 module
 
-public import Mathlib.Algebra.Ring.Defs
+import Mathlib.Tactic.Ring
 public import CompPoly.Data.Array.Lemmas
 
 /-!
 # Module docstring
 -/
 
-@[expose] public section
+public section
 ```
 
 - `module` goes on the line after the copyright header, before the imports.
-- Imports are `public import`, so downstream modules keep seeing them.
-  - As we develop the library and reduce the export surface, 
-    we may make imports non-public.
-- `@[expose] public section` goes after the module docstring and stays open for the
-  rest of the file, so definition bodies remain available to `rfl`, `decide`, `simp`,
-  and kernel reduction downstream.
-  - As we develop the library and reduce the export surface, 
-    we may remove `@[expose]`.
+- Use plain `import` for proof and implementation dependencies. Use `public import`
+  only when the current module deliberately re-exports the imported API or a public
+  declaration requires it.
+- Use `public section` for exported declarations. Keep definition bodies opaque by
+  default, and put `@[expose]` on individual definitions only when downstream
+  definitional reduction is an intentional part of their interface.
+
+## Internal Definition Access
+
+Proof and correctness modules in this package may need to unfold an implementation
+without exposing it to every downstream importer. Import the private scope alongside
+the public API in that case:
+
+```lean
+module
+
+import all CompPoly.Univariate.Raw.Ops
+public import CompPoly.Univariate.Raw.Ops
+
+public section
+```
+
+The plain `import all` is an explicit same-package implementation dependency; the
+separate `public import` preserves the intended re-export. Prefer a characterization
+lemma when ordinary downstream code only needs a behavioral fact. The
+`CompPoly.Univariate.Raw` modules are the first migrated example of this pattern.
+
+Definitions implemented with a `where` recursion may require targeted `@[expose]`
+when a separate correctness module refers to the generated `.go` declaration by
+name. Do not restore file-wide exposure for this case.
 
 ## Test Files And `meta`
 

--- a/tests/CompPolyTests/Univariate/Basic.lean
+++ b/tests/CompPolyTests/Univariate/Basic.lean
@@ -5,6 +5,7 @@ Authors: Derek Sorensen
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.Basic
 
 /-!

--- a/tests/CompPolyTests/Univariate/Linear.lean
+++ b/tests/CompPolyTests/Univariate/Linear.lean
@@ -5,6 +5,7 @@ Authors: Derek Sorensen
 -/
 module
 
+import all CompPoly.Univariate.ToPoly.Degree
 public import CompPoly.Univariate.ToPoly.Degree
 
 /-!


### PR DESCRIPTION
## Summary

- make the `Univariate.Raw` Core, Ops, Division, and Proofs modules opaque by default
- use paired `import all` and public imports for same-package correctness and white-box test dependencies
- retain targeted exposure only for reducible representation aliases and recursive definitions whose proofs name generated `.go` declarations
- document the narrower module policy and the pilot pattern

## Pilot findings

- the build identified 40 explicit same-package consumers of Raw implementation details, including two white-box tests
- three recursive division definitions still require targeted exposure because separate correctness proofs refer to generated `.go` declarations
- public declarations, facade imports, and executable behavior remain unchanged

This PR is intentionally limited to the Raw pilot so the coupling map and CI timing report can be evaluated before applying the pattern elsewhere.

## Validation

- `lake build`
- `lake test`
- `lake build CompPolyBench`
- `./scripts/lint-style.sh`
- `python3 ./scripts/check-docs-integrity.py`