### PR TITLE
feat(multivariate): add partial evaluation of the first variable

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -228,6 +228,7 @@ public import CompPoly.Multivariate.MvPolyEquiv.Core
 public import CompPoly.Multivariate.MvPolyEquiv.Eval
 public import CompPoly.Multivariate.MvPolyEquiv.Instances
 public import CompPoly.Multivariate.Operations
+public import CompPoly.Multivariate.PartialEval
 public import CompPoly.Multivariate.Rename
 public import CompPoly.Multivariate.Restrict
 public import CompPoly.Multivariate.Unlawful

--- a/CompPoly/Multivariate/Operations.lean
+++ b/CompPoly/Multivariate/Operations.lean
@@ -460,7 +460,6 @@ attribute [grind =]
   aeval_C aeval_X aeval_add aeval_mul
   aeval_zero aeval_one aeval_pow aeval_neg aeval_sub
 
-
 /-- The computable substitution `bind₁` agrees with Mathlib substitution after
 transporting through `fromCMvPolynomial`. -/
 theorem fromCMvPolynomial_bind₁ {n m : ℕ} {R : Type*} [CommSemiring R] [BEq R]
@@ -495,9 +494,11 @@ theorem fromCMvPolynomial_bind₁ {n m : ℕ} {R : Type*} [CommSemiring R] [BEq 
             (algebraMap R (CMvPolynomial m R)))
           (fun i => fromCMvPolynomial (f i))
           (fromCMvPolynomial p) := by
-    simpa [CPoly.polyRingEquiv, CPoly.polyEquiv] using h
+    simpa only [polyRingEquiv, polyEquiv, RingEquiv.toRingHom_eq_coe,
+      MvPolynomial.coe_eval₂Hom, RingHom.coe_coe, RingEquiv.coe_mk, Equiv.coe_fn_mk] using h
   rw [hcomp] at h'
   exact h'
+
 end CMvPolynomial
 
 namespace Lawful

--- a/CompPoly/Multivariate/Operations.lean
+++ b/CompPoly/Multivariate/Operations.lean
@@ -460,6 +460,44 @@ attribute [grind =]
   aeval_C aeval_X aeval_add aeval_mul
   aeval_zero aeval_one aeval_pow aeval_neg aeval_sub
 
+
+/-- The computable substitution `bind₁` agrees with Mathlib substitution after
+transporting through `fromCMvPolynomial`. -/
+theorem fromCMvPolynomial_bind₁ {n m : ℕ} {R : Type*} [CommSemiring R] [BEq R]
+    [LawfulBEq R] (f : Fin n → CMvPolynomial m R) (p : CMvPolynomial n R) :
+    fromCMvPolynomial (bind₁ f p) =
+      MvPolynomial.eval₂ MvPolynomial.C (fun i => fromCMvPolynomial (f i))
+        (fromCMvPolynomial p) := by
+  rw [bind₁_eq_aeval]
+  unfold aeval
+  have h := MvPolynomial.map_eval₂Hom
+    (f := algebraMap R (CMvPolynomial m R))
+    (g := f)
+    (φ := (CPoly.polyRingEquiv (n := m) (R := R)).toRingHom)
+    (p := fromCMvPolynomial p)
+  have hcomp :
+      ((CPoly.polyRingEquiv (n := m) (R := R)).toRingHom).comp
+        (algebraMap R (CMvPolynomial m R)) = MvPolynomial.C := by
+    ext r μ
+    rw [RingHom.comp_apply]
+    change MvPolynomial.coeff μ
+        (fromCMvPolynomial (algebraMap R (CMvPolynomial m R) r)) =
+      MvPolynomial.coeff μ (MvPolynomial.C r)
+    rw [show (algebraMap R (CMvPolynomial m R)) r = CMvPolynomial.C (n := m) r from rfl]
+    rw [fromCMvPolynomial_C]
+  rw [eval₂_equiv (p := p) (f := algebraMap R (CMvPolynomial m R)) (vals := f)]
+  have h' :
+      fromCMvPolynomial
+          (MvPolynomial.eval₂ (algebraMap R (CMvPolynomial m R)) f
+            (fromCMvPolynomial p)) =
+        MvPolynomial.eval₂
+          (((CPoly.polyRingEquiv (n := m) (R := R)).toRingHom).comp
+            (algebraMap R (CMvPolynomial m R)))
+          (fun i => fromCMvPolynomial (f i))
+          (fromCMvPolynomial p) := by
+    simpa [CPoly.polyRingEquiv, CPoly.polyEquiv] using h
+  rw [hcomp] at h'
+  exact h'
 end CMvPolynomial
 
 namespace Lawful

