### PR TITLE
ci: drop the redundant cache-get step from the release workflow

### DIFF
--- a/.github/workflows/lean_release_tag.yml
+++ b/.github/workflows/lean_release_tag.yml
@@ -90,6 +90,11 @@ jobs:
             || { echo "::error::no GitHub release for tag '${{ steps.resolve.outputs.tag }}'"; exit 1; }
 
       # Runs after the tag checkout so elan picks up that tag's `lean-toolchain`.
+      # This also supplies Mathlib's oleans: lean-action detects the Mathlib dependency
+      # in `lake-manifest.json` and runs `lake exe cache get` itself, so the library
+      # build below does not compile Mathlib from source. That is already the behaviour
+      # of the `auto` default; setting it explicitly documents the reliance and pins it
+      # against a future change of default.
       - name: Set up Lean environment
         uses: leanprover/lean-action@v1
         with:
@@ -98,9 +103,7 @@ jobs:
           test: false
           lint: false
           use-github-cache: false
-
-      - name: Fetch Mathlib oleans
-        run: lake exe cache get
+          use-mathlib-cache: true
 
       # Deliberately builds only the default `CompPoly` library into an empty build
       # directory. `lake upload` packs the whole build directory, and a full `lake build`


### PR DESCRIPTION
## Summary

Follow-up to #301 and #293. The `publish-oleans` job that #301 added carries a
`Fetch Mathlib oleans` step that does nothing, and this removes it.

`leanprover/lean-action@v1` defaults to **`use-mathlib-cache: auto`**: it detects the
Mathlib dependency in `lake-manifest.json` and runs `lake exe cache get` itself, inside
the "Set up Lean environment" step that immediately precedes the redundant one. So
Mathlib's oleans are already in place before the explicit step runs.

I originally added that step to both workflows on the mistaken belief that CI never
fetched Mathlib's cache — true of the workflow *files*, but not of the actual behaviour.
#293 already corrected `lean_action_ci.yml`; this applies the same correction to
`lean_release_tag.yml`.

## Evidence

Observed on the real `4.32.0-cache` release run
([run 31407592475](https://github.com/Verified-zkEVM/CompPoly/actions/runs/31407592475)):
the step succeeded but did no work, because lean-action had already fetched the oleans.
The same step in #293's CI run measured **5s** on a cold dependency-cache miss — far too
fast to be a real Mathlib olean download, which is what prompted the investigation.

## Change

Remove the step; set `use-mathlib-cache: true` explicitly on `lean-action` in its place,
matching what #293 did for `lean_action_ci.yml`. That keeps the reliance visible at the
call site and pins it against a future change of the `auto` default.

Net: 6 insertions, 3 deletions, one workflow file.

## Test plan

- [x] YAML parses; `publish-oleans` step list is unchanged apart from the removal
- [x] No `lake exe cache get` invocation remains in the workflow
- [x] `docs/wiki/build-cache.md` still describes the job accurately — it says the job
      "fetches Mathlib's oleans", which remains true, just via lean-action
- [ ] **Post-merge**: next release tag still publishes a working `CompPoly-oleans.tar.gz`.
      This is the only real check, since the change is invisible until a release is cut.
      Can be exercised on demand via **Actions → Lean release tag and prebuilt oleans →
      Run workflow** with tag `4.32.0-cache`, which re-uploads with `--clobber`.

## Note

No behavioural change to the published archive. If anything goes wrong here it surfaces
as a failed release build, not as a silently bad asset — the build would fail rather than
produce an archive missing Mathlib-dependent oleans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
