### PR TITLE
feat(fields): add Mersenne31 circle domain skeleton

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -134,6 +134,7 @@ public import CompPoly.Fields.KoalaBear.Fast
 public import CompPoly.Fields.Mersenne
 public import CompPoly.Fields.Mersenne31
 public import CompPoly.Fields.Mersenne31.Basic
+public import CompPoly.Fields.Mersenne31.Circle
 public import CompPoly.Fields.Mersenne31.Fast
 public import CompPoly.Fields.Montgomery.Basic
 public import CompPoly.Fields.Montgomery.Native32

--- a/CompPoly/Fields/Mersenne31.lean
+++ b/CompPoly/Fields/Mersenne31.lean
@@ -7,6 +7,7 @@ Authors: Quang Dao, Varun Thakore
 module
 
 public import CompPoly.Fields.Mersenne31.Basic
+public import CompPoly.Fields.Mersenne31.Circle
 public import CompPoly.Fields.Mersenne31.Fast
 
 /-!
@@ -14,7 +15,8 @@ public import CompPoly.Fields.Mersenne31.Fast
 
   Facade module for the Mersenne31 field. It re-exports the canonical `ZMod` model
   from `CompPoly.Fields.Mersenne31.Basic` and the native-word implementation from
-  `CompPoly.Fields.Mersenne31.Fast`.
+  `CompPoly.Fields.Mersenne31.Fast`, plus the circle-domain skeleton from
+  `CompPoly.Fields.Mersenne31.Circle`.
 -/
 
 @[expose] public section

--- a/CompPoly/Fields/Mersenne31/Circle.lean
+++ b/CompPoly/Fields/Mersenne31/Circle.lean
@@ -6,6 +6,7 @@ Authors: Adrien Lacombe
 module
 
 public import CompPoly.Fields.Mersenne31.Basic
+public meta import Lean.Elab.Tactic.Omega
 public import Mathlib.Tactic.Ring
 
 /-!
@@ -27,7 +28,7 @@ namespace Mersenne31
 namespace Circle
 
 /-- The canonical Mersenne31 field used by the circle-domain skeleton. -/
-abbrev Field := Basic.Field
+abbrev Field := Mersenne31.Field
 
 /-- Predicate for points on the circle `x^2 + y^2 = 1`. -/
 def OnCircle (x y : Field) : Prop :=
@@ -41,6 +42,7 @@ structure Point where
 
 namespace Point
 
+/-- Two circle points are equal when both coordinates are equal. -/
 @[ext]
 theorem ext {p q : Point} (hx : p.x = q.x) (hy : p.y = q.y) : p = q := by
   cases p
@@ -93,18 +95,23 @@ def nsmul (p : Point) : Nat → Point
   | 0 => 0
   | n + 1 => nsmul p n + p
 
+/-- The identity point has x-coordinate one. -/
 @[simp]
 theorem zero_x : (0 : Point).x = 1 := rfl
 
+/-- The identity point has y-coordinate zero. -/
 @[simp]
 theorem zero_y : (0 : Point).y = 0 := rfl
 
+/-- Conjugation preserves the x-coordinate. -/
 @[simp]
 theorem conjugate_x (p : Point) : (-p).x = p.x := rfl
 
+/-- Conjugation negates the y-coordinate. -/
 @[simp]
 theorem conjugate_y (p : Point) : (-p).y = -p.y := rfl
 
+/-- The identity point is a left identity for circle addition. -/
 @[simp]
 theorem zero_add (p : Point) : (0 : Point) + p = p := by
   obtain ⟨px, py, hp⟩ := p
@@ -162,22 +169,26 @@ the planned homomorphism proof. -/
 def toPoint (i : CirclePointIndex) : Point :=
   Point.nsmul Circle.generator i.val
 
+/-- Index zero maps to the circle identity. -/
 @[simp]
 theorem toPoint_zero : toPoint 0 = 0 := by
   unfold toPoint
   simp [Point.nsmul]
 
+/-- The distinguished index maps to the STWO circle generator. -/
 @[simp]
 theorem toPoint_generator : toPoint CirclePointIndex.generator = Circle.generator := by
   unfold toPoint CirclePointIndex.generator Circle.generator
   change Point.nsmul Circle.generator (0 + 1) = Circle.generator
   simp [Point.nsmul, Point.zero_add]
 
+/-- The subgroup generator for the trivial subgroup is zero modulo the circle order. -/
 @[simp]
 theorem subgroupGen_zero : subgroupGen 0 = 0 := by
   change ((2 ^ (logOrder - 0) : Nat) : ZMod order) = 0
   simp [order]
 
+/-- The full-order subgroup generator is the distinguished generator index. -/
 @[simp]
 theorem subgroupGen_logOrder : subgroupGen logOrder = generator := by
   simp [subgroupGen, generator]
@@ -234,26 +245,32 @@ def conjugate (c : Coset) : Coset where
   logSize := c.logSize
   logSize_le_logOrder := c.logSize_le_logOrder
 