--- a/CompPoly/Multivariate/PartialEval.lean
+++ b/CompPoly/Multivariate/PartialEval.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: ArkLib Contributors
+-/
+import CompPoly.Data.MvPolynomial.Notation
+import CompPoly.Multivariate.DegreeBound
+import CompPoly.Multivariate.Operations
+import CompPoly.Multivariate.MvPolyEquiv.Eval
+
+/-!
+# Partial evaluation of the first variable of a `CMvPolynomial`
+
+`partialEvalFirst a p` fixes variable `0` of a multivariate computable
+polynomial to a scalar value, together with its evaluation lemma and the
+per-variable degree-bound lemma.
+-/
+
+open CompPoly Std
+
+namespace CPoly
+
+namespace CMvPolynomial
+
+variable {n : ℕ} {R : Type} [CommSemiring R] [BEq R] [LawfulBEq R]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma partialEvalFirst_subst_degreeOf_le [Nontrivial R] (a : R)
+    (i : Fin n) (j : Fin (n + 1)) :
+    MvPolynomial.degreeOf i
+      (Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j :
+        MvPolynomial (Fin n) R) ≤ if j = i.succ then 1 else 0 := by
+  cases j using Fin.cases with
+  | zero =>
+      simp [MvPolynomial.degreeOf_C]
+  | succ j =>
+      by_cases h : j = i
+      · subst h
+        simp
+      · have hsucc : Fin.succ j ≠ i.succ := by
+          intro h'
+          exact h ((Fin.succ_injective n) h')
+        have hi_ne_j : i ≠ j := fun hij => h hij.symm
+        simp [hsucc, hi_ne_j, MvPolynomial.degreeOf_X]
+
+omit [BEq R] [LawfulBEq R] in
+private lemma partialEvalFirst_eval₂_monomial_degreeOf_le [Nontrivial R] {deg : ℕ}
+    (a : R) (i : Fin n) (s : Fin (n + 1) →₀ ℕ) (c : R)
+    (hs : s i.succ ≤ deg) :
+    MvPolynomial.degreeOf i
+      (MvPolynomial.eval₂ MvPolynomial.C
+        (fun j : Fin (n + 1) =>
+          Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j)
+        (MvPolynomial.monomial s c) : MvPolynomial (Fin n) R) ≤ deg := by
+  rw [MvPolynomial.eval₂_monomial]
+  refine (MvPolynomial.degreeOf_C_mul_le _ i c).trans ?_
+  rw [Finsupp.prod]
+  refine (MvPolynomial.degreeOf_prod_le i s.support
+    (fun j => (Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j :
+      MvPolynomial (Fin n) R) ^ s j)).trans ?_
+  calc
+    (∑ x ∈ s.support,
+        MvPolynomial.degreeOf i
+          ((Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) x :
+            MvPolynomial (Fin n) R) ^ s x))
+        ≤ ∑ x ∈ s.support, s x * (if x = i.succ then 1 else 0) := by
+          refine Finset.sum_le_sum ?_
+          intro x hx
+          exact (MvPolynomial.degreeOf_pow_le i
+            (Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) x :
+              MvPolynomial (Fin n) R) (s x)).trans
+            (Nat.mul_le_mul_left _ (partialEvalFirst_subst_degreeOf_le a i x))
+    _ ≤ s i.succ := by
+          classical
+          by_cases hi : i.succ ∈ s.support
+          · rw [Finset.sum_eq_single i.succ]
+            · simp
+            · intro x hx hne
+              simp [hne]
+            · intro hnot
+              exact False.elim (hnot hi)
+          · rw [Finset.sum_eq_zero]
+            · simp
+            · intro x hx
+              have hne : x ≠ i.succ := fun h => hi (h ▸ hx)
+              simp [hne]
+    _ ≤ deg := hs
+
+omit [BEq R] [LawfulBEq R] in
+private lemma partialEvalFirst_eval₂_degreeOf_le [Nontrivial R] {deg : ℕ}
+    (a : R) (i : Fin n) (p : MvPolynomial (Fin (n + 1)) R)
+    (hDeg : ∀ s ∈ p.support, s i.succ ≤ deg) :
+    MvPolynomial.degreeOf i
+      (MvPolynomial.eval₂ MvPolynomial.C
+        (fun j : Fin (n + 1) =>
+          Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j)
+        p : MvPolynomial (Fin n) R) ≤ deg := by
+  rw [MvPolynomial.eval₂_eq]
+  refine (MvPolynomial.degreeOf_sum_le i p.support
+    (fun s => MvPolynomial.C (p.coeff s) *
+      ∏ x ∈ s.support,
+        (Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) x :
+          MvPolynomial (Fin n) R) ^ s x)).trans ?_
+  apply Finset.sup_le
+  intro s hs
+  simpa [MvPolynomial.eval₂_monomial, Finsupp.prod] using
+    partialEvalFirst_eval₂_monomial_degreeOf_le (n := n) (R := R)
+      (deg := deg) a i s (p.coeff s) (hDeg s hs)
+
+/-! ## Core operation -/
+
+/-- Fix variable 0 of a multivariate polynomial to a scalar value `a`. -/
+def partialEvalFirst (a : R) (p : CMvPolynomial (n + 1) R) : CMvPolynomial n R :=
+  bind₁ (Fin.cons (C a) X) p
+
+/-! ## Evaluation lemma -/
+
+/-- `partialEvalFirst a p` correctly implements partial evaluation. -/
+theorem partialEvalFirst_eval (a : R) (p : CMvPolynomial (n + 1) R) (v : Fin n → R) :
+    (partialEvalFirst a p).eval v = p.eval (Fin.cons a v) := by
+  unfold partialEvalFirst
+  rw [eval_equiv, fromCMvPolynomial_bind₁]
+  rw [MvPolynomial.eval₂_comp_left]
+  have hc : (MvPolynomial.eval v).comp MvPolynomial.C = RingHom.id R := by
+    ext r
+    simp
+  have hv :
+      (⇑(MvPolynomial.eval v) ∘
+          fun i => fromCMvPolynomial
+            (((Fin.cons (CMvPolynomial.C (n := n) a)
+              (fun i : Fin n => CMvPolynomial.X (R := R) i)) :
+                Fin (n + 1) → CMvPolynomial n R) i)) =
+        Fin.cons a v := by
+    funext i
+    cases i using Fin.cases with
+    | zero => simp [fromCMvPolynomial_C]
+    | succ i => simp [fromCMvPolynomial_X]
+  rw [hc, hv]
+  exact (eval_equiv (p := p) (vals := Fin.cons a v)).symm
+
+/-! ## Degree preservation -/
+
+/-- `partialEvalFirst` preserves degree bounds for each remaining variable. -/
+theorem partialEvalFirst_degreeOf_le [Nontrivial R] {deg : ℕ} (a : R)
+    (i : Fin n) (p : CMvPolynomial (n + 1) R)
+    (hDeg : ∀ mono ∈ Lawful.monomials p, mono.degreeOf i.succ ≤ deg) :
+    ∀ mono ∈ Lawful.monomials (partialEvalFirst a p), mono.degreeOf i ≤ deg := by
+  intro mono hmono
+  have hSupport :
+      ∀ s ∈ (fromCMvPolynomial p).support, s i.succ ≤ deg := by
+    apply MvPolynomial.degreeOf_le_iff.mp
+    have hdegree := congrFun (degreeOf_equiv (p := p) (S := R)) i.succ
+    rw [← hdegree]
+    unfold CMvPolynomial.degreeOf
+    apply Finset.sup_le
+    intro mono hmono
+    exact hDeg mono (by simpa using hmono)
+  have hEval :
+      MvPolynomial.degreeOf i (fromCMvPolynomial (partialEvalFirst a p)) ≤ deg := by
+    unfold partialEvalFirst
+    rw [fromCMvPolynomial_bind₁]
+    have hvars :
+        (fun i : Fin (n + 1) =>
+            fromCMvPolynomial
+              (((Fin.cons (CMvPolynomial.C (n := n) a)
+                (fun i : Fin n => CMvPolynomial.X (R := R) i)) :
+                  Fin (n + 1) → CMvPolynomial n R) i)) =
+          (fun j : Fin (n + 1) =>
+            Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j) := by
+      funext j
+      cases j using Fin.cases with
+      | zero => simp [fromCMvPolynomial_C]
+      | succ j => simp [fromCMvPolynomial_X]
+    rw [hvars]
+    exact partialEvalFirst_eval₂_degreeOf_le (n := n) (R := R) a i
+      (fromCMvPolynomial p) hSupport
+  have hdegree := congrFun (degreeOf_equiv (p := partialEvalFirst a p) (S := R)) i
+  rw [← hdegree] at hEval
+  exact (Finset.le_sup (s := (Lawful.monomials (partialEvalFirst a p)).toFinset)
+    (f := fun m => m.degreeOf i) (by simpa using hmono)).trans hEval
+
+end CMvPolynomial
+
+end CPoly

