### PR TITLE
refactor: make univariate foundations opaque

### DIFF
--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -134,7 +134,7 @@ theorem xgcd_toPoly_eq_gcd [Field R] [BEq R] [LawfulBEq R] [DecidableEq R] (p q 
     (xgcd p q).1.toPoly = EuclideanDomain.gcd p.toPoly q.toPoly := by
   unfold xgcd; apply xgcdAux_toPoly_eq_gcd
   rw [←degree_toPoly]
-  exact mem_degreeLT_iff_degree.mp (mem_degreeLT_iff_size_le.mpr le_rfl)
+  exact mem_degreeLT.mp (mem_degreeLT_iff_size_le.mpr le_rfl)
 
 /-- CompPoly's `xgcdAux` at threshold `0` coincides with
 Mathlib's `EuclideanDomain.xgcdAux`. -/
@@ -173,7 +173,7 @@ theorem xgcd_toPoly_eq_xgcd
   have h := xgcdAux_toPoly_eq_xgcdAux p.val.size p 1 0 q 0 1
     (by
       rw [←degree_toPoly]
-      exact mem_degreeLT_iff_degree.mp (mem_degreeLT_iff_size_le.mpr le_rfl))
+      exact mem_degreeLT.mp (mem_degreeLT_iff_size_le.mpr le_rfl))
   rw [toPoly_one, toPoly_zero] at h
   exact congrArg Prod.snd h
 
@@ -325,7 +325,7 @@ theorem gcdMonic_toPoly_eq_normalize_gcd
       (p.val.size + q.val.size + 1) p q (by
         have hqdeg : q.toPoly.degree < q.val.size := by
           rw [← degree_toPoly]
-          exact mem_degreeLT_iff_degree.mp (mem_degreeLT_iff_size_le.mpr le_rfl)
+          exact mem_degreeLT.mp (mem_degreeLT_iff_size_le.mpr le_rfl)
         have hleNat : q.val.size ≤ p.val.size + q.val.size + 1 := by
           omega
         have hle : (q.val.size : WithBot ℕ) ≤
@@ -497,7 +497,7 @@ lemma xgcd_stopSpec
   have hM : g₀.toPoly.natDegree + 1 ≤ g₀.val.size :=
     (Polynomial.natDegree_lt_iff_degree_lt hg₀poly).mpr
       (degree_toPoly g₀ ▸
-        mem_degreeLT_iff_degree.mp (mem_degreeLT_iff_size_le.mpr le_rfl))
+        mem_degreeLT.mp (mem_degreeLT_iff_size_le.mpr le_rfl))
   obtain ⟨N, hN⟩ : ∃ N, g₀.val.size = N + 1 := ⟨g₀.val.size - 1, by omega⟩
   obtain ⟨hr1, hs1, ht1⟩ : (g₁ - g₁/g₀*g₀).toPoly = g₁.toPoly ∧ (0 - g₁/g₀*1).toPoly = 0 ∧
       (1 - g₁/g₀*0).toPoly = 1 := by

--- a/CompPoly/Univariate/EuclideanAlgorithm.lean
+++ b/CompPoly/Univariate/EuclideanAlgorithm.lean
@@ -133,7 +133,8 @@ coincides with Mathlib's `EuclideanDomain.gcd`. -/
 theorem xgcd_toPoly_eq_gcd [Field R] [BEq R] [LawfulBEq R] [DecidableEq R] (p q : CPolynomial R) :
     (xgcd p q).1.toPoly = EuclideanDomain.gcd p.toPoly q.toPoly := by
   unfold xgcd; apply xgcdAux_toPoly_eq_gcd
-  rw [←degree_toPoly]; exact mem_degreeLT_iff_size_le.mpr le_rfl
+  rw [←degree_toPoly]
+  exact mem_degreeLT_iff_degree.mp (mem_degreeLT_iff_size_le.mpr le_rfl)
 
 /-- CompPoly's `xgcdAux` at threshold `0` coincides with
 Mathlib's `EuclideanDomain.xgcdAux`. -/
