### PR TITLE
feat: ship prebuilt oleans with each release

### DIFF
--- a/.github/workflows/lean_release_tag.yml
+++ b/.github/workflows/lean_release_tag.yml
@@ -1,4 +1,4 @@
-name: Add Lean release tag
+name: Lean release tag and prebuilt oleans
 
 on:
   push:
@@ -7,10 +7,26 @@ on:
       - 'master'
     paths:
       - 'lean-toolchain'
+  # Covers releases created by hand rather than by `lean-release-tag` (patch and
+  # variant tags, for example). Releases the automated job creates below use
+  # `GITHUB_TOKEN`, which by design does not re-trigger workflows, so this cannot
+  # double-fire for the toolchain-bump path.
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Existing release tag to build and attach prebuilt oleans to. Use this to
+          backfill a release that predates this workflow, or to rebuild an asset.
+        required: true
+        type: string
 
 jobs:
   lean-release-tag:
     name: Add Lean release tag
+    # On manual dispatch the tag and release already exist; only publish the asset.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,3 +36,92 @@ jobs:
       with:
         do-release: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Attach a prebuilt olean archive to the release, so downstream projects fetch
+  # CompPoly's artifacts instead of compiling it. Lake's `preferReleaseBuild` (set in
+  # `lakefile.lean`) makes consumers use this automatically.
+  # See `docs/wiki/build-cache.md`.
+  publish-oleans:
+    name: Publish prebuilt oleans
+    needs: lean-release-tag
+    if: >-
+      always() &&
+      (needs.lean-release-tag.result == 'success' ||
+       needs.lean-release-tag.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # `lean-release-tag` names the tag after the toolchain suffix and puts it on the
+      # commit that changed `lean-toolchain`, which is not necessarily this push's HEAD.
+      # So derive the name, then build from the tag itself to keep the archive and the
+      # tag's source tree in agreement.
+      - name: Resolve release tag
+        id: resolve
+        run: |
+          case "${{ github.event_name }}" in
+            workflow_dispatch) tag='${{ inputs.tag }}' ;;
+            release)           tag='${{ github.event.release.tag_name }}' ;;
+            *)                 tag="$(sed -n 's|^leanprover/lean4:||p' lean-toolchain | tr -d '[:space:]')" ;;
+          esac
+          if [ -z "$tag" ]; then
+            echo "::error::could not resolve a release tag" && exit 1
+          fi
+          git fetch --tags --force --quiet
+          if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "::error::tag '$tag' does not exist" && exit 1
+          fi
+          git checkout --quiet "refs/tags/$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Building prebuilt oleans for $tag."
+
+      # `lake upload` shells out to `gh release upload`, which needs the release to
+      # already exist. `do-release: true` creates it above; a hand-made tag may not have
+      # one, so fail early with a clear message rather than deep inside Lake.
+      - name: Check the release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${{ steps.resolve.outputs.tag }}" >/dev/null \
+            || { echo "::error::no GitHub release for tag '${{ steps.resolve.outputs.tag }}'"; exit 1; }
+
+      # Runs after the tag checkout so elan picks up that tag's `lean-toolchain`.
+      - name: Set up Lean environment
+        uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: false
+          test: false
+          lint: false
+          use-github-cache: false
+
+      - name: Fetch Mathlib oleans
+        run: lake exe cache get
+
+      # Deliberately builds only the default `CompPoly` library into an empty build
+      # directory. `lake upload` packs the whole build directory, and a full `lake build`
+      # would also leave the benchmark executable's Linux-only `bin/` and `.o` output
+      # there, which would both bloat the asset and contradict the `platformIndependent`
+      # claim that lets one archive serve every platform.
+      - name: Build the library
+        run: |
+          rm -rf .lake/build
+          lake build CompPoly
+
+      - name: Pack and attach the archive
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: lake upload "${{ steps.resolve.outputs.tag }}"
+
+      - name: Report the archive
+        run: |
+          archive=".lake/CompPoly-oleans.tar.gz"
+          echo "### Prebuilt oleans for \`${{ steps.resolve.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Archive size: $(du -h "$archive" | cut -f1)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Entries: $(tar tzf "$archive" | wc -l | tr -d ' ')" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`.olean\` files: $(tar tzf "$archive" | grep -c '\.olean$')" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ Human contributors should usually start with [`README.md`](README.md),
 - [`docs/wiki/repo-map.md`](docs/wiki/repo-map.md) - subtree map and task routing.
 - [`docs/wiki/generated-files.md`](docs/wiki/generated-files.md) - source-of-truth
   rules for generated or derived outputs.
+- [`docs/wiki/build-cache.md`](docs/wiki/build-cache.md) - Mathlib's olean cache and
+  CompPoly's prebuilt release archive.
 - [`docs/wiki/module-system.md`](docs/wiki/module-system.md) - module headers,
   `public`/`meta` imports, module privacy, and migration fix patterns.
 - [`docs/wiki/representations-and-bridges.md`](docs/wiki/representations-and-bridges.md)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ git = "https://github.com/Verified-zkEVM/CompPoly"
 rev = "init"
 ```
 