--- a/CompPoly/Multivariate/PartialEval.lean
+++ b/CompPoly/Multivariate/PartialEval.lean
@@ -39,7 +39,7 @@ private lemma partialEvalFirst_subst_degreeOf_le [Nontrivial R] (a : R)
         simp only [Fin.cases_succ, MvPolynomial.degreeOf_X_self, ↓reduceIte, Std.le_refl]
       · have hsucc : Fin.succ j ≠ i.succ := by
           intro h'
-          exact h ((Fin.succ_injective n) h')
+          exact h (Fin.succ_inj.mp h')
         have hi_ne_j : i ≠ j := fun hij => h hij.symm
         simp only [Fin.cases_succ, MvPolynomial.degreeOf_X, hi_ne_j, ↓reduceIte, hsucc,
           Std.le_refl]

--- a/CompPoly/Multivariate/PartialEval.lean
+++ b/CompPoly/Multivariate/PartialEval.lean
@@ -1,12 +1,12 @@
 /-
-Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Copyright (c) 2026 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: ArkLib Contributors
+Authors: Cody Gunton
 -/
-import CompPoly.Data.MvPolynomial.Notation
-import CompPoly.Multivariate.DegreeBound
-import CompPoly.Multivariate.Operations
-import CompPoly.Multivariate.MvPolyEquiv.Eval
+module
+
+public import CompPoly.Multivariate.Operations
+public import Mathlib.Algebra.MvPolynomial.Degrees
 
 /-!
 # Partial evaluation of the first variable of a `CMvPolynomial`
@@ -16,13 +16,13 @@ polynomial to a scalar value, together with its evaluation lemma and the
 per-variable degree-bound lemma.
 -/
 
-open CompPoly Std
+@[expose] public section
 
 namespace CPoly
 
 namespace CMvPolynomial
 
-variable {n : ℕ} {R : Type} [CommSemiring R] [BEq R] [LawfulBEq R]
+variable {n : ℕ} {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R]
 
 omit [BEq R] [LawfulBEq R] in
 private lemma partialEvalFirst_subst_degreeOf_le [Nontrivial R] (a : R)
@@ -32,16 +32,17 @@ private lemma partialEvalFirst_subst_degreeOf_le [Nontrivial R] (a : R)
         MvPolynomial (Fin n) R) ≤ if j = i.succ then 1 else 0 := by
   cases j using Fin.cases with
   | zero =>
-      simp [MvPolynomial.degreeOf_C]
+      simp only [Fin.cases_zero, MvPolynomial.degreeOf_C, zero_le]
   | succ j =>
       by_cases h : j = i
       · subst h
-        simp
+        simp only [Fin.cases_succ, MvPolynomial.degreeOf_X_self, ↓reduceIte, Std.le_refl]
       · have hsucc : Fin.succ j ≠ i.succ := by
           intro h'
           exact h ((Fin.succ_injective n) h')
         have hi_ne_j : i ≠ j := fun hij => h hij.symm
-        simp [hsucc, hi_ne_j, MvPolynomial.degreeOf_X]
+        simp only [Fin.cases_succ, MvPolynomial.degreeOf_X, hi_ne_j, ↓reduceIte, hsucc,
+          Std.le_refl]
 
 omit [BEq R] [LawfulBEq R] in
 private lemma partialEvalFirst_eval₂_monomial_degreeOf_le [Nontrivial R] {deg : ℕ}
@@ -74,16 +75,16 @@ private lemma partialEvalFirst_eval₂_monomial_degreeOf_le [Nontrivial R] {deg 
           classical
           by_cases hi : i.succ ∈ s.support
           · rw [Finset.sum_eq_single i.succ]
-            · simp
+            · simp only [↓reduceIte, mul_one, Std.le_refl]
             · intro x hx hne
-              simp [hne]
+              simp only [hne, ↓reduceIte, mul_zero]
             · intro hnot
               exact False.elim (hnot hi)
           · rw [Finset.sum_eq_zero]
-            · simp
+            · simp only [zero_le]
             · intro x hx
               have hne : x ≠ i.succ := fun h => hi (h ▸ hx)
-              simp [hne]
+              simp only [hne, ↓reduceIte, mul_zero]
     _ ≤ deg := hs
 
 omit [BEq R] [LawfulBEq R] in
@@ -103,7 +104,7 @@ private lemma partialEvalFirst_eval₂_degreeOf_le [Nontrivial R] {deg : ℕ}
           MvPolynomial (Fin n) R) ^ s x)).trans ?_
   apply Finset.sup_le
   intro s hs