@@ -170,7 +171,9 @@ theorem xgcd_toPoly_eq_xgcd
       EuclideanDomain.xgcd p.toPoly q.toPoly := by
   unfold xgcd EuclideanDomain.xgcd
   have h := xgcdAux_toPoly_eq_xgcdAux p.val.size p 1 0 q 0 1
-    (by rw [←degree_toPoly]; exact mem_degreeLT_iff_size_le.mpr le_rfl)
+    (by
+      rw [←degree_toPoly]
+      exact mem_degreeLT_iff_degree.mp (mem_degreeLT_iff_size_le.mpr le_rfl))
   rw [toPoly_one, toPoly_zero] at h
   exact congrArg Prod.snd h
 
@@ -194,12 +197,7 @@ theorem normXgcd_bezout [Field R] [BEq R] [LawfulBEq R]
   simp only [Bezout] at h ⊢
   rw [h]
   apply toPolyLinearEquiv.injective
-  change (((p.xgcd q threshold).2.1 * p + (p.xgcd q threshold).2.2 * q).leadingCoeff⁻¹ •
-      ((p.xgcd q threshold).2.1 * p + (p.xgcd q threshold).2.2 * q)).toPoly =
-    (((p.xgcd q threshold).2.1 * p + (p.xgcd q threshold).2.2 * q).leadingCoeff⁻¹ •
-        (p.xgcd q threshold).2.1 * p +
-      ((p.xgcd q threshold).2.1 * p + (p.xgcd q threshold).2.2 * q).leadingCoeff⁻¹ •
-        (p.xgcd q threshold).2.2 * q).toPoly
+  rw [toPolyLinearEquiv_apply, toPolyLinearEquiv_apply]
   simp only [toPoly_smul, toPoly_add, toPoly_mul, Polynomial.smul_eq_C_mul]
   ring
 