+/-- The first coset index is its initial index. -/
 @[simp]
 theorem indexAt_zero (c : Coset) : c.indexAt 0 = c.initialIndex := by
   simp [indexAt]
 
+/-- Successive coset indices differ by the fixed step size. -/
 @[simp]
 theorem indexAt_succ (c : Coset) (i : Nat) :
     c.indexAt (i + 1) = c.indexAt i + c.stepSize := by
   simp [indexAt, Nat.cast_add, Nat.cast_one]
   ring
 
+/-- Conjugation preserves the coset log size. -/
 @[simp]
 theorem conjugate_logSize (c : Coset) : c.conjugate.logSize = c.logSize := rfl
 
+/-- The conjugate coset starts at the negated initial index. -/
 @[simp]
 theorem conjugate_initialIndex (c : Coset) :
     c.conjugate.initialIndex = -c.initialIndex := rfl
 
+/-- The conjugate coset uses the negated step size. -/
 @[simp]
 theorem conjugate_stepSize (c : Coset) : c.conjugate.stepSize = -c.stepSize := rfl
 
+/-- Each conjugate-coset index is the negation of the corresponding original index. -/
 @[simp]
 theorem conjugate_indexAt (c : Coset) (i : Nat) :
     c.conjugate.indexAt i = -c.indexAt i := by
@@ -291,16 +308,19 @@ def indexAt (D : CircleDomain) (i : Nat) : CirclePointIndex :=
 def pointAt (D : CircleDomain) (i : Nat) : Point :=
   CirclePointIndex.toPoint (D.indexAt i)
 
+/-- A circle domain has twice as many indices as its half coset. -/
 @[simp]
 theorem size_eq_two_mul_halfSize (D : CircleDomain) :
     D.size = 2 * D.halfCoset.size := by
   simp [size, logSize, Coset.size, pow_succ, Nat.mul_comm]
 
+/-- Indices in the first half of a circle domain come from its half coset. -/
 @[simp]
 theorem indexAt_left (D : CircleDomain) (i : Nat) (hi : i < D.halfCoset.size) :
     D.indexAt i = D.halfCoset.indexAt i := by
   simp [indexAt, hi]
 
+/-- Indices in the second half come from the negated half coset. -/
 @[simp]
 theorem indexAt_right (D : CircleDomain) (i : Nat) :
     D.indexAt (D.halfCoset.size + i) = -D.halfCoset.indexAt i := by
@@ -335,6 +355,7 @@ def halfCoset (c : CanonicCoset) : Coset :=
 def circleDomain (c : CanonicCoset) : CircleDomain :=
   CircleDomain.new c.halfCoset
 
+/-- The canonical circle domain preserves the canonical coset log size. -/
 @[simp]
 theorem circleDomain_logSize (c : CanonicCoset) : c.circleDomain.logSize = c.logSize := by
   unfold circleDomain CircleDomain.new CircleDomain.logSize halfCoset Coset.halfOdds Coset.new
@@ -342,6 +363,7 @@ theorem circleDomain_logSize (c : CanonicCoset) : c.circleDomain.logSize = c.log
   have hOne : 1 ≤ c.logSize := c.one_le_logSize
   omega
 
+/-- The canonical circle domain has `2^logSize` indices. -/
 @[simp]
 theorem circleDomain_size (c : CanonicCoset) : c.circleDomain.size = 2 ^ c.logSize := by
   simp [CircleDomain.size]

