### PR TITLE
feat(multilinear): factor the equality kernel

### DIFF
--- a/CompPoly/Multilinear/Basic.lean
+++ b/CompPoly/Multilinear/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 CompPoly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao, Chung Thai Nguyen
+Authors: Quang Dao, Chung Thai Nguyen, Aristotle (Harmonic), Elias Judin
 -/
 module
 
@@ -524,6 +524,18 @@ def eval₂Mle (p : CMlPolynomialEval R n) (f : R →+* S) (x : Vector S n) : S 
 def eval (p : CMlPolynomialEval R n) (x : Vector R n) : R :=
   Vector.dotProduct p (lagrangeBasis x)
 
+/-- Evaluation commutes with scalar multiplication of a hypercube table. -/
+theorem eval_smul (a : R) (p : CMlPolynomialEval R n) (x : Vector R n) :
+    eval (a • p) x = a * eval p x := by
+  unfold eval
+  rw [Vector.dotProduct_eq_root_dotProduct, Vector.dotProduct_eq_root_dotProduct]
+  simp only [_root_.dotProduct, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Vector.get_eq_getElem (a • p) i, Vector.get_eq_getElem p i,
+    Vector.getElem_smul]
+  simp only [smul_eq_mul, mul_assoc]
+
 /-- Evaluate a `CMlPolynomialEval` at a point using a ring homomorphism -/
 def eval₂ (p : CMlPolynomialEval R n) (f : R →+* S) (x : Vector S n) : S := eval (map f p) x
 
@@ -583,6 +595,45 @@ theorem eval_mle_eq_eval (p : CMlPolynomialEval R n) (x : Vector R n) :
       · exact ih _ _
       · simp only [eval]
         exact eval_mle_step_dot_product p x
+
+/-- The multilinear equality kernel is the product of its coordinatewise affine factors. -/
+theorem eqTilde_eq_prod (w x : Vector R n) :
+    eqTilde w x = ∏ i : Fin n, (w[i] * x[i] + (1 - w[i]) * (1 - x[i])) := by
+  rw [eqTilde, ← eval_mle_eq_eval]
+  induction n with
+  | zero => simp [evalMle, evalMleValues]
+  | succ n ih =>
+      rw [evalMle_succ]
+      have hstep : evalMleLayer (lagrangeBasis w) x.head =
+          (w.head * x.head + (1 - w.head) * (1 - x.head)) • lagrangeBasis w.tail := by
+        apply Vector.ext
+        intro j hj
+        rw [← Vector.get_eq_getElem (evalMleLayer (lagrangeBasis w) x.head) ⟨j, hj⟩]
+        rw [← Vector.get_eq_getElem
+          ((w.head * x.head + (1 - w.head) * (1 - x.head)) • lagrangeBasis w.tail)
+          ⟨j, hj⟩]
+        rw [evalMleLayer_get, lagrange_basis_even, lagrange_basis_odd]
+        rw [Vector.get_eq_getElem
+          ((w.head * x.head + (1 - w.head) * (1 - x.head)) • lagrangeBasis w.tail)
+          ⟨j, hj⟩]
+        rw [Vector.getElem_smul]
+        simp only [smul_eq_mul]
+        change (1 - x.head) * ((1 - w.head) * (lagrangeBasis w.tail).get ⟨j, hj⟩) +
+            x.head * (w.head * (lagrangeBasis w.tail).get ⟨j, hj⟩) =
+          (w.head * x.head + (1 - w.head) * (1 - x.head)) *
+            (lagrangeBasis w.tail).get ⟨j, hj⟩
+        ring
+      rw [hstep, eval_mle_eq_eval, eval_smul, ← eval_mle_eq_eval, ih,
+        Fin.prod_univ_succ]
+      congr 1
+      exact Finset.prod_congr rfl fun i _ => by simp [Nat.add_comm]
+
+/-- The equality kernel factors across appended coordinate blocks. -/
+theorem eqTilde_append {m : ℕ} (w₁ x₁ : Vector R n) (w₂ x₂ : Vector R m) :
+    eqTilde (w₁ ++ w₂) (x₁ ++ x₂) = eqTilde w₁ x₁ * eqTilde w₂ x₂ := by
+  simp only [eqTilde_eq_prod]
+  rw [Fin.prod_univ_add]
+  congr 1 <;> exact Finset.prod_congr rfl fun i _ => by simp
 
 /-- Multilinear-extension interpolation through a ring homomorphism agrees with the
 dot-product evaluator. -/

--- a/tests/CompPolyTests/Multilinear/Equiv.lean
+++ b/tests/CompPolyTests/Multilinear/Equiv.lean
@@ -39,5 +39,13 @@ example (w x : Vector ℚ 2) :
     eqTilde w x = eval (lagrangeBasis w) x := by
   rfl
 
+example (w x : Vector ℚ 2) :
+    eqTilde w x = ∏ i : Fin 2, (w[i] * x[i] + (1 - w[i]) * (1 - x[i])) := by
+  exact eqTilde_eq_prod w x
+
+example (w₁ x₁ : Vector ℚ 2) (w₂ x₂ : Vector ℚ 3) :
+    eqTilde (w₁ ++ w₂) (x₁ ++ x₂) = eqTilde w₁ x₁ * eqTilde w₂ x₂ := by
+  exact eqTilde_append w₁ x₁ w₂ x₂
+
 end CMlPolynomialEval
 end CompPoly


### PR DESCRIPTION
## Summary

- characterize the executable multilinear equality kernel as the product of its coordinatewise affine factors
- prove that the kernel factors across appended variable blocks
- add the scalar-evaluation lemma used by the recursive proof and generic regression examples

## Scope and integration

This deliberately extends the existing `CMlPolynomialEval.eqTilde` API and reuses the existing little-endian `evalMle` evaluator. It does not add a second equality-kernel definition, a stacking abstraction, or legacy big-endian bit machinery.

The append order was checked against leanVM commit `a386121f84292f6fa663aaa3e570c15bc0240ea2`, where a stack opening point is `[low_point, sel_bits]`. This patch is the reusable algebraic prerequisite for a later aligned-stacking contribution.

## Attribution

Adapted and rewritten from [`Leanth/Poly/EqKernel.lean` in leanth PR #10](https://github.com/Verified-zkEVM/leanth/pull/10), originally developed by Aristotle (Harmonic) and Elias Judin. Both contributors are retained in the file header and commit trailers.

## Validation

- `lake build CompPoly.Multilinear.Basic`
- `lake build CompPolyTests.Multilinear.Equiv`
- `lake test`
- `./scripts/lint-style.sh CompPoly/Multilinear/Basic.lean tests/CompPolyTests/Multilinear/Equiv.lean`
- axiom audit of all new declarations: only `propext`, `Classical.choice`, and `Quot.sound`
- `git diff --check`