@@ -327,7 +325,7 @@ theorem gcdMonic_toPoly_eq_normalize_gcd
       (p.val.size + q.val.size + 1) p q (by
         have hqdeg : q.toPoly.degree < q.val.size := by
           rw [← degree_toPoly]
-          exact mem_degreeLT_iff_size_le.mpr le_rfl
+          exact mem_degreeLT_iff_degree.mp (mem_degreeLT_iff_size_le.mpr le_rfl)
         have hleNat : q.val.size ≤ p.val.size + q.val.size + 1 := by
           omega
         have hle : (q.val.size : WithBot ℕ) ≤
@@ -342,7 +340,7 @@ theorem gcdMonic_eq_normXgcd_fst
     (p q : CPolynomial R) :
     CPolynomial.gcdMonic p q = (CPolynomial.normXgcd p q).1 := by
   apply toPolyLinearEquiv.injective
-  change (CPolynomial.gcdMonic p q).toPoly = (CPolynomial.normXgcd p q).1.toPoly
+  rw [toPolyLinearEquiv_apply, toPolyLinearEquiv_apply]
   rw [gcdMonic_toPoly_eq_normalize_gcd, normXgcd_fst_toPoly]
 
 /-- The Bezout component of `normXgcd` under `toPoly` is Mathlib's
@@ -364,7 +362,7 @@ theorem normXgcd_fst_comm
     (p q : CPolynomial R) :
     (normXgcd p q).1 = (normXgcd q p).1 := by
   apply toPolyLinearEquiv.injective
-  show (normXgcd p q).1.toPoly = (normXgcd q p).1.toPoly
+  rw [toPolyLinearEquiv_apply, toPolyLinearEquiv_apply]
   rw [normXgcd_fst_toPoly, normXgcd_fst_toPoly]
   -- `normalize (gcd a b) = normalize (gcd b a)` via mutual divisibility.
   refine (normalize_eq_normalize_iff_associated).mpr ?_
@@ -498,7 +496,8 @@ lemma xgcd_stopSpec
   have hge1 : 1 ≤ g₀.toPoly.natDegree := natDegree_toPoly g₀ ▸ hthr.trans (not_lt.mp hstop)
   have hM : g₀.toPoly.natDegree + 1 ≤ g₀.val.size :=
     (Polynomial.natDegree_lt_iff_degree_lt hg₀poly).mpr
-      (degree_toPoly g₀ ▸ mem_degreeLT_iff_size_le.mpr le_rfl)
+      (degree_toPoly g₀ ▸
+        mem_degreeLT_iff_degree.mp (mem_degreeLT_iff_size_le.mpr le_rfl))
   obtain ⟨N, hN⟩ : ∃ N, g₀.val.size = N + 1 := ⟨g₀.val.size - 1, by omega⟩
   obtain ⟨hr1, hs1, ht1⟩ : (g₁ - g₁/g₀*g₀).toPoly = g₁.toPoly ∧ (0 - g₁/g₀*1).toPoly = 0 ∧
       (1 - g₁/g₀*0).toPoly = 1 := by

--- a/CompPoly/Univariate/Linear.lean
+++ b/CompPoly/Univariate/Linear.lean
@@ -14,7 +14,7 @@ public import CompPoly.Univariate.Basic
 This file contains linear maps and instance-stable bounded-degree predicates for `CPolynomial`.
 -/
 
-@[expose] public section
+public section
 
 namespace CompPoly
 
@@ -32,6 +32,11 @@ def lcoeff (n : ℕ) : (CPolynomial R) →ₗ[R] R where
   map_add' p q := coeff_add p q n
   map_smul' r p := coeff_smul r p n
 
+/-- Applying `lcoeff n` returns the coefficient of degree `n`. -/
+@[simp]
+theorem lcoeff_apply (n : ℕ) (p : CPolynomial R) : lcoeff n p = coeff p n := by
+  rfl
+
 end LinearMaps
 
 section DegreeBounds
@@ -45,6 +50,16 @@ def degreeLE (n : WithBot ℕ) : Set (CPolynomial R) :=
 /-- The set of `CPolynomial R` consisting of polynomials of degree < `n`. -/
 def degreeLT (n : ℕ) : Set (CPolynomial R) :=
   { p | p.val.degreeBound < n }
+
+/-- Membership in `degreeLE` is the corresponding degree bound. -/
+theorem mem_degreeLE_iff_degree {n : WithBot ℕ} {p : CPolynomial R} :
+    p ∈ degreeLE (R := R) n ↔ p.degree ≤ n := by
+  rfl
+
+/-- Membership in `degreeLT` is the corresponding strict degree bound. -/
+theorem mem_degreeLT_iff_degree {n : ℕ} {p : CPolynomial R} :
+    p ∈ degreeLT (R := R) n ↔ p.degree < n := by
+  rfl
 
 /-- `degreeLT n` is exactly the bounded-size carrier storing at most `n` coefficients. -/
 theorem mem_degreeLT_iff_size_le {n : ℕ} {p : CPolynomial R} :
@@ -181,6 +196,12 @@ def degreeLTCoeffs (n : ℕ) : ↥(degreeLT (R := R) n) →ₗ[R] (Fin n → R) 
     intro r p
     funext i
     exact coeff_smul r p.1 i
+
+/-- Applying `degreeLTCoeffs` returns the corresponding bounded coefficient. -/
+@[simp]
+theorem degreeLTCoeffs_apply (n : ℕ) (p : ↥(degreeLT (R := R) n)) (i : Fin n) :
+    degreeLTCoeffs n p i = coeff p.1 i := by
+  rfl
 
 end DegreeLTSubtype
 

--- a/CompPoly/Univariate/Linear.lean
+++ b/CompPoly/Univariate/Linear.lean
@@ -52,12 +52,12 @@ def degreeLT (n : ℕ) : Set (CPolynomial R) :=
   { p | p.val.degreeBound < n }
 
 /-- Membership in `degreeLE` is the corresponding degree bound. -/
-theorem mem_degreeLE_iff_degree {n : WithBot ℕ} {p : CPolynomial R} :
+theorem mem_degreeLE {n : WithBot ℕ} {p : CPolynomial R} :
     p ∈ degreeLE (R := R) n ↔ p.degree ≤ n := by
   rfl
 
 /-- Membership in `degreeLT` is the corresponding strict degree bound. -/
-theorem mem_degreeLT_iff_degree {n : ℕ} {p : CPolynomial R} :
+theorem mem_degreeLT {n : ℕ} {p : CPolynomial R} :
     p ∈ degreeLT (R := R) n ↔ p.degree < n := by
   rfl
 

--- a/CompPoly/Univariate/Quotient/Core.lean
+++ b/CompPoly/Univariate/Quotient/Core.lean
@@ -22,7 +22,7 @@ public import CompPoly.Univariate.Raw.Proofs
   equivalence relation and thus descend to the quotient.
 -/
 
-@[expose] public section
+public section
 namespace CompPoly
 
 namespace CPolynomial
@@ -63,6 +63,7 @@ instance Raw.instSetoidCPolynomial [Zero R] : Setoid (CPolynomial.Raw R) where
 
   This quotient identifies polynomials that differ only by trailing zeros, and is intended
   to be equivalent to mathlib's `Polynomial R`. -/
+@[expose]
 def QuotientCPolynomial (R : Type*) [Zero R] := Quotient (@Raw.instSetoidCPolynomial R _)
 
 namespace QuotientCPolynomial

--- a/CompPoly/Univariate/Quotient/Equiv.lean
+++ b/CompPoly/Univariate/Quotient/Equiv.lean
@@ -26,7 +26,7 @@ mathlib's `Polynomial R`.
 * `QuotientCPolynomial.ringEquiv` - the ring equivalence `QuotientCPolynomial R ≃+* Polynomial R`
 -/
 
-@[expose] public section
+public section
 
 namespace CompPoly
 

--- a/CompPoly/Univariate/Raw/Context.lean
+++ b/CompPoly/Univariate/Raw/Context.lean
@@ -19,7 +19,7 @@ Array-level execution dictionaries for reusable raw univariate polynomial
 kernels.
 -/
 
-@[expose] public section
+public section
 
 namespace CompPoly
 

--- a/CompPoly/Univariate/Raw/Modular.lean
+++ b/CompPoly/Univariate/Raw/Modular.lean
@@ -14,7 +14,7 @@ Context-parametric modular multiplication and exponentiation over raw
 univariate polynomials.
 -/
 
-@[expose] public section
+public section
 
 namespace CompPoly
 

--- a/CompPoly/Univariate/ReedSolomon.lean
+++ b/CompPoly/Univariate/ReedSolomon.lean
@@ -59,7 +59,7 @@ def messagePoly [Zero F] [BEq F] [LawfulBEq F]
 /-- `(messagePoly msg).degree < k`. -/
 lemma messagePoly_degree_lt [Zero F] [BEq F] [LawfulBEq F] {k : ℕ} (msg : Vector F k) :
     (messagePoly msg).degree < k :=
-  CPolynomial.mem_degreeLT_iff_degree.mp <|
+  CPolynomial.mem_degreeLT.mp <|
     CPolynomial.mem_degreeLT_iff_size_le.mpr
       ((CPolynomial.Raw.Trim.size_le_size msg.toArray).trans_eq msg.size_toArray)
 

--- a/CompPoly/Univariate/ReedSolomon.lean
+++ b/CompPoly/Univariate/ReedSolomon.lean
@@ -59,8 +59,9 @@ def messagePoly [Zero F] [BEq F] [LawfulBEq F]
 /-- `(messagePoly msg).degree < k`. -/
 lemma messagePoly_degree_lt [Zero F] [BEq F] [LawfulBEq F] {k : ℕ} (msg : Vector F k) :
     (messagePoly msg).degree < k :=
-  CPolynomial.mem_degreeLT_iff_size_le.mpr
-    ((CPolynomial.Raw.Trim.size_le_size msg.toArray).trans_eq msg.size_toArray)
+  CPolynomial.mem_degreeLT_iff_degree.mp <|
+    CPolynomial.mem_degreeLT_iff_size_le.mpr
+      ((CPolynomial.Raw.Trim.size_le_size msg.toArray).trans_eq msg.size_toArray)
 
 /-- `messagePoly` recovers a `CPolynomial` of degree `< k` from its bounded coefficient vector. -/
 lemma messagePoly_ofFn_coeff [Semiring F] [BEq F] [LawfulBEq F] (k : ℕ) (f : CPolynomial F)

--- a/CompPoly/Univariate/ReedSolomon/GaoCorrectness.lean
+++ b/CompPoly/Univariate/ReedSolomon/GaoCorrectness.lean
@@ -297,7 +297,8 @@ theorem decode_eq_some [Field F]
   -- Extract the message from the exact-division equation `hGVf`.
   obtain ⟨hmod0, hdivtp⟩ :=
     (exactDiv_toPoly_iff _ _ _ hVne0).mp (hGVf.trans (mul_comm _ _))
-  have hdiveq : G / V = messagePoly msg := toPolyLinearEquiv.injective hdivtp
+  have hdiveq : G / V = messagePoly msg := toPolyLinearEquiv.injective (by
+    simpa only [toPolyLinearEquiv_apply] using hdivtp)
   show (if G.mod V == 0 then if (G / V).degree < k then some (G / V) else none else none) = _
   rw [if_pos (beq_iff_eq.mpr hmod0), if_pos (hdiveq ▸ messagePoly_degree_lt msg), hdiveq]
 

--- a/CompPoly/Univariate/Roots/Correctness.lean
+++ b/CompPoly/Univariate/Roots/Correctness.lean
@@ -6,6 +6,8 @@ Authors: Valerii Huhnin
 module
 
 import all CompPoly.Univariate.EuclideanAlgorithm
+import all CompPoly.Univariate.Raw.Context
+import all CompPoly.Univariate.Raw.Modular
 public import CompPoly.Univariate.Roots.Backend
 public import CompPoly.Univariate.Roots.Splitter
 public import CompPoly.Univariate.EuclideanAlgorithm

--- a/CompPoly/Univariate/Roots/RootProduct.lean
+++ b/CompPoly/Univariate/Roots/RootProduct.lean
@@ -6,6 +6,7 @@ Authors: Valerii Huhnin
 module
 
 import all CompPoly.Univariate.EuclideanAlgorithm
+import all CompPoly.Univariate.Raw.Modular
 public import CompPoly.Univariate.Raw.Modular
 public import CompPoly.Univariate.EuclideanAlgorithm
 public import CompPoly.Univariate.Roots.Context

--- a/CompPoly/Univariate/ToPoly/Degree.lean
+++ b/CompPoly/Univariate/ToPoly/Degree.lean
@@ -14,7 +14,7 @@ public import CompPoly.Univariate.ToPoly.Impl
 Degree lemmas for the computable-univariate to `Polynomial` conversion.
 -/
 
-@[expose] public section
+public section
 
 open Polynomial
 
@@ -41,6 +41,12 @@ noncomputable def toPolyLinearEquiv : CPolynomial R ≃ₗ[R] R[X] where
   map_smul' := toPoly_smul
   left_inv := fun p => Subtype.ext (toImpl_toPoly_of_canonical p)
   right_inv := toPoly_mk_toImpl
+
+/-- The forward map of `toPolyLinearEquiv` is `toPoly`. -/
+@[simp]
+theorem toPolyLinearEquiv_apply (p : CPolynomial R) : toPolyLinearEquiv p = p.toPoly := by
+  rfl
+
 theorem degree_le_iff_coeff_zero (p : CPolynomial R) (n : WithBot ℕ) :
     p.degree ≤ n ↔ ∀ k : ℕ, n < k → p.coeff k = 0 := by
     rw [degree_toPoly, Polynomial.degree_le_iff_coeff_zero]
@@ -54,7 +60,7 @@ theorem degree_lt_iff_coeff_zero (p : CPolynomial R) (n : ℕ) :
 omit [BEq R] [LawfulBEq R] in
 theorem mem_degreeLE {n : WithBot ℕ} {p : (CPolynomial R)} :
     p ∈ degreeLE (R := R) n ↔ degree p ≤ n := by
-  rfl
+  exact mem_degreeLE_iff_degree
 
 omit [BEq R] [LawfulBEq R] in
 theorem degreeLE_mono (m n : WithBot ℕ) (h_lessThan : m ≤ n) :
@@ -63,7 +69,7 @@ theorem degreeLE_mono (m n : WithBot ℕ) (h_lessThan : m ≤ n) :
 
 omit [BEq R] [LawfulBEq R] in
 theorem mem_degreeLT {n : ℕ} {p : CPolynomial R} : p ∈ degreeLT (R := R) n ↔ degree p < n := by
-  rfl
+  exact mem_degreeLT_iff_degree
 
 omit [BEq R] [LawfulBEq R] in
 theorem degreeLT_mono {m n : ℕ} (h : m ≤ n) :
@@ -74,8 +80,8 @@ omit [BEq R] [LawfulBEq R] in
 theorem degreeLT_succ_eq_degreeLE {n : ℕ} :
     degreeLT (R := R) (n + 1) = degreeLE (R := R) ↑n := by
   ext p
-  change p.val.degreeBound < (n + 1 : ℕ) ↔ p.val.degreeBound ≤ (n : WithBot ℕ)
-  cases hd : p.val.degreeBound with
+  rw [mem_degreeLT_iff_degree, mem_degreeLE_iff_degree]
+  cases hd : p.degree with
   | bot =>
       simp
   | coe a =>
@@ -110,7 +116,7 @@ lemma degreeLTEquiv_left_inv [DecidableEq R] (n : ℕ)
   intro i
   rw [show coeff (∑ j : Fin n, monomial (R := R) (↑j) (coeff p.1 j)) i =
     ∑ j : Fin n, coeff (monomial (R := R) (↑j) (coeff p.1 j)) i from
-      map_sum (lcoeff (R := R) i) _ _]
+      by simpa only [lcoeff_apply] using map_sum (lcoeff (R := R) i) _ _]
   simp only [coeff_monomial]
   by_cases hi : i < n
   · rw [Finset.sum_eq_single_of_mem ⟨i, hi⟩ (Finset.mem_univ _)
@@ -127,7 +133,7 @@ lemma degreeLTEquiv_right_inv [DecidableEq R] (n : ℕ)
   funext i
   rw [show coeff (∑ j : Fin n, monomial (R := R) (↑j) (f j)) ↑i =
     ∑ j : Fin n, coeff (monomial (R := R) (↑j) (f j)) ↑i from
-      map_sum (lcoeff (R := R) ↑i) _ _]
+      by simpa only [lcoeff_apply] using map_sum (lcoeff (R := R) ↑i) _ _]
   simp only [coeff_monomial]
   rw [Finset.sum_eq_single_of_mem i (Finset.mem_univ _)
     (fun j _ hji => if_neg fun h => hji (Fin.ext (by omega)))]