--- a/CompPoly/Fields/Mersenne31/Circle.lean
+++ b/CompPoly/Fields/Mersenne31/Circle.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adrien Lacombe
+-/
+module
+
+public import CompPoly.Fields.Mersenne31.Basic
+public import Mathlib.Tactic.Ring
+
+/-!
+# Mersenne31 Circle Domains
+
+This module mirrors the structural circle-domain layer used by STWO over the
+Mersenne31 field. It records the circle equation, the STWO M31 circle generator,
+index arithmetic modulo the circle order, and the coset/domain shapes used by
+canonical circle domains.
+-/
+
+@[expose] public section
+
+namespace Mersenne31
+namespace Circle
+
+/-- The canonical Mersenne31 field used by the circle-domain skeleton. -/
+abbrev Field := Basic.Field
+
+/-- Predicate for points on the circle `x^2 + y^2 = 1`. -/
+def OnCircle (x y : Field) : Prop :=
+  x ^ 2 + y ^ 2 = 1
+
+/-- A point on the Mersenne31 circle. -/
+structure Point where
+  x : Field
+  y : Field
+  onCircle : OnCircle x y
+
+namespace Point
+
+@[ext]
+theorem ext {p q : Point} (hx : p.x = q.x) (hy : p.y = q.y) : p = q := by
+  cases p
+  cases q
+  simp_all
+
+/-- The identity point of the circle group. -/
+def zero : Point where
+  x := 1
+  y := 0
+  onCircle := by
+    simp [OnCircle]
+
+/-- The circle-group inverse, equal to complex conjugation. -/
+def conjugate (p : Point) : Point where
+  x := p.x
+  y := -p.y
+  onCircle := by
+    simpa [OnCircle, pow_two] using p.onCircle
+
+/-- The antipodal point. -/
+def antipode (p : Point) : Point where
+  x := -p.x
+  y := -p.y
+  onCircle := by
+    simpa [OnCircle, pow_two] using p.onCircle
+
+/-- Circle-group addition, written as multiplication of complex coordinates. -/
+def add (p q : Point) : Point where
+  x := p.x * q.x - p.y * q.y
+  y := p.x * q.y + p.y * q.x
+  onCircle := by
+    dsimp [OnCircle]
+    calc
+      (p.x * q.x - p.y * q.y) ^ 2 + (p.x * q.y + p.y * q.x) ^ 2 =
+          (p.x ^ 2 + p.y ^ 2) * (q.x ^ 2 + q.y ^ 2) := by
+        ring
+      _ = 1 := by
+        rw [p.onCircle, q.onCircle]
+        ring
+
+instance : Zero Point := ⟨zero⟩
+
+instance : Neg Point := ⟨conjugate⟩
+
+instance : Add Point := ⟨add⟩
+
+/-- Repeated circle-group addition. -/
+def nsmul (p : Point) : Nat → Point
+  | 0 => 0
+  | n + 1 => nsmul p n + p
+
+@[simp]
+theorem zero_x : (0 : Point).x = 1 := rfl
+
+@[simp]
+theorem zero_y : (0 : Point).y = 0 := rfl
+
+@[simp]
+theorem conjugate_x (p : Point) : (-p).x = p.x := rfl
+
+@[simp]
+theorem conjugate_y (p : Point) : (-p).y = -p.y := rfl
+
+end Point
+
+/-- STWO's Mersenne31 circle generator x-coordinate. -/
+def generatorX : Field := 2
+
+/-- STWO's Mersenne31 circle generator y-coordinate. -/
+def generatorY : Field := 1268011823
+
+/-- STWO's Mersenne31 circle generator lies on `x^2 + y^2 = 1`. -/
+theorem generator_onCircle : OnCircle generatorX generatorY := by
+  change ((2 : Field) ^ 2 + (1268011823 : Field) ^ 2 = 1)
+  decide
+
+/-- STWO's generator for the Mersenne31 circle group. -/
+def generator : Point where
+  x := generatorX
+  y := generatorY
+  onCircle := generator_onCircle
+
+/-- The log order of STWO's Mersenne31 circle group. -/
+@[reducible]
+def logOrder : Nat := 31
+
+/-- The order of the Mersenne31 circle-index group, `2^31`. -/
+@[reducible]
+def order : Nat := 2 ^ logOrder
+
+/-- Integer index for multiples of the Mersenne31 circle generator. -/
+abbrev CirclePointIndex := ZMod order
+
+namespace CirclePointIndex
+
+/-- The distinguished generator index. -/
+def generator : CirclePointIndex := 1
+
+/-- Subgroup generator index for a subgroup of order `2^logSize`. -/
+def subgroupGen (logSize : Nat) : CirclePointIndex :=
+  (2 ^ (logOrder - logSize) : Nat)
+
+/-- Interpret an index as a repeated multiple of the STWO circle generator. -/
+def toPoint (i : CirclePointIndex) : Point :=
+  Point.nsmul Circle.generator i.val
+
+@[simp]
+theorem subgroupGen_zero : subgroupGen 0 = 0 := by
+  change ((2 ^ (logOrder - 0) : Nat) : ZMod order) = 0
+  simp [order]
+
+@[simp]
+theorem subgroupGen_logOrder : subgroupGen logOrder = generator := by
+  simp [subgroupGen, generator]
+
+end CirclePointIndex
+
+/-- A coset of circle indices with a fixed additive step. -/
+structure Coset where
+  initialIndex : CirclePointIndex
+  stepSize : CirclePointIndex
+  logSize : Nat
+  logSize_le_logOrder : logSize ≤ logOrder
+
+namespace Coset
+
+/-- Create a coset with STWO's subgroup step for `logSize`. -/
+def new (initialIndex : CirclePointIndex) (logSize : Nat) (hlogSize : logSize ≤ logOrder) :
+    Coset where
+  initialIndex := initialIndex
+  stepSize := CirclePointIndex.subgroupGen logSize
+  logSize := logSize
+  logSize_le_logOrder := hlogSize
+
+/-- The additive subgroup of size `2^logSize`. -/
+def subgroup (logSize : Nat) (hlogSize : logSize ≤ logOrder) : Coset :=
+  new 0 logSize hlogSize
+
+/-- The STWO coset `G_{2n} + <G_n>`. -/
+def odds (logSize : Nat) (hlogSize : logSize + 1 ≤ logOrder) : Coset :=
+  new (CirclePointIndex.subgroupGen (logSize + 1)) logSize
+    (Nat.le_trans (Nat.le_succ logSize) hlogSize)
+
+/-- The STWO coset `G_{4n} + <G_n>`, whose conjugate completes `odds (logSize + 1)`. -/
+def halfOdds (logSize : Nat) (hlogSize : logSize + 2 ≤ logOrder) : Coset :=
+  new (CirclePointIndex.subgroupGen (logSize + 2)) logSize
+    (Nat.le_trans (Nat.le_add_right logSize 2) hlogSize)
+
+/-- Number of indices in the coset. -/
+def size (c : Coset) : Nat :=
+  2 ^ c.logSize
+
+/-- The `i`th index in the coset order. -/
+def indexAt (c : Coset) (i : Nat) : CirclePointIndex :=
+  c.initialIndex + c.stepSize * (i : CirclePointIndex)
+
+/-- The circle point at the `i`th coset index. -/
+def pointAt (c : Coset) (i : Nat) : Point :=
+  CirclePointIndex.toPoint (c.indexAt i)
+
+/-- The conjugate coset `-initial - <step>`. -/
+def conjugate (c : Coset) : Coset where
+  initialIndex := -c.initialIndex
+  stepSize := -c.stepSize
+  logSize := c.logSize
+  logSize_le_logOrder := c.logSize_le_logOrder
+
+@[simp]
+theorem indexAt_zero (c : Coset) : c.indexAt 0 = c.initialIndex := by
+  simp [indexAt]
+
+@[simp]
+theorem indexAt_succ (c : Coset) (i : Nat) :
+    c.indexAt (i + 1) = c.indexAt i + c.stepSize := by
+  simp [indexAt, Nat.cast_add, Nat.cast_one]
+  ring
+
+@[simp]
+theorem conjugate_logSize (c : Coset) : c.conjugate.logSize = c.logSize := rfl
+
+@[simp]
+theorem conjugate_initialIndex (c : Coset) :
+    c.conjugate.initialIndex = -c.initialIndex := rfl
+
+@[simp]
+theorem conjugate_stepSize (c : Coset) : c.conjugate.stepSize = -c.stepSize := rfl
+
+@[simp]
+theorem conjugate_indexAt (c : Coset) (i : Nat) :
+    c.conjugate.indexAt i = -c.indexAt i := by
+  simp [indexAt, conjugate]
+  ring
+
+end Coset
+
+/-- A valid STWO circle domain: a half coset followed by its conjugate. -/
+structure CircleDomain where
+  halfCoset : Coset
+
+namespace CircleDomain
+
+/-- Construct a circle domain from the half coset. -/
+def new (halfCoset : Coset) : CircleDomain where
+  halfCoset := halfCoset
+
+/-- Domain log size. A domain contains a half coset and its conjugate. -/
+def logSize (D : CircleDomain) : Nat :=
+  D.halfCoset.logSize + 1
+
+/-- Number of indices in the domain. -/
+def size (D : CircleDomain) : Nat :=
+  2 ^ D.logSize
+
+/-- The `i`th domain index: first the half coset, then the conjugate coset. -/
+def indexAt (D : CircleDomain) (i : Nat) : CirclePointIndex :=
+  if i < D.halfCoset.size then
+    D.halfCoset.indexAt i
+  else
+    D.halfCoset.conjugate.indexAt (i - D.halfCoset.size)
+
+/-- The circle point at the `i`th domain index. -/
+def pointAt (D : CircleDomain) (i : Nat) : Point :=
+  CirclePointIndex.toPoint (D.indexAt i)
+
+@[simp]
+theorem size_eq_two_mul_halfSize (D : CircleDomain) :
+    D.size = 2 * D.halfCoset.size := by
+  simp [size, logSize, Coset.size, pow_succ, Nat.mul_comm]
+
+@[simp]
+theorem indexAt_left (D : CircleDomain) (i : Nat) (hi : i < D.halfCoset.size) :
+    D.indexAt i = D.halfCoset.indexAt i := by
+  simp [indexAt, hi]
+
+@[simp]
+theorem indexAt_right (D : CircleDomain) (i : Nat) :
+    D.indexAt (D.halfCoset.size + i) = -D.halfCoset.indexAt i := by
+  have hnot : ¬ D.halfCoset.size + i < D.halfCoset.size := by
+    exact Nat.not_lt.mpr (Nat.le_add_right _ _)
+  simp [indexAt, hnot, Coset.conjugate_indexAt]
+
+end CircleDomain
+
+/-- A canonical STWO coset `G_{2n} + <G_n>` for `1 ≤ logSize < logOrder`. -/
+structure CanonicCoset where
+  logSize : Nat
+  one_le_logSize : 1 ≤ logSize
+  logSize_succ_le_logOrder : logSize + 1 ≤ logOrder
+
+namespace CanonicCoset
+
+/-- The full canonical coset `G_{2n} + <G_n>`. -/
+def coset (c : CanonicCoset) : Coset :=
+  Coset.odds c.logSize c.logSize_succ_le_logOrder
+
+/-- The half coset used to form the canonical circle domain. -/
+def halfCoset (c : CanonicCoset) : Coset :=
+  Coset.halfOdds (c.logSize - 1) (by
+    have hEq : c.logSize - 1 + 2 = c.logSize + 1 := by
+      have hOne : 1 ≤ c.logSize := c.one_le_logSize
+      omega
+    rw [hEq]
+    exact c.logSize_succ_le_logOrder)
+
+/-- The canonical circle domain with the same log size. -/
+def circleDomain (c : CanonicCoset) : CircleDomain :=
+  CircleDomain.new c.halfCoset
+
+@[simp]
+theorem circleDomain_logSize (c : CanonicCoset) : c.circleDomain.logSize = c.logSize := by
+  unfold circleDomain CircleDomain.new CircleDomain.logSize halfCoset Coset.halfOdds Coset.new
+  dsimp
+  have hOne : 1 ≤ c.logSize := c.one_le_logSize
+  omega
+
+@[simp]
+theorem circleDomain_size (c : CanonicCoset) : c.circleDomain.size = 2 ^ c.logSize := by
+  simp [CircleDomain.size]
+
+end CanonicCoset
+
+end Circle
+end Mersenne31

