### PR TITLE
refactor: make toPoly core implementations opaque

### DIFF
--- a/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Divisibility.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Interpolation/LeeOSullivan/Correctness/Divisibility.lean
@@ -256,8 +256,7 @@ theorem coeffY_dvd_vanishingPolynomial_pow_of_multiplicity
     apply cpoly_eq_of_toPoly_eq
     rw [CPolynomial.toPoly_mul, CPolynomial.toPoly_pow]
     have hWto : W.toPoly = Wpoly := by
-      change Wpoly.toImpl.toPoly = Wpoly
-      exact CPolynomial.Raw.toPoly_toImpl
+      simpa only [W] using CPolynomial.toPoly_mk_toImpl Wpoly
     rw [hWto]
     rw [hWpoly]
     ring

--- a/CompPoly/Univariate/NTT/Interpolation.lean
+++ b/CompPoly/Univariate/NTT/Interpolation.lean
@@ -179,10 +179,8 @@ theorem inverseSpec_interpolatePow_eq [BEq R] [LawfulBEq R]
             exact (CPolynomial.Raw.toImpl_toPoly (R := R) (inverseSpec D values)).symm
     _ = q.toPoly.toImpl := by
             rw [hpoly]
-    _ = q.val.trim := by
-            exact CPolynomial.Raw.toImpl_toPoly (R := R) q.val
     _ = q.val := by
-            exact CPolynomial.Raw.Trim.trim_eq_of_isCanonical q.property
+            exact CPolynomial.toImpl_toPoly_of_canonical q
 
 /-- The inverse NTT implementation interpolates the input values on the NTT domain. -/
 theorem inverseImpl_interpolatePow_eq [BEq R] [LawfulBEq R]

--- a/CompPoly/Univariate/ToPoly/Core.lean
+++ b/CompPoly/Univariate/ToPoly/Core.lean
@@ -20,7 +20,7 @@ public import CompPoly.Univariate.Linear
 Conversions between computable univariate polynomials and mathlib `Polynomial`.
 -/
 
-@[expose] public section
+public section
 
 open Polynomial
 
@@ -209,6 +209,13 @@ theorem trim_toImpl [LawfulBEq R] (p : R[X]) : p.toImpl.trim = p.toImpl := by
   exact Trim.trim_eq_of_isCanonical (isCanonical_toImpl p)
 
 end Raw
+
+omit [BEq R] in
+/-- Building a canonical polynomial from `toImpl` and converting it back yields the
+original mathlib polynomial. -/
+theorem toPoly_mk_toImpl (p : R[X]) :
+    CPolynomial.toPoly ⟨p.toImpl, Raw.isCanonical_toImpl p⟩ = p := by
+  exact Raw.toPoly_toImpl
 
 /-- `ofArray` preserves the raw polynomial's `toPoly` image. -/
 theorem ofArray_toPoly [LawfulBEq R] (p : CPolynomial.Raw R) :

--- a/CompPoly/Univariate/ToPoly/Degree.lean
+++ b/CompPoly/Univariate/ToPoly/Degree.lean
@@ -40,7 +40,7 @@ noncomputable def toPolyLinearEquiv : CPolynomial R ≃ₗ[R] R[X] where
   map_add' := toPoly_add
   map_smul' := toPoly_smul
   left_inv := fun p => Subtype.ext (toImpl_toPoly_of_canonical p)
-  right_inv := fun _ => toPoly_toImpl
+  right_inv := toPoly_mk_toImpl
 theorem degree_le_iff_coeff_zero (p : CPolynomial R) (n : WithBot ℕ) :
     p.degree ≤ n ↔ ∀ k : ℕ, n < k → p.coeff k = 0 := by
     rw [degree_toPoly, Polynomial.degree_le_iff_coeff_zero]


### PR DESCRIPTION
## Summary

- make Univariate.ToPoly.Core public definitions opaque by default
- add a public toPoly_mk_toImpl characterization theorem
- update downstream proofs to use public round-trip lemmas
- add no new import all dependencies

This PR is stacked on #295.

## Dependency ledger

- Univariate.ToPoly.Degree: the linear equivalence right inverse previously relied on reducing the canonical toPoly wrapper; it now uses toPoly_mk_toImpl.
- Univariate.NTT.Interpolation: the interpolation round trip previously reduced toPoly and toImpl wrappers; it now uses the existing toImpl_toPoly_of_canonical theorem.
- LeeOSullivan Correctness Divisibility: construction of a canonical witness from a mathlib polynomial previously reduced the wrapper; it now uses toPoly_mk_toImpl.

A direct private Core dependency was tested for Degree but removed because the public characterization theorem is a narrower and more stable interface.

## Validation

- lake build
- lake test
- lake build CompPolyBench
- ./scripts/lint-style.sh