@@ -138,8 +144,14 @@ def degreeLTEquiv [DecidableEq R] (n : ℕ) :
   toFun := degreeLTCoeffs (R := R) n
   invFun := fun f => ⟨Finset.univ.sum (fun i : Fin n => monomial (R := R) (↑i) (f i)),
     degreeLTEquiv_invFun_mem (R := R) n f⟩
-  left_inv := degreeLTEquiv_left_inv (R := R) n
-  right_inv := degreeLTEquiv_right_inv (R := R) n
+  left_inv := by
+    intro p
+    simpa only [degreeLTCoeffs_apply] using degreeLTEquiv_left_inv (R := R) n p
+  right_inv := by
+    intro f
+    funext i
+    rw [degreeLTCoeffs_apply]
+    exact congrFun (degreeLTEquiv_right_inv (R := R) n f) i
   map_add' := by
     intro p q
     exact (degreeLTCoeffs (R := R) n).map_add p q
@@ -155,7 +167,7 @@ theorem degreeLTEquiv_toPoly [DecidableEq R] {n : ℕ} {p : CPolynomial R}
     (hp : p ∈ degreeLT (R := R) n) (i : Fin n) :
       degreeLTEquiv (R := R) n ⟨p, hp⟩ i =
           Polynomial.degreeLTEquiv R n ⟨p.toPoly, degreeLT_toPoly.mp hp⟩ i := by