-  simpa [MvPolynomial.eval₂_monomial, Finsupp.prod] using
+  simpa only [MvPolynomial.eval₂_monomial, Finsupp.prod] using
     partialEvalFirst_eval₂_monomial_degreeOf_le (n := n) (R := R)
       (deg := deg) a i s (p.coeff s) (hDeg s hs)
 
@@ -123,7 +124,7 @@ theorem partialEvalFirst_eval (a : R) (p : CMvPolynomial (n + 1) R) (v : Fin n �
   rw [MvPolynomial.eval₂_comp_left]
   have hc : (MvPolynomial.eval v).comp MvPolynomial.C = RingHom.id R := by
     ext r
-    simp
+    simp only [RingHom.coe_comp, Function.comp_apply, MvPolynomial.eval_C, RingHom.id_apply]
   have hv :
       (⇑(MvPolynomial.eval v) ∘
           fun i => fromCMvPolynomial
@@ -133,8 +134,10 @@ theorem partialEvalFirst_eval (a : R) (p : CMvPolynomial (n + 1) R) (v : Fin n �
         Fin.cons a v := by
     funext i
     cases i using Fin.cases with
-    | zero => simp [fromCMvPolynomial_C]
-    | succ i => simp [fromCMvPolynomial_X]
+    | zero => simp only [Function.comp_apply, Fin.cons_zero, fromCMvPolynomial_C,
+        MvPolynomial.eval_C]
+    | succ i => simp only [Function.comp_apply, Fin.cons_succ, fromCMvPolynomial_X,
+        MvPolynomial.eval_X]
   rw [hc, hv]
   exact (eval_equiv (p := p) (vals := Fin.cons a v)).symm
 
@@ -169,8 +172,8 @@ theorem partialEvalFirst_degreeOf_le [Nontrivial R] {deg : ℕ} (a : R)
             Fin.cases (MvPolynomial.C a) (fun k : Fin n => MvPolynomial.X k) j) := by
       funext j
       cases j using Fin.cases with
-      | zero => simp [fromCMvPolynomial_C]
-      | succ j => simp [fromCMvPolynomial_X]
+      | zero => simp only [Fin.cons_zero, fromCMvPolynomial_C, Fin.cases_zero]
+      | succ j => simp only [Fin.cons_succ, fromCMvPolynomial_X, Fin.cases_succ]
     rw [hvars]
     exact partialEvalFirst_eval₂_degreeOf_le (n := n) (R := R) a i
       (fromCMvPolynomial p) hSupport

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,6 +43,8 @@ CompPoly aims to be the premier formally verified library for computable polynom
    - ✅ `algebra`, `module`: Algebra and module structures
    - ✅ `degrees`; ✅ `eval₂Hom`: Degree utilities and evaluation homomorphisms
    - ✅ `finSuccEquiv`: Variable manipulation equivalences (for `CMvPolynomial`)
+   - ✅ `partialEvalFirst`: Partial evaluation fixing the first variable, with its
+     evaluation and per-variable degree-bound lemmas
    - ✅ `isEmptyRingEquiv` for `CMvPolynomial 0 R`
    - ✅ `smulZeroClass`: Scalar multiplication with zero behavior
    - ✅ `sumToIter`: Iteration utility with reconstruction/API lemmas

--- a/tests/CompPolyTests.lean
+++ b/tests/CompPolyTests.lean
@@ -42,6 +42,7 @@ public import CompPolyTests.LinearAlgebra.Dense
 public import CompPolyTests.LinearAlgebra.PolynomialMatrix.Approximant
 public import CompPolyTests.Multilinear.Equiv
 public import CompPolyTests.Multivariate.CMvMonomial
+public import CompPolyTests.Multivariate.PartialEval
 public import CompPolyTests.Multivariate.Restrict
 public import CompPolyTests.Multivariate.TypeclassMinimization
 public import CompPolyTests.Multivariate.VarsDegrees

--- a/tests/CompPolyTests/Multivariate/PartialEval.lean
+++ b/tests/CompPolyTests/Multivariate/PartialEval.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 CompPoly. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Derek Sorensen
+-/
+module
+
+public import CompPoly.Multivariate.CMvPolynomialEvalLemmas
+public import CompPoly.Multivariate.PartialEval
+
+/-!
+  # Multivariate Partial Evaluation Tests
+
+  Checks what `partialEvalFirst` does on generators, that it agrees with direct
+  evaluation on a concrete polynomial, and that it does not raise the degree of
+  the remaining variables.
+
+  The checks are symbolic rather than `decide`-based: `CMvPolynomial` is carried
+  by a quotient of `Std.ExtTreeMap`, so kernel reduction gets stuck on
+  `Quot.lift` (the same reason `Multivariate/Restrict.lean`'s tests are
+  symbolic).
+-/
+
+@[expose] public section
+
+namespace CPoly
+
+open _root_.CPoly.CMvPolynomial
+
+/-- `eval` on a variable. The library has `eval_C`/`eval_add`/`eval_mul` as
+`simp` lemmas but no `eval_X`, so the concrete check below supplies it. -/
+private lemma eval_X_apply {n : ℕ} {R : Type*} [CommSemiring R] [BEq R] [LawfulBEq R]
+    (i : Fin n) (v : Fin n → R) :
+    (CMvPolynomial.X i : CMvPolynomial n R).eval v = v i := by
+  simp [eval_equiv, fromCMvPolynomial_X]
+
+/-! ## Action on generators -/
+
+-- Fixing variable `0` leaves constants alone.
+example (a c : ℚ) :
+    partialEvalFirst (n := 1) a (CMvPolynomial.C c) = CMvPolynomial.C c := by
+  simp [partialEvalFirst]
+
+-- Variable `0` becomes the scalar it was fixed to.
+example (a : ℚ) :
+    partialEvalFirst (n := 1) a (CMvPolynomial.X 0) = CMvPolynomial.C a := by
+  simp [partialEvalFirst]
+
+-- Every other variable is shifted down by one.
+example (a : ℚ) (i : Fin 1) :
+    partialEvalFirst a (CMvPolynomial.X i.succ) = CMvPolynomial.X i := by
+  simp [partialEvalFirst]
+
+/-! ## Agreement with direct evaluation -/
+
+/-- `X 0 * X 1 + 3` over `Fin 2`. -/
+private def testPoly : CMvPolynomial 2 ℚ :=
+  CMvPolynomial.X 0 * CMvPolynomial.X 1 + CMvPolynomial.C 3
+
+-- Fixing variable `0` to `2`, then evaluating the remaining variable at `5`,
+-- gives `2 * 5 + 3 = 13`.
+example : (partialEvalFirst (2 : ℚ) testPoly).eval (fun _ => 5) = 13 := by
+  rw [partialEvalFirst_eval]
+  simp only [testPoly, eval_add, eval_mul, eval_C, eval_X_apply, Fin.cons_zero]
+  norm_num
+
+-- The same value reached through the general theorem rather than by computing.
+example :
+    (partialEvalFirst (2 : ℚ) testPoly).eval (fun _ => 5)
+      = testPoly.eval (Fin.cons 2 (fun _ => 5)) :=
+  partialEvalFirst_eval _ _ _
+
+/-! ## Degree preservation -/
+
+-- Fixing a variable cannot raise the degree of any variable that remains: a
+-- bound on variable `1` of `p` transfers to variable `0` of the restriction.
+example (a : ℚ) (deg : ℕ) (p : CMvPolynomial 2 ℚ)
+    (hp : ∀ mono ∈ Lawful.monomials p, mono.degreeOf (Fin.succ 0) ≤ deg) :
+    ∀ mono ∈ Lawful.monomials (partialEvalFirst a p), mono.degreeOf 0 ≤ deg :=
+  partialEvalFirst_degreeOf_le a 0 p hp
+
+end CPoly

--- a/tests/CompPolyTests/Multivariate/PartialEval.lean
+++ b/tests/CompPolyTests/Multivariate/PartialEval.lean
@@ -39,17 +39,17 @@ private lemma eval_X_apply {n : ℕ} {R : Type*} [CommSemiring R] [BEq R] [Lawfu
 -- Fixing variable `0` leaves constants alone.
 example (a c : ℚ) :
     partialEvalFirst (n := 1) a (CMvPolynomial.C c) = CMvPolynomial.C c := by
-  simp [partialEvalFirst]
+  simp only [partialEvalFirst, Nat.reduceAdd, bind₁_C]
 
 -- Variable `0` becomes the scalar it was fixed to.
 example (a : ℚ) :
     partialEvalFirst (n := 1) a (CMvPolynomial.X 0) = CMvPolynomial.C a := by
-  simp [partialEvalFirst]
+  simp only [partialEvalFirst, Nat.reduceAdd, Fin.isValue, bind₁_X, Fin.cons_zero]
 
 -- Every other variable is shifted down by one.
 example (a : ℚ) (i : Fin 1) :
     partialEvalFirst a (CMvPolynomial.X i.succ) = CMvPolynomial.X i := by
-  simp [partialEvalFirst]
+  simp only [partialEvalFirst, Nat.reduceAdd, bind₁_X, Fin.cons_succ]
 
 /-! ## Agreement with direct evaluation -/
 


### PR DESCRIPTION
## Summary

Adds partial evaluation of the first variable for `CMvPolynomial`, together with the
`bind₁` bridge lemma it needs. Relands the salvageable part of #241 by @codygunton,
whose commit is preserved as the first commit here.

`Supersedes #241` (which itself superseded the closed #235).

## What lands

| Where | What |
|---|---|
| `Multivariate/PartialEval.lean` (new) | `partialEvalFirst`, `partialEvalFirst_eval`, `partialEvalFirst_degreeOf_le` |
| `Multivariate/Operations.lean` | `fromCMvPolynomial_bind₁` |
| `tests/CompPolyTests/Multivariate/PartialEval.lean` (new) | regression coverage |

`partialEvalFirst a p` fixes variable `0` of `p : CMvPolynomial (n + 1) R` to a scalar,
implemented as `bind₁ (Fin.cons (C a) X) p`. Two facts come with it: it really is partial
evaluation,

```lean
theorem partialEvalFirst_eval (a : R) (p : CMvPolynomial (n + 1) R) (v : Fin n → R) :
    (partialEvalFirst a p).eval v = p.eval (Fin.cons a v)
```

and fixing a variable cannot raise the degree of any variable that remains
(`partialEvalFirst_degreeOf_le`).

Both gaps were real. Nothing in the tree had a "fix a variable" operation —
`Multivariate/Restrict.lean` is degree *truncation*, a different thing — and while `bind₁`
has been in `Operations.lean` for a while with `bind₁_eq_aeval`, it had no
`fromCMvPolynomial` transport lemma, unlike every other computable operation.

## What was dropped from #241, and why

#241 also added `Multivariate/DegreeBound.lean`, which is not relanded:

- `CDegreeLE` and `CMvDegreeLE` were subtypes with no instances, operations or lemmas, and
  were unused within #241 itself.
- `IndividualDegreeLE` was not used even by the degree theorem that motivated it —
  `partialEvalFirst_degreeOf_le` states its bound unfolded.

All three existed so that an external consumer could refer to them by name. Dropping the file
also removes an inconsistency, since it placed the predicate in `CPoly.CMvPolynomial` but the
two subtypes in a bare `CompPoly` namespace.

Also deliberately out of scope: generalizing to an arbitrary variable index. Variable `0` is
the case sumcheck-style folding needs; a `partialEvalNth` over `Fin.succAbove` would mean
redoing the three degree-bookkeeping helpers, which is follow-up work rather than a reland.

## Port notes

#241 was based on Lean v4.30.0 and predates the module-system migration. The proofs needed
**no** repair at 4.33.1 — every declaration they use still exists with a matching signature,
and the module compiled on the first attempt. Changes on top of the original commit:

- Module-system migration: `module` header, `public import`, `@[expose] public section`,
  matching the rest of `Multivariate/`. Imports reduce to `Operations` plus
  `Mathlib.Algebra.MvPolynomial.Degrees`.
- Every `simp`/`simpa` in the new code is now `simp only`/`simpa only`, per the repo tactic
  guidance.
- Uses core `Fin.succ_inj` rather than Mathlib's `Fin.succ_injective`, which lives in
  `Mathlib/Data/Fin/SuccPred.lean` and was reachable here only via an incidental import
  closure.
- Ring variable widened from `Type` to `Type*`.

The tests are symbolic rather than `decide`-based: `CMvPolynomial` is carried by a quotient of
`Std.ExtTreeMap`, so kernel reduction gets stuck on `Quot.lift`. They cover the action on
generators (via the `@[simp]` `bind₁_C`/`bind₁_X`), agreement with direct evaluation on a
concrete polynomial, and the degree bound. This is the same reason
`tests/CompPolyTests/Multivariate/Restrict.lean` is symbolic.

## Follow-up worth noting

`CMvPolynomialEvalLemmas.lean` has `eval_zero`, `eval_one`, `eval_C`, `eval_add`, `eval_mul`
and `eval_pow` as `@[simp]` lemmas but no `eval_X`. The concrete test here needs it, so it is
proved locally as a `private lemma`. It looks like it belongs in the library as a public
`@[simp]` lemma, but that is outside this PR's scope.

## Testing

- `lake build` — clean, no new warnings
- `lake test`
- `./scripts/update-lib.sh && ./scripts/check-imports.sh`
- `./scripts/lint-style.sh`
- `python3 ./scripts/check-docs-integrity.py`
- `lake exe axiomsweep --check` — 0 sorry-tainted, 0 non-standard axioms