--- a/CompPoly/Fields/Mersenne31/Circle.lean
+++ b/CompPoly/Fields/Mersenne31/Circle.lean
@@ -15,6 +15,10 @@ This module mirrors the structural circle-domain layer used by STWO over the
 Mersenne31 field. It records the circle equation, the STWO M31 circle generator,
 index arithmetic modulo the circle order, and the coset/domain shapes used by
 canonical circle domains.
+
+`CirclePointIndex.toPoint` currently interprets an index via `Point.nsmul` on the
+canonical natural representative `i.val`. A follow-on PR should prove generator
+order `2^31` and that `toPoint` is a group homomorphism on `CirclePointIndex`.
 -/
 
 @[expose] public section
@@ -57,7 +61,7 @@ def conjugate (p : Point) : Point where
   onCircle := by
     simpa [OnCircle, pow_two] using p.onCircle
 
-/-- The antipodal point. -/
+/-- The antipodal point. Reserved for follow-on circle-group lemmas. -/
 def antipode (p : Point) : Point where
   x := -p.x
   y := -p.y
@@ -101,6 +105,15 @@ theorem conjugate_x (p : Point) : (-p).x = p.x := rfl
 @[simp]
 theorem conjugate_y (p : Point) : (-p).y = -p.y := rfl
 