-  simp [degreeLTEquiv, degreeLTCoeffs, Polynomial.degreeLTEquiv, ← coeff_toPoly]
+  simp [degreeLTEquiv, degreeLTCoeffs_apply, Polynomial.degreeLTEquiv, ← coeff_toPoly]
 
 theorem degreeLTEquiv_eq_zero_iff_eq_zero [DecidableEq R] {n : ℕ} {p : CPolynomial R}
     (hp : p ∈ degreeLT (R := R) n) :

--- a/CompPoly/Univariate/ToPoly/Degree.lean
+++ b/CompPoly/Univariate/ToPoly/Degree.lean
@@ -58,18 +58,9 @@ theorem degree_lt_iff_coeff_zero (p : CPolynomial R) (n : ℕ) :
     simp only [coeff_toPoly]
 
 omit [BEq R] [LawfulBEq R] in
-theorem mem_degreeLE {n : WithBot ℕ} {p : (CPolynomial R)} :
-    p ∈ degreeLE (R := R) n ↔ degree p ≤ n := by
-  exact mem_degreeLE_iff_degree
-
-omit [BEq R] [LawfulBEq R] in
 theorem degreeLE_mono (m n : WithBot ℕ) (h_lessThan : m ≤ n) :
     degreeLE (R := R) m ≤ degreeLE (R := R) n :=
   fun _ hf => mem_degreeLE.2 (le_trans (mem_degreeLE.1 hf) h_lessThan)
