### PR TITLE
refactor: make canonical polynomial implementations opaque

### DIFF
--- a/CompPoly/Bivariate/Basic.lean
+++ b/CompPoly/Bivariate/Basic.lean
@@ -5,6 +5,7 @@ Authors: Derek Sorensen, Dimitris Mitsios
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.Basic
 
 /-!
@@ -243,7 +244,8 @@ variable {R : Type*}
 /-- `CBivariate.coeff` as two composed `CPolynomial.coeff`. -/
 @[simp]
 theorem coeff_eq_coeff_coeff [Zero R] (f : CBivariate R) (i j : ℕ) :
-    coeff f i j = CPolynomial.coeff (CPolynomial.coeff f j) i := rfl
+    coeff f i j = CPolynomial.coeff (CPolynomial.coeff f j) i := by
+  rfl
 
 /-- Bivariate coefficients are additive. -/
 theorem coeff_add [Semiring R] [BEq R] [LawfulBEq R] [Nontrivial R]

--- a/CompPoly/Bivariate/Deriv.lean
+++ b/CompPoly/Bivariate/Deriv.lean
@@ -5,6 +5,7 @@ Authors: Dimitris Mitsios
 -/
 module
 
+import all CompPoly.Bivariate.Basic
 public import CompPoly.Bivariate.Basic
 public import CompPoly.Bivariate.ToPoly
 public import CompPoly.Univariate.Deriv

--- a/CompPoly/Bivariate/GuruswamiSudan/Interpolation/Dense/Correctness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Interpolation/Dense/Correctness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Bivariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.Dense.Algorithm
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.Correctness
 public import CompPoly.Bivariate.GuruswamiSudan.PolynomialCorrectness

--- a/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Basis.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Basis.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Bivariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.LeeOSullivan.Correctness.Common
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.LeeOSullivan.Correctness.Combinations
 

--- a/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Completeness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Completeness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Bivariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.LeeOSullivan.Correctness.Divisibility
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.LeeOSullivan.Correctness.Soundness
 

--- a/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Divisibility.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Divisibility.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Bivariate.GuruswamiSudan.Interpolation.LeeOSullivan.Correctness.Basis
 
 /-!

--- a/CompPoly/Bivariate/GuruswamiSudan/PolynomialCorrectness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/PolynomialCorrectness.lean
@@ -309,7 +309,6 @@ theorem ofMonomialCoeffs_ne_zero_of_coeff_getD_ne_zero {R : Type*}
   let monomial := monomials.getD k ⟨0, 0⟩
   have hget := ofMonomialCoeffs_coeff_getD (R := R) (monomials := monomials)
     (coeffs := coeffs) hnodup hk
-  dsimp [monomial] at hget
   have hzeroCoeff :
       coeff (ofMonomialCoeffs monomials coeffs) monomial.xDegree monomial.yDegree = 0 := by
     rw [hzero]

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/Common/Lemmas.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/Common/Lemmas.lean
@@ -489,7 +489,7 @@ theorem initialCoefficientPolynomial_evalHorner_eq_composeYCoeff_monomial_zero
         simp only [List.foldl_cons]
         apply ih
         dsimp [polyStep, coeffStep]
-        rw [cpoly_eval_add, hacc, cpoly_eval_monomial,
+        rw [cpoly_eval_add, hacc, cpoly_eval_monomial, CBivariate.coeff_eq_coeff_coeff,
           cpoly_mulPowCoeff_monomial_zero_depth_zero]
   exact hfold (List.range' 0 Q.val.size) 0 0
     (by simp [CPolynomial.eval_toPoly, CPolynomial.toPoly_zero])

--- a/CompPoly/Univariate/Basic.lean
+++ b/CompPoly/Univariate/Basic.lean
@@ -23,7 +23,7 @@ public import CompPoly.Univariate.Raw.Division
   properties compared to the raw `CPolynomial.Raw` type.
 -/
 
-@[expose] public section
+public section
 namespace CompPoly
 
 open CPolynomial.Raw
@@ -54,6 +54,7 @@ variable {R : Type*}
   The NTT `butterflyStage` in `Univariate/NTT/Transform.lean` is not on this list: it
   operates on a scalar coefficient `Array R` and never calls `trim`.
 -/
+@[expose]
 def CPolynomial (R : Type*) [Zero R] := { p : CPolynomial.Raw R // IsCanonical p }
 
 namespace CPolynomial

--- a/CompPoly/Univariate/BatchEval/Correctness.lean
+++ b/CompPoly/Univariate/BatchEval/Correctness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.BatchEval.SubproductTree
 public import CompPoly.Univariate.ToPoly.Impl
 

--- a/CompPoly/Univariate/CoefficientInterpolation.lean
+++ b/CompPoly/Univariate/CoefficientInterpolation.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.BatchEval.Context
 public import CompPoly.Univariate.Deriv
 public import CompPoly.Univariate.Vanishing

--- a/CompPoly/Univariate/ManyEval/Correctness.lean
+++ b/CompPoly/Univariate/ManyEval/Correctness.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.ManyEval.Basic
 public import CompPoly.Data.Array.Lemmas
 

--- a/CompPoly/Univariate/Raw/Context.lean
+++ b/CompPoly/Univariate/Raw/Context.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.DivisionCorrectness
 public import CompPoly.Univariate.NTT.FastMul
 public import CompPoly.Univariate.NTT.FastMulLow

--- a/CompPoly/Univariate/Vanishing.lean
+++ b/CompPoly/Univariate/Vanishing.lean
@@ -5,6 +5,7 @@ Authors: Valerii Huhnin
 -/
 module
 
+import all CompPoly.Univariate.Basic
 public import CompPoly.Univariate.BatchEval.SubproductTree
 
 /-!

--- a/tests/CompPolyTests/Bivariate/Basic.lean
+++ b/tests/CompPolyTests/Bivariate/Basic.lean
@@ -5,6 +5,7 @@ Authors: Derek Sorensen
 -/
 module
 
+import all CompPoly.Bivariate.Basic
 public import CompPoly.Bivariate.ToPoly
 
 /-!


### PR DESCRIPTION
## Summary

- remove file-wide `@[expose]` from `CompPoly.Univariate.Basic`
- retain targeted exposure for the `CPolynomial` representation type
- give only proofs and white-box tests that unfold Basic definitions explicit private-scope access
- convert an exported bare `rfl` proof to a private tactic proof
- replace one definitional dependency with the public `CBivariate.coeff_eq_coeff_coeff` theorem

This PR is stacked on #294 and contains only the next `Univariate.Basic` opacity layer.

## Internal dependency ledger

Twelve consumers require private access as currently written:

- `Bivariate.Basic`: coefficient, monomial, and weighted-degree representation proofs
- `Bivariate.Deriv`: nested coefficient representation proofs
- dense interpolation correctness: canonical/raw coefficient identification
- Lee-O-Sullivan basis and completeness correctness: nested coefficient identification
- Lee-O-Sullivan divisibility: unfolds `linearFactor`
- batch-evaluation correctness and vanishing-polynomial proofs: unfold `linearFactor`
- coefficient interpolation: unfolds `linearFactor` and `natDegree`
- many-evaluation correctness: unfolds `eval`
- Raw context adapters: canonical wrapper and reversal-modulus definitional equality
- bivariate Basic tests: white-box reduction of `monomialXY`

`Root.Common.Lemmas` initially appeared to need the private bivariate scope, but the dependency was removed by rewriting with `CBivariate.coeff_eq_coeff_coeff` instead.

## Validation

- `lake build`
- `lake test`
- `lake build CompPolyBench`
- `./scripts/lint-style.sh`