+Prefer pinning a [release tag](https://github.com/Verified-zkEVM/CompPoly/releases).
+Each release carries a prebuilt archive of CompPoly's `.olean` files, so `lake build`
+downloads them instead of compiling the library, on any platform. Pinning a bare
+branch or commit still works but builds from source. Fetch Mathlib's oleans the usual
+way alongside it:
+
+```bash
+lake exe cache get   # Mathlib's oleans
+lake build           # CompPoly's oleans are fetched automatically
+```
+
+See [`docs/wiki/build-cache.md`](docs/wiki/build-cache.md) for details.
+
 Then you can import the desired modules, for example:
 ```lean
 import CompPoly.Multivariate.CMvPolynomial

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -11,6 +11,8 @@ are too specific or too changeable to keep at the repo root.
 - [`repo-map.md`](repo-map.md) - where to edit and how the main subtrees relate.
 - [`generated-files.md`](generated-files.md) - derived outputs and their sources of
   truth.
+- [`build-cache.md`](build-cache.md) - Mathlib's olean cache and CompPoly's prebuilt
+  release archive.
 - [`module-system.md`](module-system.md) - Lean module-system conventions, `meta`
   test files, and migration fix patterns.
 - [`representations-and-bridges.md`](representations-and-bridges.md) - the main
@@ -32,6 +34,7 @@ are too specific or too changeable to keep at the repo root.
   - `quickstart.md` for commands, validation, and CI expectations.
   - `repo-map.md` for repo structure and work-area routing.
   - `generated-files.md` for derived outputs and source-of-truth rules.
+  - `build-cache.md` for prebuilt-artifact caches and how they are published.
   - `module-system.md` for module headers, `public`/`meta` imports, and privacy.
   - `representations-and-bridges.md` for representation choice and Mathlib bridges.
   - `typeclass-minimization.md` for minimal typeclass assumptions and avoiding

--- a/docs/wiki/build-cache.md
+++ b/docs/wiki/build-cache.md
@@ -1,0 +1,90 @@
+# Build Cache
+
+Two independent caches keep you from compiling code someone else already compiled.
+They cover different packages and are fetched by different commands.
+
+| What | Covers | How you get it |
+| --- | --- | --- |
+| Mathlib's cache | `mathlib` and its own dependencies | `lake exe cache get` |
+| CompPoly release archive | `CompPoly` itself | automatic for consumers; see below for contributors |
+
+Neither is required — both only ever save time. If a fetch fails, Lake logs a warning
+and builds from source.
+
+## Consuming CompPoly
+
+Nothing to run. A project that requires CompPoly at a release tag gets the prebuilt
+library from a plain build:
+
+```bash
+lake exe cache get   # Mathlib's oleans
+lake build           # downloads CompPoly's oleans instead of compiling them
+```
+
+This works because [`../../lakefile.lean`](../../lakefile.lean) sets
+`preferReleaseBuild := true`, so Lake fetches
+`CompPoly-oleans.tar.gz` from the matching GitHub release and unpacks it into the
+build directory. One archive serves every platform: the library sets
+`platformIndependent := true`, so its module traces exclude platform-dependent
+elements and Linux-built oleans validate on macOS and Windows.
+
+**This only applies to release tags.** Lake resolves the archive URL from a git tag
+reachable at the revision you pinned, so a dependency pinned to an arbitrary `main`
+commit has no tag, logs `no release tag found for revision`, and compiles from source.
+Pin a release tag to get the cache.
+
+## Working on CompPoly itself
+
+Lake deliberately skips this mechanism for the root package — it assumes the package
+you are editing should be built from your sources — so a contributor does not get the
+archive from `lake build`. On a cold clone:
+
+```bash
+lake exe cache get   # Mathlib's oleans; the expensive half
+lake build
+```
+
+That compiles CompPoly's own modules, currently a few minutes. To start from a release
+tag's prebuilt artifacts instead, fetch the archive explicitly with an empty build
+directory:
+
+```bash
+git checkout v4.32.0
+gh release download v4.32.0 --pattern CompPoly-oleans.tar.gz
+lake unpack CompPoly-oleans.tar.gz
+```
+
+## Publishing the archive
+
+[`../../.github/workflows/lean_release_tag.yml`](../../.github/workflows/lean_release_tag.yml)
+does this. On a push to `main` that changes
+[`../../lean-toolchain`](../../lean-toolchain), `lean-release-tag` creates the tag and
+release, then the `publish-oleans` job checks out that tag, fetches Mathlib's oleans,
+builds the library, and runs `lake upload <tag>`.
+
+The build step is `rm -rf .lake/build && lake build CompPoly`, and the narrow target
+matters. `lake upload` packs the *whole* build directory, so a full `lake build` would
+also ship the benchmark executable's Linux-only `bin/` and `.o` output — bloating the
+asset and contradicting the platform-independence claim above.
+
+To attach an asset to a release that predates this workflow, or to replace one, use
+**Actions → Add Lean release tag → Run workflow** and give it the tag.
+`lake upload` passes `--clobber`, so re-running replaces the existing asset.
+
+## Reproducing an archive locally
+
+```bash
+lake exe cache get
+rm -rf .lake/build && lake build CompPoly
+lake pack                       # writes .lake/CompPoly-oleans.tar.gz
+tar tzf .lake/CompPoly-oleans.tar.gz | head
+```
+
+`lake pack` only packs what is already built; it never builds anything.
+
+## What this does not cover
+
+CI's own per-commit build reuse is a separate mechanism — a GitHub Actions cache of
+`.lake` plus `lake exe cache get`, described in
+[`quickstart.md`](quickstart.md#ci-mapping). The release archive is cut once per
+release tag and plays no part in it.

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -17,6 +17,11 @@ lake exe cache get
 lake build
 ```
 
+`lake exe cache get` covers Mathlib and its dependencies, which is the expensive half.
+It does not cover CompPoly's own modules; `lake build` compiles those. Downstream
+projects that depend on CompPoly do get its prebuilt oleans automatically — see
+[`build-cache.md`](build-cache.md).
+
 ## Validation By Change Type
 
 ### Existing Lean files only

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,11 +5,32 @@ open System Lake DSL
 package CompPoly where
   version := v!"0.1.0"
   testDriver := "CompPolyTests"
+  -- Downstream users fetch prebuilt artifacts from our GitHub releases instead of
+  -- compiling CompPoly from source. Lake only does this for a package consumed as a
+  -- dependency; it skips the root package, so this does not affect building CompPoly
+  -- itself. See `docs/wiki/build-cache.md`.
+  preferReleaseBuild := true
+  -- Set explicitly rather than left to Lake's `remoteUrl?` fallback. `gh` accepts a
+  -- URL here, so this serves both the download URL and `lake upload`'s `-R`.
+  releaseRepo := "https://github.com/Verified-zkEVM/CompPoly"
+  -- Overrides Lake's default `CompPoly-{platform}.tar.gz`: one archive serves every
+  -- platform, because the archive holds only the platform-independent library
+  -- artifacts (see `platformIndependent` on `lean_lib CompPoly` below).
+  buildArchive := "CompPoly-oleans.tar.gz"
+  -- A CompPoly release only supports the toolchain it was built with, so let Lake
+  -- prioritize it when resolving toolchains for downstream projects.
+  fixedToolchain := true
 
 require "leanprover-community" / mathlib @ git "v4.32.0"
 
 @[default_target]
-lean_lib CompPoly
+lean_lib CompPoly where
+  -- Release archives are built on Linux CI and consumed on every platform. This drops
+  -- platform-dependent elements from module traces so those oleans validate on macOS
+  -- and Windows too. Declared on the library rather than the package so it does not
+  -- also claim platform independence for `lean_exe CompPolyBench`, whose native output
+  -- genuinely is platform-specific. Mathlib uses the same mechanism.
+  platformIndependent := true
 
 lean_lib CompPolyTests where
   srcDir := "tests"


### PR DESCRIPTION
## Summary

Downstream projects currently compile all 274 CompPoly modules (~85k lines) from
source. This attaches a **prebuilt olean archive to each release tag**, so they don't
have to — and consumers need no cache command at all: plain `lake build` fetches it.

`lake exe cache get` can never serve CompPoly's own oleans. Mathlib's cache tool
hardcodes its package list, resolves paths via `mathlibDepPath`, and gates uploads
behind Mathlib CI's OIDC-to-Azure exchange. Lake's built-in GitHub release path covers
this instead, with **nothing to host** — GitHub Releases is the storage.

## Requirements for a codebase to use the cache

All of these must hold. If any fails, Lake logs a warning and builds from source — it
never breaks a build.

1. **Pin a release tag, not a branch or bare commit.** This is the one people will get
   wrong. Lake resolves the archive URL from a git tag reachable at the pinned
   revision; a bare `main` SHA has no tag, so it logs `no release tag found for
   revision` and compiles.
   ```toml
   [[require]]
   name = "CompPoly"
   git = "https://github.com/Verified-zkEVM/CompPoly"
   rev = "v4.32.0"     # a release tag
   ```
2. **Be on the tag's Lean toolchain.** Oleans are only loadable by the Lean version
   that produced them. Release tags are named for the toolchain, so tag `v4.32.0`
   means `leanprover/lean4:v4.32.0`. CompPoly now sets `fixedToolchain`, so
   `lake update` prioritizes it.
3. **Consume CompPoly as a dependency, not as the root package.** Lake deliberately
   skips this for the package you are editing (`unless self.isRoot`), on the
   assumption that your own sources should be built. This is why it does not change
   anything for CompPoly contributors.
4. **CompPoly's `.lake/build` must not already exist.** Lake will not clobber an
   existing build. To force a refetch, delete
   `.lake/packages/CompPoly/.lake/build`.
5. **Don't disable caching** — no `--no-cache` and no `LAKE_NO_CACHE=1`.
6. **`curl` and `tar` on PATH.** Lake shells out to both.

Explicitly *not* required: any particular OS or CPU. One archive serves Linux, macOS,
and Windows.

Still fetch Mathlib separately — the two caches cover different packages:

```bash
lake exe cache get   # Mathlib and its dependencies
lake build           # CompPoly's oleans fetched automatically
```

## Changes

- **`lakefile.lean`** — `preferReleaseBuild`, `releaseRepo`, `buildArchive`,
  `fixedToolchain` on the package, and `platformIndependent := true` on
  `lean_lib CompPoly`. That last one is on the *library*, not the package, so it does
  not also claim platform independence for `lean_exe CompPolyBench`, whose native
  output genuinely is platform-specific. `releaseRepo` is set explicitly rather than
  left to Lake's `remoteUrl?` fallback, which is inverted in Lake v4.32.0
  (`Lake/Config/Package.lean:260` returns `some ""` when unset).
- **`.github/workflows/lean_release_tag.yml`** — new `publish-oleans` job. Runs
  automatically in the same workflow run right after the tag and release are created.
  It checks out the tag (`lean-release-tag` puts the tag on the commit that changed
  `lean-toolchain`, which is not necessarily the push HEAD), fetches Mathlib's oleans,
  builds, and runs `lake upload <tag>`.
  - `rm -rf .lake/build && lake build CompPoly` is load-bearing: `lake upload` packs
    the *whole* build directory, and a full `lake build` would also ship the benchmark
    executable's Linux-only `bin/` and `.o`, bloating the asset and contradicting the
    platform-independence claim.
  - Also triggers on `release: published`, so hand-made tags like `v4.30.0-patch1` and
    `4.32.0-fext` are covered too. Releases the automated job creates use
    `GITHUB_TOKEN`, which by design does not re-trigger workflows, so this cannot
    double-fire.
  - And on `workflow_dispatch` with a tag, to backfill older releases. `lake upload`
    passes `--clobber`, so re-running replaces an existing asset.
- **Docs** — new `docs/wiki/build-cache.md`; pointers from `AGENTS.md`,
  `docs/wiki/README.md`, `docs/wiki/quickstart.md`, and the README's import section.

## Test plan

- [x] `lake check-build -R` — config elaborates
- [x] `lake build CompPoly` clean; build dir holds only `ir` and `lib`, **no `bin/`**
- [x] `lake pack` → 68 MB, 275 oleans, 3988 entries, and zero `bin/`, `.o`, `.so`,
      `.dylib`, `.a` entries
- [x] Unpacked the archive into an empty build dir: `lake build CompPoly --no-build`
      and `--no-build --rehash` both report **all 2627 targets up to date**
- [x] Release facet resolves to
      `https://github.com/Verified-zkEVM/CompPoly/releases/download/<tag>/CompPoly-oleans.tar.gz`
      (checked with a local throwaway tag; 404 as expected, no asset published yet)
- [x] `lake test`, `./scripts/lint-style.sh`, `check-docs-integrity.py`
- [ ] **Post-merge**: first release tag publishes the asset, then a scratch consumer
      pinned to that tag fetches it instead of compiling. This cannot be tested before
      merge — it needs a published asset.
- [ ] **Post-merge**: repeat that consumer check on macOS to confirm the
      Linux-built archive validates cross-platform.

## Notes

Flipping `platformIndependent` changes module traces, so the first build after this
merges is a full rebuild. One-time cost.

This does nothing for CompPoly's own per-commit CI reuse — that is the GitHub Actions
cache layer, addressed separately in #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