-
-omit [BEq R] [LawfulBEq R] in
-theorem mem_degreeLT {n : ℕ} {p : CPolynomial R} : p ∈ degreeLT (R := R) n ↔ degree p < n := by
-  exact mem_degreeLT_iff_degree
 
 omit [BEq R] [LawfulBEq R] in
 theorem degreeLT_mono {m n : ℕ} (h : m ≤ n) :
@@ -80,7 +71,7 @@ omit [BEq R] [LawfulBEq R] in
 theorem degreeLT_succ_eq_degreeLE {n : ℕ} :
     degreeLT (R := R) (n + 1) = degreeLE (R := R) ↑n := by
   ext p
-  rw [mem_degreeLT_iff_degree, mem_degreeLE_iff_degree]
+  rw [mem_degreeLT, mem_degreeLE]
   cases hd : p.degree with
   | bot =>
       simp

--- a/CompPoly/Univariate/ToPoly/Impl.lean
+++ b/CompPoly/Univariate/ToPoly/Impl.lean
@@ -210,14 +210,14 @@ theorem lcoeff_toPoly [BEq R] [LawfulBEq R] (n : ℕ) (p : CPolynomial R) :
 theorem degreeLE_toPoly {n : WithBot ℕ} [BEq R] [LawfulBEq R] {p : CPolynomial R} :
     p ∈ degreeLE (R := R) n ↔ p.toPoly ∈ Polynomial.degreeLE R n := by
   rw [Polynomial.mem_degreeLE]