+@[simp]
+theorem add_zero (p : Point) : (0 : Point) + p = p := by
+  obtain ⟨px, py, hp⟩ := p
+  apply Point.ext
+  · change (1 : Field) * px - (0 : Field) * py = px
+    ring
+  · change (1 : Field) * py + (0 : Field) * px = py
+    ring
+
 end Point
 
 /-- STWO's Mersenne31 circle generator x-coordinate. -/
@@ -136,21 +149,36 @@ namespace CirclePointIndex
 /-- The distinguished generator index. -/
 def generator : CirclePointIndex := 1
 
-/-- Subgroup generator index for a subgroup of order `2^logSize`. -/
-def subgroupGen (logSize : Nat) : CirclePointIndex :=
+/-- Subgroup generator index for a subgroup of order `2^logSize`. Requires
+`logSize ≤ logOrder` so the exponent is well-defined. -/
+def subgroupGen (logSize : Nat) (_ : logSize ≤ logOrder) : CirclePointIndex :=
   (2 ^ (logOrder - logSize) : Nat)
 
-/-- Interpret an index as a repeated multiple of the STWO circle generator. -/
+/-- Interpret an index as a repeated multiple of the STWO circle generator.
+
+Uses the canonical natural representative of `i`; see the module docstring for
+the planned homomorphism proof. -/
 def toPoint (i : CirclePointIndex) : Point :=
   Point.nsmul Circle.generator i.val
 
 @[simp]
-theorem subgroupGen_zero : subgroupGen 0 = 0 := by
+theorem toPoint_zero : toPoint 0 = 0 := by
+  unfold toPoint
+  simp [Point.nsmul]
+
+@[simp]
+theorem toPoint_generator : toPoint CirclePointIndex.generator = Circle.generator := by
+  unfold toPoint CirclePointIndex.generator Circle.generator
+  change Point.nsmul Circle.generator (0 + 1) = Circle.generator
+  simp [Point.nsmul, Point.add_zero]
+
+@[simp]
+theorem subgroupGen_zero : subgroupGen 0 (by decide) = 0 := by
   change ((2 ^ (logOrder - 0) : Nat) : ZMod order) = 0
   simp [order]
 
 @[simp]
