### PR TITLE
refactor: make toPoly equivalence opaque

### DIFF
--- a/CompPoly/Bivariate/Deriv.lean
+++ b/CompPoly/Bivariate/Deriv.lean
@@ -270,8 +270,8 @@ theorem shiftY_toPoly [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [Dec
   congr 1
   rw [Polynomial.map_add, Polynomial.map_X, Polynomial.map_C]
   congr 2
-  show (CPolynomial.C b).toPoly = _
-  rw [CPolynomial.C_toPoly]
+  change (CPolynomial.ringEquiv (R := R)).toRingHom (CPolynomial.C b) = _
+  rw [CPolynomial.ringEquiv_toRingHom_apply, CPolynomial.C_toPoly]
 
 /-- Outer coefficient of the X-shift: Taylor-shift the j-th Y-coefficient. -/
 theorem outerCoeff_shiftX [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
@@ -302,10 +302,17 @@ theorem eval_C_eq_evalY [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (b : R) (Q : CBivariate R) :
     CPolynomial.eval (CPolynomial.C b) Q = evalY b Q := by
   apply CPolynomial.ringEquiv.injective
-  show (CPolynomial.eval (CPolynomial.C b) Q).toPoly = (evalY b Q).toPoly
+  change
+    (CPolynomial.ringEquiv (R := R)).toRingHom
+        (CPolynomial.eval (CPolynomial.C b) Q) =
+      (CPolynomial.ringEquiv (R := R)).toRingHom (evalY b Q)
+  rw [CPolynomial.ringEquiv_toRingHom_apply, CPolynomial.ringEquiv_toRingHom_apply]
   rw [evalY_toPoly, CPolynomial.eval_toPoly, toPoly_eq_map, ← CPolynomial.C_toPoly b]
-  exact (Polynomial.eval_map_apply (p := CPolynomial.toPoly Q)
-          (CPolynomial.ringEquiv (R := R)).toRingHom (CPolynomial.C b)).symm
+  have h := (Polynomial.eval_map_apply (p := CPolynomial.toPoly Q)
+    (CPolynomial.ringEquiv (R := R)).toRingHom (CPolynomial.C b)).symm
+  rw [CPolynomial.ringEquiv_toRingHom_apply,
+    CPolynomial.ringEquiv_toRingHom_apply] at h
+  exact h
 
 /-- The (0,0) coefficient of the shift is evaluation at the point. -/
 theorem coeff_shiftC_zero_zero [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]

--- a/CompPoly/Bivariate/Deriv.lean
+++ b/CompPoly/Bivariate/Deriv.lean
@@ -270,8 +270,12 @@ theorem shiftY_toPoly [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [Dec
   congr 1
   rw [Polynomial.map_add, Polynomial.map_X, Polynomial.map_C]
   congr 2
+  have ringEquiv_toPoly (p : CPolynomial R) :
+      (CPolynomial.ringEquiv (R := R)).toRingHom p = p.toPoly := by
+    rw [RingEquiv.toRingHom_eq_coe]
+    exact CPolynomial.ringEquiv_apply p
   change (CPolynomial.ringEquiv (R := R)).toRingHom (CPolynomial.C b) = _
-  rw [CPolynomial.ringEquiv_toRingHom_apply, CPolynomial.C_toPoly]
+  rw [ringEquiv_toPoly, CPolynomial.C_toPoly]
 
 /-- Outer coefficient of the X-shift: Taylor-shift the j-th Y-coefficient. -/
 theorem outerCoeff_shiftX [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R] [DecidableEq R]
@@ -302,16 +306,19 @@ theorem eval_C_eq_evalY [CommSemiring R] [BEq R] [LawfulBEq R] [Nontrivial R]
     (b : R) (Q : CBivariate R) :
     CPolynomial.eval (CPolynomial.C b) Q = evalY b Q := by
   apply CPolynomial.ringEquiv.injective
+  have ringEquiv_toPoly (p : CPolynomial R) :
+      (CPolynomial.ringEquiv (R := R)).toRingHom p = p.toPoly := by
+    rw [RingEquiv.toRingHom_eq_coe]
+    exact CPolynomial.ringEquiv_apply p
   change
     (CPolynomial.ringEquiv (R := R)).toRingHom
         (CPolynomial.eval (CPolynomial.C b) Q) =
       (CPolynomial.ringEquiv (R := R)).toRingHom (evalY b Q)
-  rw [CPolynomial.ringEquiv_toRingHom_apply, CPolynomial.ringEquiv_toRingHom_apply]
+  rw [ringEquiv_toPoly, ringEquiv_toPoly]
   rw [evalY_toPoly, CPolynomial.eval_toPoly, toPoly_eq_map, ← CPolynomial.C_toPoly b]
   have h := (Polynomial.eval_map_apply (p := CPolynomial.toPoly Q)
     (CPolynomial.ringEquiv (R := R)).toRingHom (CPolynomial.C b)).symm
-  rw [CPolynomial.ringEquiv_toRingHom_apply,
-    CPolynomial.ringEquiv_toRingHom_apply] at h
+  rw [ringEquiv_toPoly, ringEquiv_toPoly] at h
   exact h
 
 /-- The (0,0) coefficient of the shift is evaluation at the point. -/

--- a/CompPoly/Bivariate/FactorMonic.lean
+++ b/CompPoly/Bivariate/FactorMonic.lean
@@ -75,7 +75,7 @@ theorem divByLinearY_euclid_toPoly
   rw [Polynomial.map_add, Polynomial.map_mul, CPolynomial.C_toPoly,
     linearYDivisor_toPoly (R := R) f]
   simp only [Polynomial.map_C, Polynomial.map_sub, Polynomial.map_X]
-  simpa [e, CPolynomial.ringEquiv, CBivariate.toPoly_eq_map,
+  simpa [e, CPolynomial.ringEquiv_apply, CBivariate.toPoly_eq_map,
     mul_comm, add_comm, add_left_comm, add_assoc] using
     (divByLinearY_spec Q f).symm
 

--- a/CompPoly/Bivariate/GuruswamiSudan/Interpolation/Correctness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Interpolation/Correctness.lean
@@ -62,7 +62,7 @@ private theorem linearYDivisor_C_toPoly {F : Type*}
       (Polynomial.X - Polynomial.C y).map (Polynomial.C : F →+* Polynomial F) := by
   rw [CBivariate.toPoly_eq_map]
   rw [CBivariate.linearYDivisor_toPoly]
-  simp [CPolynomial.C_toPoly, CPolynomial.ringEquiv]
+  simp [CPolynomial.C_toPoly, CPolynomial.ringEquiv_apply]
 
 private theorem lowMessageYPolynomial_toPoly {F : Type*}
     [Field F] [BEq F] [LawfulBEq F] [DecidableEq F]

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/Alekhnovich/Correctness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/Alekhnovich/Correctness.lean
@@ -385,11 +385,14 @@ private theorem cpoly_C_one {F : Type*}
     [Field F] [BEq F] [LawfulBEq F] :
     CPolynomial.C (1 : F) = 1 := by
   apply CPolynomial.ringEquiv.injective
+  have ringEquiv_toPoly (p : CPolynomial F) :
+      (CPolynomial.ringEquiv (R := F)).toRingHom p = p.toPoly := by
+    rw [RingEquiv.toRingHom_eq_coe]
+    exact CPolynomial.ringEquiv_apply p
   change
     (CPolynomial.ringEquiv (R := F)).toRingHom (CPolynomial.C (1 : F)) =
       (CPolynomial.ringEquiv (R := F)).toRingHom 1
-  rw [CPolynomial.ringEquiv_toRingHom_apply,
-    CPolynomial.ringEquiv_toRingHom_apply]
+  rw [ringEquiv_toPoly, ringEquiv_toPoly]
   rw [CPolynomial.C_toPoly, CPolynomial.toPoly_one, Polynomial.C_1]
 
 private theorem shiftedSubstitutionCoeffTerm_top_coeff {F : Type*}

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/Alekhnovich/Correctness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/Alekhnovich/Correctness.lean
@@ -385,7 +385,11 @@ private theorem cpoly_C_one {F : Type*}
     [Field F] [BEq F] [LawfulBEq F] :
     CPolynomial.C (1 : F) = 1 := by
   apply CPolynomial.ringEquiv.injective
-  change (CPolynomial.C (1 : F)).toPoly = (1 : CPolynomial F).toPoly
+  change
+    (CPolynomial.ringEquiv (R := F)).toRingHom (CPolynomial.C (1 : F)) =
+      (CPolynomial.ringEquiv (R := F)).toRingHom 1
+  rw [CPolynomial.ringEquiv_toRingHom_apply,
+    CPolynomial.ringEquiv_toRingHom_apply]
   rw [CPolynomial.C_toPoly, CPolynomial.toPoly_one, Polynomial.C_1]
 
 private theorem shiftedSubstitutionCoeffTerm_top_coeff {F : Type*}

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/Common/Lemmas.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/Common/Lemmas.lean
@@ -457,9 +457,12 @@ theorem composeY_toPoly {F : Type*}
   rw [CPolynomial.eval_toPoly]
   rw [CBivariate.toPoly_eq_map]
   rw [Polynomial.eval_map]
-  exact (Polynomial.eval₂_hom
+  have h := (Polynomial.eval₂_hom
     (f := (CPolynomial.ringEquiv (R := F)).toRingHom)
     (p := CPolynomial.toPoly Q) (x := p)).symm
+  rw [CPolynomial.ringEquiv_toRingHom_apply,
+    CPolynomial.ringEquiv_toRingHom_apply] at h
+  exact h
 
 theorem initialCoefficientPolynomial_evalHorner_eq_composeYCoeff_monomial_zero
     {F : Type*} [Field F] [BEq F] [LawfulBEq F] [DecidableEq F]

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/Common/Lemmas.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/Common/Lemmas.lean
@@ -457,11 +457,14 @@ theorem composeY_toPoly {F : Type*}
   rw [CPolynomial.eval_toPoly]
   rw [CBivariate.toPoly_eq_map]
   rw [Polynomial.eval_map]
+  have ringEquiv_toPoly (r : CPolynomial F) :
+      (CPolynomial.ringEquiv (R := F)).toRingHom r = r.toPoly := by
+    rw [RingEquiv.toRingHom_eq_coe]
+    exact CPolynomial.ringEquiv_apply r
   have h := (Polynomial.eval₂_hom
     (f := (CPolynomial.ringEquiv (R := F)).toRingHom)
     (p := CPolynomial.toPoly Q) (x := p)).symm
-  rw [CPolynomial.ringEquiv_toRingHom_apply,
-    CPolynomial.ringEquiv_toRingHom_apply] at h
+  rw [ringEquiv_toPoly, ringEquiv_toPoly] at h
   exact h
 
 theorem initialCoefficientPolynomial_evalHorner_eq_composeYCoeff_monomial_zero

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Correctness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Correctness.lean
@@ -541,10 +541,13 @@ private theorem composeY_monomialXY {F : Type*}
     CBivariate.composeY (CBivariate.monomialXY x y c) p =
       CPolynomial.monomial x c * p ^ y := by
   apply (CPolynomial.ringEquiv (R := F)).injective
-  rw [show CPolynomial.ringEquiv (CBivariate.composeY (CBivariate.monomialXY x y c) p) =
-      (CBivariate.composeY (CBivariate.monomialXY x y c) p).toPoly by rfl]
-  rw [show CPolynomial.ringEquiv (CPolynomial.monomial x c * p ^ y) =
-      (CPolynomial.monomial x c * p ^ y).toPoly by rfl]
+  change
+    (CPolynomial.ringEquiv (R := F)).toRingHom
+        (CBivariate.composeY (CBivariate.monomialXY x y c) p) =
+      (CPolynomial.ringEquiv (R := F)).toRingHom
+        (CPolynomial.monomial x c * p ^ y)
+  rw [CPolynomial.ringEquiv_toRingHom_apply,
+    CPolynomial.ringEquiv_toRingHom_apply]
   rw [composeY_toPoly, CBivariate.monomialXY_toPoly, CPolynomial.toPoly_mul,
     CPolynomial.toPoly_pow, Polynomial.eval_monomial]
   rw [show (CPolynomial.monomial x c : CPolynomial F).toPoly =

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Correctness.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Correctness.lean
@@ -541,13 +541,16 @@ private theorem composeY_monomialXY {F : Type*}
     CBivariate.composeY (CBivariate.monomialXY x y c) p =
       CPolynomial.monomial x c * p ^ y := by
   apply (CPolynomial.ringEquiv (R := F)).injective
+  have ringEquiv_toPoly (r : CPolynomial F) :
+      (CPolynomial.ringEquiv (R := F)).toRingHom r = r.toPoly := by
+    rw [RingEquiv.toRingHom_eq_coe]
+    exact CPolynomial.ringEquiv_apply r
   change
     (CPolynomial.ringEquiv (R := F)).toRingHom
         (CBivariate.composeY (CBivariate.monomialXY x y c) p) =
       (CPolynomial.ringEquiv (R := F)).toRingHom
         (CPolynomial.monomial x c * p ^ y)
-  rw [CPolynomial.ringEquiv_toRingHom_apply,
-    CPolynomial.ringEquiv_toRingHom_apply]
+  rw [ringEquiv_toPoly, ringEquiv_toPoly]
   rw [composeY_toPoly, CBivariate.monomialXY_toPoly, CPolynomial.toPoly_mul,
     CPolynomial.toPoly_pow, Polynomial.eval_monomial]
   rw [show (CPolynomial.monomial x c : CPolynomial F).toPoly =

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Lemmas.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Lemmas.lean
@@ -603,12 +603,16 @@ theorem cpoly_monomial_substitution_sum {F : Type*}
       CPolynomial.monomial x coeff * (CPolynomial.C a + CPolynomial.X * p) ^ y := by
   apply (CPolynomial.ringEquiv (R := F)).injective
   change
-    ((List.range' 0 (y + 1)).foldl
+    (CPolynomial.ringEquiv (R := F)).toRingHom
+      ((List.range' 0 (y + 1)).foldl
         (fun acc t ↦
           acc + CPolynomial.monomial (x + t)
             (coeff * (Nat.choose y t : F) * a ^ (y - t)) * p ^ t)
-        0).toPoly =
-      (CPolynomial.monomial x coeff * (CPolynomial.C a + CPolynomial.X * p) ^ y).toPoly
+        0) =
+      (CPolynomial.ringEquiv (R := F)).toRingHom
+        (CPolynomial.monomial x coeff * (CPolynomial.C a + CPolynomial.X * p) ^ y)
+  rw [CPolynomial.ringEquiv_toRingHom_apply,
+    CPolynomial.ringEquiv_toRingHom_apply]
   rw [foldl_cpoly_toPoly_add
     (fun t ↦
       CPolynomial.monomial (x + t) (coeff * (Nat.choose y t : F) * a ^ (y - t)) *

--- a/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Lemmas.lean
+++ b/CompPoly/Bivariate/GuruswamiSudan/Root/RothRuckenstein/Lemmas.lean
@@ -602,6 +602,10 @@ theorem cpoly_monomial_substitution_sum {F : Type*}
         0 =
       CPolynomial.monomial x coeff * (CPolynomial.C a + CPolynomial.X * p) ^ y := by
   apply (CPolynomial.ringEquiv (R := F)).injective
+  have ringEquiv_toPoly (r : CPolynomial F) :
+      (CPolynomial.ringEquiv (R := F)).toRingHom r = r.toPoly := by
+    rw [RingEquiv.toRingHom_eq_coe]
+    exact CPolynomial.ringEquiv_apply r
   change
     (CPolynomial.ringEquiv (R := F)).toRingHom
       ((List.range' 0 (y + 1)).foldl
@@ -611,8 +615,7 @@ theorem cpoly_monomial_substitution_sum {F : Type*}
         0) =
       (CPolynomial.ringEquiv (R := F)).toRingHom
         (CPolynomial.monomial x coeff * (CPolynomial.C a + CPolynomial.X * p) ^ y)
-  rw [CPolynomial.ringEquiv_toRingHom_apply,
-    CPolynomial.ringEquiv_toRingHom_apply]
+  rw [ringEquiv_toPoly, ringEquiv_toPoly]
   rw [foldl_cpoly_toPoly_add
     (fun t ↦
       CPolynomial.monomial (x + t) (coeff * (Nat.choose y t : F) * a ^ (y - t)) *

--- a/CompPoly/Bivariate/ToPoly.lean
+++ b/CompPoly/Bivariate/ToPoly.lean
@@ -231,7 +231,6 @@ theorem toPoly_eq_map {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring
       intro n
       split_ifs <;> simp_all +decide [ CPolynomial.toPoly ]
       · erw [ CPolynomial.Raw.coeff_toPoly ]
-        unfold CPolynomial.ringEquiv
         aesop
       · rw [ CPolynomial.Raw.coeff_toPoly ]
         simp +decide [ CPolynomial.support, * ] at *
@@ -496,8 +495,6 @@ theorem CC_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] 
   rw [ toPoly_eq_map ]
   unfold CBivariate.CC
   simp [ CPolynomial.C_toPoly ]
-  change (CPolynomial.C r).toPoly = Polynomial.C r
-  exact CPolynomial.C_toPoly r
 
 /--
 `X` (inner variable) corresponds to `Polynomial.C Polynomial.X` in `R[X][Y]`.
@@ -506,7 +503,6 @@ theorem X_toPoly {R : Type*} [BEq R] [LawfulBEq R] [Nontrivial R] [Semiring R] :
     toPoly (X (R := R)) = Polynomial.C Polynomial.X := by
   rw [ toPoly_eq_map ]
   simp [ CBivariate.X, CPolynomial.C_toPoly ]
-  change (CPolynomial.X : CPolynomial R).toPoly = Polynomial.X
   exact CPolynomial.X_toPoly
 
 /--
@@ -653,12 +649,13 @@ theorem eval_eval_horner_x_then_y_eq_eval_eval {R : Type*}
     dsimp [coeffEval]
     congr
     ext c acc
-    simp [CPolynomial.eval_horner_eq_eval, CPolynomial.eval_toPoly, CPolynomial.ringEquiv]
+    simp [CPolynomial.eval_horner_eq_eval, CPolynomial.eval_toPoly,
+      CPolynomial.ringEquiv_apply]
   have h_evalX_map :
       (evalX (R := R) x p).toPoly = (CPolynomial.toPoly p).map coeffEval := by
     ext j
     rw [evalX_toPoly_coeff]
-    simp [toPoly_coeff, coeffEval, CPolynomial.ringEquiv]
+    simp [toPoly_coeff, coeffEval, CPolynomial.ringEquiv_apply]
     rw [← CPolynomial.coeff_toPoly (p := p) (i := j)]
     simp [CPolynomial.coeff, CPolynomial.Raw.coeff]
   calc

--- a/CompPoly/Univariate/CMvEquiv.lean
+++ b/CompPoly/Univariate/CMvEquiv.lean
@@ -124,8 +124,9 @@ private theorem cmvEquiv_symm_toPoly
       ((Polynomial.mapEquiv (CMvPolynomial.isEmptyRingEquiv (R := R)))
         (CMvPolynomial.finSuccEquiv (n := 0) (R := R) p))).toPoly =
       (Polynomial.mapEquiv (CMvPolynomial.isEmptyRingEquiv (R := R)))
-        (CMvPolynomial.finSuccEquiv (n := 0) (R := R) p) from
-    (ringEquiv (R := R)).right_inv _]
+        (CMvPolynomial.finSuccEquiv (n := 0) (R := R) p) from by
+      rw [← ringEquiv_apply]
+      exact (ringEquiv (R := R)).right_inv _]
   unfold CMvPolynomial.finSuccEquiv CPoly.polynomialCMvPolyEquiv
     CMvPolynomial.isEmptyRingEquiv
   ext n

--- a/CompPoly/Univariate/ToPoly/Equiv.lean
+++ b/CompPoly/Univariate/ToPoly/Equiv.lean
@@ -14,7 +14,7 @@ public import CompPoly.Univariate.ToPoly.Core
 Ring equivalences between computable univariate polynomials and `Polynomial`.
 -/
 
-@[expose] public section
+public section
 
 open Polynomial
 
@@ -180,6 +180,18 @@ noncomputable def ringEquiv [LawfulBEq R] [Nontrivial R] :
     apply toPoly_toImpl
   map_mul' := by intros p q; rw [toPoly_mul p q]
   map_add' := by intros p q; apply toPoly_add
+
+/-- The forward map of `ringEquiv` is `toPoly`. -/
+@[simp]
+theorem ringEquiv_apply [LawfulBEq R] [Nontrivial R] (p : CPolynomial R) :
+    ringEquiv p = p.toPoly := by
+  rfl
+
+/-- The ring hom underlying `ringEquiv` is `toPoly`. -/
+@[simp]
+theorem ringEquiv_toRingHom_apply [LawfulBEq R] [Nontrivial R] (p : CPolynomial R) :
+    (ringEquiv (R := R)).toRingHom p = p.toPoly := by
+  rfl
 
 end RingEquiv
 

--- a/CompPoly/Univariate/ToPoly/Equiv.lean
+++ b/CompPoly/Univariate/ToPoly/Equiv.lean
@@ -187,12 +187,6 @@ theorem ringEquiv_apply [LawfulBEq R] [Nontrivial R] (p : CPolynomial R) :
     ringEquiv p = p.toPoly := by
   rfl
 
-/-- The ring hom underlying `ringEquiv` is `toPoly`. -/
-@[simp]
-theorem ringEquiv_toRingHom_apply [LawfulBEq R] [Nontrivial R] (p : CPolynomial R) :
-    (ringEquiv (R := R)).toRingHom p = p.toPoly := by
-  rfl
-
 end RingEquiv
 
 end CPolynomial


### PR DESCRIPTION
## Summary

- make Univariate.ToPoly.Equiv public definitions opaque by default
- add public ringEquiv_apply and ringEquiv_toRingHom_apply characterization theorems
- migrate downstream proofs away from definitional reduction of the RingEquiv structure
- add no new import all dependencies

This PR is stacked on #297.

## Dependency ledger

- Univariate.CMvEquiv used the inverse law while relying on the forward map reducing to toPoly; it now uses ringEquiv_apply.
- Bivariate ToPoly, Deriv, and FactorMonic reduced the forward map or underlying ring hom; they now use the public application equations.
- Guruswami-Sudan interpolation and root-correctness proofs similarly used definitional conversion after ringEquiv.injective or polynomial hom lemmas; they now rewrite through ringEquiv_toRingHom_apply.

The failures could have been addressed with private access, but public application equations provide the narrower interface, so no import all statements were added.

## Validation

- lake build
- lake test
- lake build CompPolyBench
- ./scripts/lint-style.sh