-  rw [mem_degreeLE_iff_degree]
+  rw [mem_degreeLE]
   rw [degree_toPoly]
 
 /-- CPolynomial.degreeLT is correct wrt the Mathlib spec. -/
 theorem degreeLT_toPoly {n : ℕ} [BEq R] [LawfulBEq R] {p : CPolynomial R} :
     p ∈ degreeLT (R := R) n ↔ p.toPoly ∈ Polynomial.degreeLT R n := by
   rw [Polynomial.mem_degreeLT]
-  rw [mem_degreeLT_iff_degree]
+  rw [mem_degreeLT]
   rw [degree_toPoly]
 
 end ImplementationCorrectness

--- a/CompPoly/Univariate/ToPoly/Impl.lean
+++ b/CompPoly/Univariate/ToPoly/Impl.lean
@@ -16,7 +16,7 @@ Proofs that operations defined on CPolynomial and CPolynomial.Raw are correct
 wrt the mathlib specs, using the ring equivalence
 -/
 
-@[expose] public section
+public section
 
 open Polynomial
 
@@ -204,20 +204,20 @@ theorem C_mul_X_pow_toPoly [BEq R] [LawfulBEq R] [DecidableEq R] [Nontrivial R] 
 /-- CPolynomial.lcoeff is correct wrt the Mathlib spec. -/
 theorem lcoeff_toPoly [BEq R] [LawfulBEq R] (n : ℕ) (p : CPolynomial R) :
     lcoeff (R := R) n p = Polynomial.lcoeff R n (toPoly p) := by