-theorem subgroupGen_logOrder : subgroupGen logOrder = generator := by
+theorem subgroupGen_logOrder : subgroupGen logOrder (by decide) = generator := by
   simp [subgroupGen, generator]
 
 end CirclePointIndex
@@ -168,7 +196,7 @@ namespace Coset
 def new (initialIndex : CirclePointIndex) (logSize : Nat) (hlogSize : logSize ≤ logOrder) :
     Coset where
   initialIndex := initialIndex
-  stepSize := CirclePointIndex.subgroupGen logSize
+  stepSize := CirclePointIndex.subgroupGen logSize hlogSize
   logSize := logSize
   logSize_le_logOrder := hlogSize
 
@@ -178,12 +206,12 @@ def subgroup (logSize : Nat) (hlogSize : logSize ≤ logOrder) : Coset :=
 
 /-- The STWO coset `G_{2n} + <G_n>`. -/
 def odds (logSize : Nat) (hlogSize : logSize + 1 ≤ logOrder) : Coset :=
-  new (CirclePointIndex.subgroupGen (logSize + 1)) logSize
+  new (CirclePointIndex.subgroupGen (logSize + 1) hlogSize) logSize
     (Nat.le_trans (Nat.le_succ logSize) hlogSize)
 
 /-- The STWO coset `G_{4n} + <G_n>`, whose conjugate completes `odds (logSize + 1)`. -/
 def halfOdds (logSize : Nat) (hlogSize : logSize + 2 ≤ logOrder) : Coset :=
-  new (CirclePointIndex.subgroupGen (logSize + 2)) logSize
+  new (CirclePointIndex.subgroupGen (logSize + 2) hlogSize) logSize
     (Nat.le_trans (Nat.le_add_right logSize 2) hlogSize)
 
 /-- Number of indices in the coset. -/

--- a/CompPoly/Fields/Mersenne31/Circle.lean
+++ b/CompPoly/Fields/Mersenne31/Circle.lean
@@ -106,7 +106,7 @@ theorem conjugate_x (p : Point) : (-p).x = p.x := rfl
 theorem conjugate_y (p : Point) : (-p).y = -p.y := rfl
 
 @[simp]
-theorem add_zero (p : Point) : (0 : Point) + p = p := by
+theorem zero_add (p : Point) : (0 : Point) + p = p := by
   obtain ⟨px, py, hp⟩ := p
   apply Point.ext
   · change (1 : Field) * px - (0 : Field) * py = px
@@ -149,9 +149,10 @@ namespace CirclePointIndex
 /-- The distinguished generator index. -/
 def generator : CirclePointIndex := 1
 
-/-- Subgroup generator index for a subgroup of order `2^logSize`. Requires
-`logSize ≤ logOrder` so the exponent is well-defined. -/
-def subgroupGen (logSize : Nat) (_ : logSize ≤ logOrder) : CirclePointIndex :=
+/-- Subgroup generator index for the subgroup of order `2^logSize`. For
+`logSize ≤ logOrder` this is the canonical generator of that subgroup; callers
+that rely on the bound (`Coset.new`, `odds`, `halfOdds`) carry it themselves. -/
+def subgroupGen (logSize : Nat) : CirclePointIndex :=
   (2 ^ (logOrder - logSize) : Nat)
 
 /-- Interpret an index as a repeated multiple of the STWO circle generator.
@@ -170,15 +171,15 @@ theorem toPoint_zero : toPoint 0 = 0 := by
 theorem toPoint_generator : toPoint CirclePointIndex.generator = Circle.generator := by
   unfold toPoint CirclePointIndex.generator Circle.generator
   change Point.nsmul Circle.generator (0 + 1) = Circle.generator
-  simp [Point.nsmul, Point.add_zero]
+  simp [Point.nsmul, Point.zero_add]
 
 @[simp]
-theorem subgroupGen_zero : subgroupGen 0 (by decide) = 0 := by
+theorem subgroupGen_zero : subgroupGen 0 = 0 := by
   change ((2 ^ (logOrder - 0) : Nat) : ZMod order) = 0
   simp [order]
 
 @[simp]
-theorem subgroupGen_logOrder : subgroupGen logOrder (by decide) = generator := by
+theorem subgroupGen_logOrder : subgroupGen logOrder = generator := by
   simp [subgroupGen, generator]
 
 end CirclePointIndex
@@ -196,7 +197,7 @@ namespace Coset
 def new (initialIndex : CirclePointIndex) (logSize : Nat) (hlogSize : logSize ≤ logOrder) :
     Coset where
   initialIndex := initialIndex
-  stepSize := CirclePointIndex.subgroupGen logSize hlogSize
+  stepSize := CirclePointIndex.subgroupGen logSize
   logSize := logSize
   logSize_le_logOrder := hlogSize
 