-    simp [lcoeff, Polynomial.lcoeff_apply, ← coeff_toPoly]
+    simp [Polynomial.lcoeff_apply, ← coeff_toPoly]
 
 /-- CPolynomial.degreeLE is correct wrt the Mathlib spec. -/
 theorem degreeLE_toPoly {n : WithBot ℕ} [BEq R] [LawfulBEq R] {p : CPolynomial R} :
     p ∈ degreeLE (R := R) n ↔ p.toPoly ∈ Polynomial.degreeLE R n := by
   rw [Polynomial.mem_degreeLE]
-  change p.degree ≤ n ↔ p.toPoly.degree ≤ n
+  rw [mem_degreeLE_iff_degree]
   rw [degree_toPoly]
 
 /-- CPolynomial.degreeLT is correct wrt the Mathlib spec. -/
 theorem degreeLT_toPoly {n : ℕ} [BEq R] [LawfulBEq R] {p : CPolynomial R} :
     p ∈ degreeLT (R := R) n ↔ p.toPoly ∈ Polynomial.degreeLT R n := by
   rw [Polynomial.mem_degreeLT]
-  change p.degree < n ↔ p.toPoly.degree < n
+  rw [mem_degreeLT_iff_degree]
   rw [degree_toPoly]
 
 end ImplementationCorrectness

--- a/tests/CompPolyTests/Univariate/Linear.lean
+++ b/tests/CompPolyTests/Univariate/Linear.lean
@@ -90,7 +90,7 @@ private def intDegreeLT : ↥(CPolynomial.degreeLT (R := Int) 3) := by
   simp [intPoly, CPolynomial.monomial, CPolynomial.Raw.monomial]
 
 example : CPolynomial.degreeLTEquiv (R := Int) 3 intDegreeLT ⟨1, by decide⟩ = 7 := by
-  simpa [CPolynomial.degreeLTEquiv, CPolynomial.degreeLTCoeffs, intDegreeLT, intPoly] using
+  simpa [CPolynomial.degreeLTEquiv, CPolynomial.degreeLTCoeffs_apply, intDegreeLT, intPoly] using
     CPolynomial.coeff_monomial (R := Int) 1 1 7
 
 end CPolynomial


### PR DESCRIPTION
## Summary

- make ToPoly.Impl, ToPoly.Degree, Quotient.Core, Quotient.Equiv, Linear, Raw.Context, and Raw.Modular opaque by default
- retain targeted exposure for the QuotientCPolynomial representation
- add public application and membership equations for linear and bounded-degree APIs
- migrate downstream degree, Euclidean-algorithm, Reed-Solomon, Gao, and regression proofs away from definitional reduction

This PR is stacked on #298.

## Dependency ledger

Three new private imports are required, all in implementation-correctness modules:

- Roots.RootProduct imports all of Raw.Modular to unfold the five raw modular algorithms, including the recursive binary exponentiation helper.
- Roots.Correctness imports all of Raw.Modular for the same algorithm proofs.
- Roots.Correctness imports all of Raw.Context to unfold the naive multiplication and remainder dictionaries.

The Raw.Context import is direct because importing all of Raw.Modular does not transitively expose private bodies from Raw.Context.

All other failures were resolved through public characterization theorems: lcoeff_apply, degreeLTCoeffs_apply, mem_degreeLE_iff_degree, mem_degreeLT_iff_degree, and toPolyLinearEquiv_apply.

## Validation

- lake build
- lake test
- lake build CompPolyBench
- ./scripts/lint-style.sh