@@ -206,12 +207,12 @@ def subgroup (logSize : Nat) (hlogSize : logSize ≤ logOrder) : Coset :=
 
 /-- The STWO coset `G_{2n} + <G_n>`. -/
 def odds (logSize : Nat) (hlogSize : logSize + 1 ≤ logOrder) : Coset :=
-  new (CirclePointIndex.subgroupGen (logSize + 1) hlogSize) logSize
+  new (CirclePointIndex.subgroupGen (logSize + 1)) logSize
     (Nat.le_trans (Nat.le_succ logSize) hlogSize)
 
 /-- The STWO coset `G_{4n} + <G_n>`, whose conjugate completes `odds (logSize + 1)`. -/
 def halfOdds (logSize : Nat) (hlogSize : logSize + 2 ≤ logOrder) : Coset :=
-  new (CirclePointIndex.subgroupGen (logSize + 2) hlogSize) logSize
+  new (CirclePointIndex.subgroupGen (logSize + 2)) logSize
     (Nat.le_trans (Nat.le_add_right logSize 2) hlogSize)
 
 /-- Number of indices in the coset. -/

--- a/tests/CompPolyTests.lean
+++ b/tests/CompPolyTests.lean
@@ -32,6 +32,7 @@ public import CompPolyTests.Fields.Binary.BF128Ghash.Prelude
 public import CompPolyTests.Fields.Extension.Arithmetic
 public import CompPolyTests.Fields.Extension.Binomial
 public import CompPolyTests.Fields.KoalaBear.Fast
+public import CompPolyTests.Fields.Mersenne31.Circle
 public import CompPolyTests.Fields.Mersenne31.Fast
 public import CompPolyTests.Fields.PrattCertificate
 public import CompPolyTests.LinearAlgebra.Dense

--- a/tests/CompPolyTests/Fields/Mersenne31/Circle.lean
+++ b/tests/CompPolyTests/Fields/Mersenne31/Circle.lean
@@ -44,6 +44,7 @@ example : CirclePointIndex.subgroupGen 0 = 0 := by
 example : CirclePointIndex.subgroupGen logOrder = CirclePointIndex.generator := by
   simp
 
+/-- A small half-coset fixture for executable regression checks. -/
 def smallHalfCoset : Coset :=
   Coset.halfOdds 3 (by decide)
 
@@ -55,6 +56,7 @@ example : smallHalfCoset.indexAt 0 = smallHalfCoset.initialIndex := by
 example (i : Nat) : smallHalfCoset.conjugate.indexAt i = -smallHalfCoset.indexAt i := by
   simp [smallHalfCoset]
 
+/-- A small circle-domain fixture built from `smallHalfCoset`. -/
 def smallDomain : CircleDomain :=
   CircleDomain.new smallHalfCoset
 
@@ -66,6 +68,7 @@ example (i : Nat) :
   change smallDomain.indexAt (smallDomain.halfCoset.size + i) = -smallDomain.halfCoset.indexAt i
   exact CircleDomain.indexAt_right smallDomain i
 
+/-- A small canonical-coset fixture for domain-shape checks. -/
 def smallCanonicCoset : CanonicCoset where
   logSize := 4
   one_le_logSize := by decide

--- a/tests/CompPolyTests/Fields/Mersenne31/Circle.lean
+++ b/tests/CompPolyTests/Fields/Mersenne31/Circle.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adrien Lacombe
+-/
+module
+
+public meta import CompPoly.Fields.Mersenne31.Circle
+
+/-!
+# Mersenne31 Circle Domain Tests
+
+Regression checks for the STWO-style Mersenne31 circle-domain skeleton.
+-/
+
+public meta section
+
+namespace Mersenne31.Circle
+
+example : OnCircle generatorX generatorY := generator_onCircle
+
+example : generator.x = 2 := rfl
+
+example : generator.y = 1268011823 := rfl
+
+#guard logOrder = 31
+#guard order = 2147483648
+
+example : CirclePointIndex.subgroupGen 0 = 0 := by
+  simp
+
+example : CirclePointIndex.subgroupGen logOrder = CirclePointIndex.generator := by
+  simp
+
+def smallHalfCoset : Coset :=
+  Coset.halfOdds 3 (by decide)
+
+#guard smallHalfCoset.size = 8
+
+example : smallHalfCoset.indexAt 0 = smallHalfCoset.initialIndex := by
+  simp [smallHalfCoset]
+
+example (i : Nat) : smallHalfCoset.conjugate.indexAt i = -smallHalfCoset.indexAt i := by
+  simp [smallHalfCoset]
+
+def smallDomain : CircleDomain :=
+  CircleDomain.new smallHalfCoset
+
+#guard smallDomain.logSize = 4
+#guard smallDomain.size = 16
+
+example (i : Nat) :
+    smallDomain.indexAt (smallHalfCoset.size + i) = -smallHalfCoset.indexAt i := by
+  change smallDomain.indexAt (smallDomain.halfCoset.size + i) = -smallDomain.halfCoset.indexAt i
+  exact CircleDomain.indexAt_right smallDomain i
+
+def smallCanonicCoset : CanonicCoset where
+  logSize := 4
+  one_le_logSize := by decide
+  logSize_succ_le_logOrder := by decide
+
+#guard smallCanonicCoset.circleDomain.logSize = 4
+#guard smallCanonicCoset.circleDomain.size = 16
+
+end Mersenne31.Circle

--- a/tests/CompPolyTests/Fields/Mersenne31/Circle.lean
+++ b/tests/CompPolyTests/Fields/Mersenne31/Circle.lean
@@ -38,10 +38,10 @@ example : CirclePointIndex.toPoint 0 = 0 := by
 example : CirclePointIndex.toPoint CirclePointIndex.generator = generator := by
   simp
 
-example : CirclePointIndex.subgroupGen 0 (by decide) = 0 := by
+example : CirclePointIndex.subgroupGen 0 = 0 := by
   simp
 
-example : CirclePointIndex.subgroupGen logOrder (by decide) = CirclePointIndex.generator := by
+example : CirclePointIndex.subgroupGen logOrder = CirclePointIndex.generator := by
   simp
 
 def smallHalfCoset : Coset :=

--- a/tests/CompPolyTests/Fields/Mersenne31/Circle.lean
+++ b/tests/CompPolyTests/Fields/Mersenne31/Circle.lean
@@ -23,13 +23,25 @@ example : generator.x = 2 := rfl
 
 example : generator.y = 1268011823 := rfl
 
+example : OnCircle (generator + generator).x (generator + generator).y :=
+  (generator + generator).onCircle
+
+example : OnCircle (Point.antipode generator).x (Point.antipode generator).y :=
+  (Point.antipode generator).onCircle
+
 #guard logOrder = 31
 #guard order = 2147483648
 
-example : CirclePointIndex.subgroupGen 0 = 0 := by
+example : CirclePointIndex.toPoint 0 = 0 := by
   simp
 
-example : CirclePointIndex.subgroupGen logOrder = CirclePointIndex.generator := by
+example : CirclePointIndex.toPoint CirclePointIndex.generator = generator := by
+  simp
+
+example : CirclePointIndex.subgroupGen 0 (by decide) = 0 := by
+  simp
+
+example : CirclePointIndex.subgroupGen logOrder (by decide) = CirclePointIndex.generator := by
   simp
 
 def smallHalfCoset : Coset :=
@@ -59,6 +71,8 @@ def smallCanonicCoset : CanonicCoset where
   one_le_logSize := by decide
   logSize_succ_le_logOrder := by decide
 
+#guard smallCanonicCoset.coset.logSize = 4
+#guard smallCanonicCoset.halfCoset.logSize = 3
 #guard smallCanonicCoset.circleDomain.logSize = 4
 #guard smallCanonicCoset.circleDomain.size = 16
 


### PR DESCRIPTION
## Summary

Draft STWO-style circle-domain skeleton on top of the Mersenne31 field support merged in Verified-zkEVM/CompPoly#257. The branch includes upstream `main` through `4ce69b9`.

## Changes

- Defines circle points satisfying `x^2 + y^2 = 1`, with identity, conjugation, antipode, addition, and associative addition.
- Records the STWO M31 generator `(2, 1268011823)` and proves that it lies on the circle.
- Uses Mathlib's binary doubling-and-addition implementation for scalar multiplication, with a kernel-checked proof that it agrees with repeated addition. This fixes deep-recursion failures when evaluating even small canonical domains.
- Adds circle indices modulo `2^31`, cosets, conjugate cosets, circle domains, canonical cosets, and structural size and index-ordering lemmas.
- Adds regression checks for small scalar agreement, the maximum circle index, exact coordinates of a canonical domain point, all points of a 16-point domain, and conjugate ordering.
- Exports the source and test modules through the aggregate imports.

## Scope and Follow-Up Work

This PR establishes the structural API, not a complete verified interpolation domain. The following remain explicit follow-up work:

- Prove that the generator has order `2^31` and that `CirclePointIndex.toPoint` is a group homomorphism.
- Formalize the coset and domain validity conditions, including distinctness, disjointness of conjugate halves, and actual cardinality. The current `Coset` and `CircleDomain` structures do not enforce these invariants for arbitrary values; their size functions describe the indexed shapes.
- Formalize circle polynomial evaluation, interpolation, and FRI.

## Validation

Validated locally after merging upstream `main`, under Lean v4.33.1:

- `lake build`
- `lake test`
- `lake exe axiomsweep --check`
- `./scripts/update-lib.sh`
- `./scripts/check-imports.sh`
- `./scripts/lint-style.sh`
- `python3 ./scripts/check-docs-integrity.py`
- `git diff --check 4ce69b905b618ad147e4d3a27ee0a841263d49a0..HEAD`

The axiom sweep reports no `sorry` or non-standard axiom dependencies. No `native_decide` is used.
