### PR TITLE
fix(algebra): require identity maps in algebra towers

### DIFF
--- a/CompPoly/Data/RingTheory/AlgebraTower.lean
+++ b/CompPoly/Data/RingTheory/AlgebraTower.lean
@@ -8,37 +8,34 @@ module
 public import Mathlib.LinearAlgebra.Matrix.Reindex
 
 /-!
-  # Tower of Algebras and Tower of Algebra Equivalences
+# Towers of algebras and their equivalences
 
-  This file contains definitions, theorems, instances that are used in defining tower of algebras
-  and their equivalences.
+An `AlgebraTower` is a preorder-indexed family of commutative semirings with ring
+homomorphisms between comparable levels. Self-maps are identities, and the maps compose
+along chains of indices. Each map induces an algebra structure on its target, and
+composition gives compatible scalar actions across three levels.
 
-  ## Main definitions
-
-  * `AlgebraTower` : a tower of algebras
-  * `AlgebraTowerEquiv` : an equivalence of towers of algebras
+An `AlgebraTowerEquiv` consists of ring equivalences at each level that commute with
+the tower maps.
 -/
 
 @[expose] public section
 
-/-- A tower of algebras is a sequence of algebras `AT i` indexed over a preorder `ι` with the
-    following data:
-    - `algebraMap : AT i →+* AT j` is a ring homomorphism from `AT i` to `AT j` for all `i ≤ j`
-    - `identity'` states that the map from a level to itself is the identity
-    - `commutes'` is a proof that the ring homomorphism commutes with the multiplication
-    - `coherence'`: A tower of algebras is coherent if the algebra maps satisfy the
-      coherence condition: the direct map from i to k equals the composition of maps i → j → k.
--/
+/-- A preorder-indexed family of commutative semirings with compatible ring homomorphisms.
+
+The map from a level to itself is the identity. For `i ≤ j ≤ k`, the map from `i` to `k`
+is the composite of the maps from `i` to `j` and from `j` to `k`. -/
 class AlgebraTower {ι : Type*} [Preorder ι] (AT : ι → Type*)
   [∀ i, CommSemiring (AT i)] where
   /-- Ring homomorphisms from `AT i` to `AT j` for all `i ≤ j`. -/
   protected algebraMap : ∀ i j, (h : i ≤ j) → (AT i →+* AT j)
-  /-- The map from a level to itself is the identity. -/
-  identity' : ∀ i, algebraMap i i le_rfl = RingHom.id (AT i)
-  /-- Commutativity of multiplication with respect to the ring homomorphism. -/
+  /-- The ring homomorphism from level `i` to itself is the identity. -/
+  algebraMap_self' : ∀ i, algebraMap i i le_rfl = RingHom.id (AT i)
+  /-- Every image element commutes with every element of the target semiring. -/
   commutes' : ∀ (i j : ι) (h : i ≤ j) (r : AT i) (x : AT j),
     (algebraMap i j h r) * x = x * (algebraMap i j h r)
-  coherence': ∀ (i j k : ι) (h1 : i ≤ j) (h2 : j ≤ k),
+  /-- The map from `i` to `k` is the composite of the maps from `i` to `j` and `j` to `k`. -/
+  coherence' : ∀ (i j k : ι) (h1 : i ≤ j) (h2 : j ≤ k),
     algebraMap i k (h1.trans h2) =
       (algebraMap j k h2).comp (algebraMap i j h1)
 
@@ -47,14 +44,13 @@ variable {ι : Type*} [Preorder ι]
   {B : ι → Type*} [∀ i, CommSemiring (B i)] [AlgebraTower B]
   {C : ι → Type*} [∀ i, CommSemiring (C i)] [AlgebraTower C]
 
-/-- A self-map is the identity, independently of the chosen order proof. -/
+/-- The tower map from level `i` to itself is the identity for every proof of `i ≤ i`. -/
 @[simp]
 lemma AlgebraTower.algebraMap_self (i : ι) (h : i ≤ i) :
     AlgebraTower.algebraMap (AT := A) i i h = RingHom.id (A i) :=
-  AlgebraTower.identity' i
+  AlgebraTower.algebraMap_self' i
 
-/-- Mapping an element to its own level leaves it unchanged. -/
-@[simp]
+/-- The tower map from level `i` to itself fixes every element of that level. -/
 lemma AlgebraTower.algebraMap_self_apply (i : ι) (h : i ≤ i) (x : A i) :
     AlgebraTower.algebraMap (AT := A) i i h x = x := by
   rw [AlgebraTower.algebraMap_self, RingHom.id_apply]

--- a/CompPoly/Data/RingTheory/AlgebraTower.lean
+++ b/CompPoly/Data/RingTheory/AlgebraTower.lean
@@ -24,6 +24,7 @@ public import Mathlib.LinearAlgebra.Matrix.Reindex
 /-- A tower of algebras is a sequence of algebras `AT i` indexed over a preorder `ι` with the
     following data:
     - `algebraMap : AT i →+* AT j` is a ring homomorphism from `AT i` to `AT j` for all `i ≤ j`
+    - `identity'` states that the map from a level to itself is the identity
     - `commutes'` is a proof that the ring homomorphism commutes with the multiplication
     - `coherence'`: A tower of algebras is coherent if the algebra maps satisfy the
       coherence condition: the direct map from i to k equals the composition of maps i → j → k.
@@ -32,6 +33,8 @@ class AlgebraTower {ι : Type*} [Preorder ι] (AT : ι → Type*)
   [∀ i, CommSemiring (AT i)] where
   /-- Ring homomorphisms from `AT i` to `AT j` for all `i ≤ j`. -/
   protected algebraMap : ∀ i j, (h : i ≤ j) → (AT i →+* AT j)
+  /-- The map from a level to itself is the identity. -/
+  identity' : ∀ i, algebraMap i i le_rfl = RingHom.id (AT i)
   /-- Commutativity of multiplication with respect to the ring homomorphism. -/
   commutes' : ∀ (i j : ι) (h : i ≤ j) (r : AT i) (x : AT j),
     (algebraMap i j h r) * x = x * (algebraMap i j h r)
@@ -43,6 +46,18 @@ variable {ι : Type*} [Preorder ι]
   {A : ι → Type*} [∀ i, CommSemiring (A i)] [AlgebraTower A]
   {B : ι → Type*} [∀ i, CommSemiring (B i)] [AlgebraTower B]
   {C : ι → Type*} [∀ i, CommSemiring (C i)] [AlgebraTower C]
+
+/-- A self-map is the identity, independently of the chosen order proof. -/
+@[simp]
+lemma AlgebraTower.algebraMap_self (i : ι) (h : i ≤ i) :
+    AlgebraTower.algebraMap (AT := A) i i h = RingHom.id (A i) :=
+  AlgebraTower.identity' i
+
+/-- Mapping an element to its own level leaves it unchanged. -/
+@[simp]
+lemma AlgebraTower.algebraMap_self_apply (i : ι) (h : i ≤ i) (x : A i) :
+    AlgebraTower.algebraMap (AT := A) i i h x = x := by
+  rw [AlgebraTower.algebraMap_self, RingHom.id_apply]
 
 @[simp]
 abbrev AlgebraTower.toAlgebra {i j : ι} (h : i ≤ j) : Algebra (A i) (A j) :=

--- a/CompPoly/Fields/Binary/Tower/Abstract/Algebra.lean
+++ b/CompPoly/Fields/Binary/Tower/Abstract/Algebra.lean
@@ -174,6 +174,7 @@ algebra over `BTField k`.
 -/
 noncomputable instance : AlgebraTower (BTField) where
   algebraMap := towerAlgebraMap
+  identity' := towerAlgebraMap_id
   commutes' := by
     intro i j h r x
     exact CommMonoid.mul_comm ((towerAlgebraMap i j h) r) x

--- a/CompPoly/Fields/Binary/Tower/Abstract/Algebra.lean
+++ b/CompPoly/Fields/Binary/Tower/Abstract/Algebra.lean
@@ -174,7 +174,7 @@ algebra over `BTField k`.
 -/
 noncomputable instance : AlgebraTower (BTField) where
   algebraMap := towerAlgebraMap
-  identity' := towerAlgebraMap_id
+  algebraMap_self' := towerAlgebraMap_id
   commutes' := by
     intro i j h r x
     exact CommMonoid.mul_comm ((towerAlgebraMap i j h) r) x

--- a/CompPoly/Fields/Binary/Tower/Concrete/Algebra.lean
+++ b/CompPoly/Fields/Binary/Tower/Concrete/Algebra.lean
@@ -204,6 +204,7 @@ algebra over `ConcreteBTField k`.
 -/
 instance instAlgebraTowerConcreteBTF : AlgebraTower (ConcreteBTField) where
   algebraMap := concreteTowerAlgebraMap
+  identity' := concreteTowerAlgebraMap_id
   commutes' := by
     intro i j h r x
     exact CommMonoid.mul_comm ((concreteTowerAlgebraMap i j h) r) x

--- a/CompPoly/Fields/Binary/Tower/Concrete/Algebra.lean
+++ b/CompPoly/Fields/Binary/Tower/Concrete/Algebra.lean
@@ -204,7 +204,7 @@ algebra over `ConcreteBTField k`.
 -/
 instance instAlgebraTowerConcreteBTF : AlgebraTower (ConcreteBTField) where
   algebraMap := concreteTowerAlgebraMap
-  identity' := concreteTowerAlgebraMap_id
+  algebraMap_self' := concreteTowerAlgebraMap_id
   commutes' := by
     intro i j h r x
     exact CommMonoid.mul_comm ((concreteTowerAlgebraMap i j h) r) x

--- a/docs/wiki/binary-fields-and-ntt.md
+++ b/docs/wiki/binary-fields-and-ntt.md
@@ -128,6 +128,15 @@ support lemmas:
 Use the tower subtree when the task is about characteristic-2 extensions more
 generally, not just GHASH.
 
+The shared `AlgebraTower` contract in `CompPoly/Data/RingTheory/AlgebraTower.lean`
+requires self-maps to be identities as well as maps to compose coherently. New
+constructors must supply `identity'`; the abstract and concrete binary towers use
+their existing `towerAlgebraMap_id` and `concreteTowerAlgebraMap_id` proofs. Clients
+can simplify self-maps with `AlgebraTower.algebraMap_self` and
+`AlgebraTower.algebraMap_self_apply`, including an arbitrary proof of `i ≤ i`.
+This contract still requires only commutative semirings indexed by a preorder;
+it does not require injective maps or field instances.
+
 ## Additive NTT Surface
 
 The additive-NTT stack is split by role rather than by one monolithic file:

--- a/docs/wiki/binary-fields-and-ntt.md
+++ b/docs/wiki/binary-fields-and-ntt.md
@@ -128,15 +128,6 @@ support lemmas:
 Use the tower subtree when the task is about characteristic-2 extensions more
 generally, not just GHASH.
 
-The shared `AlgebraTower` contract in `CompPoly/Data/RingTheory/AlgebraTower.lean`
-requires self-maps to be identities as well as maps to compose coherently. New
-constructors must supply `identity'`; the abstract and concrete binary towers use
-their existing `towerAlgebraMap_id` and `concreteTowerAlgebraMap_id` proofs. Clients
-can simplify self-maps with `AlgebraTower.algebraMap_self` and
-`AlgebraTower.algebraMap_self_apply`, including an arbitrary proof of `i ≤ i`.
-This contract still requires only commutative semirings indexed by a preorder;
-it does not require injective maps or field instances.
-
 ## Additive NTT Surface
 
 The additive-NTT stack is split by role rather than by one monolithic file:

--- a/tests/CompPolyTests.lean
+++ b/tests/CompPolyTests.lean
@@ -24,6 +24,7 @@ public import CompPolyTests.Bivariate.Multiplicity
 public import CompPolyTests.Bivariate.WeightedDegree
 public import CompPolyTests.Data.MvPolynomial.Notation
 public import CompPolyTests.Data.Polynomial.RabinCertificate
+public import CompPolyTests.Data.RingTheory.AlgebraTower
 public import CompPolyTests.Fields.BLS12_377.Fast
 public import CompPolyTests.Fields.BLS12_381.Fast
 public import CompPolyTests.Fields.BN254.Fast
@@ -31,6 +32,7 @@ public import CompPolyTests.Fields.BabyBear.Fast
 public import CompPolyTests.Fields.Binary.AdditiveNTT.NovelPolynomialBasis
 public import CompPolyTests.Fields.Binary.BF128Ghash.Prelude
 public import CompPolyTests.Fields.Binary.BF64
+public import CompPolyTests.Fields.Binary.Tower.Algebra
 public import CompPolyTests.Fields.Binary.Tower.Fast
 public import CompPolyTests.Fields.Extension.Arithmetic
 public import CompPolyTests.Fields.Extension.Binomial

--- a/tests/CompPolyTests/Data/RingTheory/AlgebraTower.lean
+++ b/tests/CompPolyTests/Data/RingTheory/AlgebraTower.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: CompPoly Contributors
+-/
+module
+
+import CompPoly.Data.RingTheory.AlgebraTower
+import Mathlib.Data.ZMod.Basic
+
+/-!
+# Algebra tower identity regression tests
+
+The old commutativity and composition laws admit an idempotent nonidentity endomorphism
+on a constant family. The self-map law excludes it while retaining commutative semirings
+and arbitrary preorders as the only ambient assumptions.
+-/
+
+namespace CompPolyTests.AlgebraTower
+
+section Generic
+
+variable {ι : Type*} [Preorder ι] {A : ι → Type*}
+  [∀ i, CommSemiring (A i)] [AlgebraTower A]
+
+example (i : ι) (h : i ≤ i) :
+    AlgebraTower.algebraMap (AT := A) i i h = RingHom.id (A i) := by
+  simp only [AlgebraTower.algebraMap_self]
+
+example (i : ι) (h : i ≤ i) (x : A i) :
+    AlgebraTower.algebraMap (AT := A) i i h x = x := by
+  simp only [AlgebraTower.algebraMap_self_apply]
+
+example (i j k : ι) (hij : i ≤ j) (hjk : j ≤ k) (x : A i) :
+    AlgebraTower.algebraMap (AT := A) i k (hij.trans hjk) x =
+      AlgebraTower.algebraMap (AT := A) j k hjk
+        (AlgebraTower.algebraMap (AT := A) i j hij x) := by
+  rw [AlgebraTower.coherence', RingHom.comp_apply]
+
+end Generic
+
+private abbrev R := ZMod 2 × ZMod 2
+
+private def diagonal : R →+* R where
+  toFun x := (x.1, x.1)
+  map_one' := rfl
+  map_zero' := rfl
+  map_add' _ _ := rfl
+  map_mul' _ _ := rfl
+
+private def oldMap (_i _j : ℕ) (_h : _i ≤ _j) : R →+* R := diagonal
+
+-- These are precisely the two laws that previously sufficed for the constant family.
+example (i j : ℕ) (h : i ≤ j) (r x : R) : oldMap i j h r * x = x * oldMap i j h r :=
+  mul_comm _ _
+
+example (i j k : ℕ) (hij : i ≤ j) (hjk : j ≤ k) :
+    oldMap i k (hij.trans hjk) = (oldMap j k hjk).comp (oldMap i j hij) := by
+  ext x <;> rfl
+
+private theorem diagonal_ne_id : diagonal ≠ RingHom.id R := by
+  intro h
+  have bad := congrArg (fun f : R →+* R => (f (0, 1)).2) h
+  change (0 : ZMod 2) = 1 at bad
+  exact zero_ne_one bad
+
+-- No strengthened tower can retain all the maps of that old-contract counterexample.
+example : ¬ ∃ t : AlgebraTower (fun _ : ℕ => R),
+    ∀ i j h, t.algebraMap i j h = oldMap i j h := by
+  rintro ⟨t, ht⟩
+  exact diagonal_ne_id ((ht 0 0 le_rfl).symm.trans (t.identity' 0))
+
+-- A concrete valid control on the same non-field carrier rules out a vacuous contract.
+private abbrev constantTower : AlgebraTower (fun _ : ℕ => R) where
+  algebraMap _ _ _ := RingHom.id R
+  identity' _ := rfl
+  commutes' _ _ _ r x := mul_comm r x
+  coherence' _ _ _ _ _ := rfl
+
+example (x : R) : constantTower.algebraMap 0 2 (by decide) x = x := rfl
+
+end CompPolyTests.AlgebraTower

--- a/tests/CompPolyTests/Data/RingTheory/AlgebraTower.lean
+++ b/tests/CompPolyTests/Data/RingTheory/AlgebraTower.lean
@@ -11,9 +11,10 @@ import Mathlib.Data.ZMod.Basic
 /-!
 # Algebra tower identity regression tests
 
-The old commutativity and composition laws admit an idempotent nonidentity endomorphism
-on a constant family. The self-map law excludes it while retaining commutative semirings
-and arbitrary preorders as the only ambient assumptions.
+The projection `(x, y) ↦ (x, x)` on `GF(2) × GF(2)` is an idempotent ring endomorphism.
+Using it between every pair of levels gives coherent maps whose self-maps are not identities.
+The identity law excludes this family of maps. Identity maps on the same carrier give a valid
+tower over a commutative semiring that is not a field.
 -/
 
 namespace CompPolyTests.AlgebraTower
@@ -25,22 +26,17 @@ variable {ι : Type*} [Preorder ι] {A : ι → Type*}
 
 example (i : ι) (h : i ≤ i) :
     AlgebraTower.algebraMap (AT := A) i i h = RingHom.id (A i) := by
-  simp only [AlgebraTower.algebraMap_self]
+  simp
 
 example (i : ι) (h : i ≤ i) (x : A i) :
     AlgebraTower.algebraMap (AT := A) i i h x = x := by
   simp only [AlgebraTower.algebraMap_self_apply]
 
-example (i j k : ι) (hij : i ≤ j) (hjk : j ≤ k) (x : A i) :
-    AlgebraTower.algebraMap (AT := A) i k (hij.trans hjk) x =
-      AlgebraTower.algebraMap (AT := A) j k hjk
-        (AlgebraTower.algebraMap (AT := A) i j hij x) := by
-  rw [AlgebraTower.coherence', RingHom.comp_apply]
-
 end Generic
 
 private abbrev R := ZMod 2 × ZMod 2
 
+/-- The ring endomorphism `(x, y) ↦ (x, x)`. -/
 private def diagonal : R →+* R where
   toFun x := (x.1, x.1)
   map_one' := rfl
@@ -48,32 +44,28 @@ private def diagonal : R →+* R where
   map_add' _ _ := rfl
   map_mul' _ _ := rfl
 
-private def oldMap (_i _j : ℕ) (_h : _i ≤ _j) : R →+* R := diagonal
+-- Constant projection maps satisfy commutativity and composition.
+example (r x : R) : diagonal r * x = x * diagonal r := mul_comm _ _
 
--- These are precisely the two laws that previously sufficed for the constant family.
-example (i j : ℕ) (h : i ≤ j) (r x : R) : oldMap i j h r * x = x * oldMap i j h r :=
-  mul_comm _ _
-
-example (i j k : ℕ) (hij : i ≤ j) (hjk : j ≤ k) :
-    oldMap i k (hij.trans hjk) = (oldMap j k hjk).comp (oldMap i j hij) := by
+example : diagonal = diagonal.comp diagonal := by
   ext x <;> rfl
 
 private theorem diagonal_ne_id : diagonal ≠ RingHom.id R := by
   intro h
-  have bad := congrArg (fun f : R →+* R => (f (0, 1)).2) h
-  change (0 : ZMod 2) = 1 at bad
-  exact zero_ne_one bad
+  have h01 := congrArg (fun f : R →+* R => (f (0, 1)).2) h
+  change (0 : ZMod 2) = 1 at h01
+  exact zero_ne_one h01
 
--- No strengthened tower can retain all the maps of that old-contract counterexample.
+-- A tower cannot use this projection for every map.
 example : ¬ ∃ t : AlgebraTower (fun _ : ℕ => R),
-    ∀ i j h, t.algebraMap i j h = oldMap i j h := by
+    ∀ i j h, t.algebraMap i j h = diagonal := by
   rintro ⟨t, ht⟩
-  exact diagonal_ne_id ((ht 0 0 le_rfl).symm.trans (t.identity' 0))
+  exact diagonal_ne_id ((ht 0 0 le_rfl).symm.trans (t.algebraMap_self' 0))
 
--- A concrete valid control on the same non-field carrier rules out a vacuous contract.
+/-- The constant tower on `GF(2) × GF(2)` with identity maps. -/
 private abbrev constantTower : AlgebraTower (fun _ : ℕ => R) where
   algebraMap _ _ _ := RingHom.id R
-  identity' _ := rfl
+  algebraMap_self' _ := rfl
   commutes' _ _ _ r x := mul_comm r x
   coherence' _ _ _ _ _ := rfl
 

--- a/tests/CompPolyTests/Fields/Binary/Tower/Algebra.lean
+++ b/tests/CompPolyTests/Fields/Binary/Tower/Algebra.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: CompPoly Contributors
+-/
+module
+
+import CompPoly.Fields.Binary.Tower.Abstract.Algebra
+import CompPoly.Fields.Binary.Tower.Concrete.Algebra
+
+/-!
+# Binary tower algebra regression tests
+
+Both tower instances satisfy the generic self-map law at symbolic levels. Adjacent maps
+remain the existing canonical embeddings, and skipping a level agrees with composition.
+All checks quantify over arbitrary field elements rather than testing only zero and one.
+-/
+
+namespace CompPolyTests.BinaryTowerAlgebra
+
+open BinaryTower ConcreteBinaryTower
+
+example (k : ℕ) (h : k ≤ k) (x : BTField k) :
+    AlgebraTower.algebraMap (AT := BTField) k k h x = x := by
+  simp only [AlgebraTower.algebraMap_self_apply]
+
+example (k : ℕ) (h : k ≤ k) (x : ConcreteBTField k) :
+    AlgebraTower.algebraMap (AT := ConcreteBTField) k k h x = x := by
+  simp only [AlgebraTower.algebraMap_self_apply]
+
+example (k : ℕ) (x : BTField k) :
+    AlgebraTower.algebraMap (AT := BTField) k (k + 1) (by omega) x =
+      canonicalEmbedding k x := by
+  change towerAlgebraMap k (k + 1) _ x = _
+  rw [towerAlgebraMap_succ_1]
+
+example (k : ℕ) (x : ConcreteBTField k) :
+    AlgebraTower.algebraMap (AT := ConcreteBTField) k (k + 1) (by omega) x =
+      canonicalAlgMap k x := by
+  change concreteTowerAlgebraMap k (k + 1) _ x = _
+  rw [concreteTowerAlgebraMap_succ_1]
+
+example (i j k : ℕ) (hij : i ≤ j) (hjk : j ≤ k) (x : BTField i) :
+    AlgebraTower.algebraMap (AT := BTField) i k (hij.trans hjk) x =
+      AlgebraTower.algebraMap (AT := BTField) j k hjk
+        (AlgebraTower.algebraMap (AT := BTField) i j hij x) := by
+  rw [AlgebraTower.coherence', RingHom.comp_apply]
+
+example (i j k : ℕ) (hij : i ≤ j) (hjk : j ≤ k) (x : ConcreteBTField i) :
+    AlgebraTower.algebraMap (AT := ConcreteBTField) i k (hij.trans hjk) x =
+      AlgebraTower.algebraMap (AT := ConcreteBTField) j k hjk
+        (AlgebraTower.algebraMap (AT := ConcreteBTField) i j hij x) := by
+  rw [AlgebraTower.coherence', RingHom.comp_apply]
+
+example (k : ℕ) (x : BTField k) :
+    AlgebraTower.algebraMap (AT := BTField) k (k + 2) (by omega) x =
+      canonicalEmbedding (k + 1) (canonicalEmbedding k x) := by
+  change towerAlgebraMap k (k + 2) _ x = _
+  rw [towerAlgebraMap_assoc (k + 2) (k + 1) k (by omega) (by omega)]
+  rw [towerAlgebraMap_succ_1, towerAlgebraMap_succ_1, RingHom.comp_apply]
+
+example (k : ℕ) (x : ConcreteBTField k) :
+    AlgebraTower.algebraMap (AT := ConcreteBTField) k (k + 2) (by omega) x =
+      canonicalAlgMap (k + 1) (canonicalAlgMap k x) := by
+  change concreteTowerAlgebraMap k (k + 2) _ x = _
+  rw [concreteTowerAlgebraMap_assoc (k + 2) (k + 1) k (by omega) (by omega)]
+  rw [concreteTowerAlgebraMap_succ_1, concreteTowerAlgebraMap_succ_1, RingHom.comp_apply]
+
+end CompPolyTests.BinaryTowerAlgebra

--- a/tests/CompPolyTests/Fields/Binary/Tower/Algebra.lean
+++ b/tests/CompPolyTests/Fields/Binary/Tower/Algebra.lean
@@ -11,9 +11,9 @@ import CompPoly.Fields.Binary.Tower.Concrete.Algebra
 /-!
 # Binary tower algebra regression tests
 
-Both tower instances satisfy the generic self-map law at symbolic levels. Adjacent maps
-remain the existing canonical embeddings, and skipping a level agrees with composition.
-All checks quantify over arbitrary field elements rather than testing only zero and one.
+The abstract and concrete binary towers satisfy the self-map identity law at symbolic levels.
+Adjacent maps are the canonical embeddings, and each map from level `k` to level `k + 2`
+is the composite of two canonical embeddings. All checks quantify over arbitrary field elements.
 -/
 
 namespace CompPolyTests.BinaryTowerAlgebra
@@ -39,18 +39,6 @@ example (k : ℕ) (x : ConcreteBTField k) :
       canonicalAlgMap k x := by
   change concreteTowerAlgebraMap k (k + 1) _ x = _
   rw [concreteTowerAlgebraMap_succ_1]
-
-example (i j k : ℕ) (hij : i ≤ j) (hjk : j ≤ k) (x : BTField i) :
-    AlgebraTower.algebraMap (AT := BTField) i k (hij.trans hjk) x =
-      AlgebraTower.algebraMap (AT := BTField) j k hjk
-        (AlgebraTower.algebraMap (AT := BTField) i j hij x) := by
-  rw [AlgebraTower.coherence', RingHom.comp_apply]
-
-example (i j k : ℕ) (hij : i ≤ j) (hjk : j ≤ k) (x : ConcreteBTField i) :
-    AlgebraTower.algebraMap (AT := ConcreteBTField) i k (hij.trans hjk) x =
-      AlgebraTower.algebraMap (AT := ConcreteBTField) j k hjk
-        (AlgebraTower.algebraMap (AT := ConcreteBTField) i j hij x) := by
-  rw [AlgebraTower.coherence', RingHom.comp_apply]
 
 example (k : ℕ) (x : BTField k) :
     AlgebraTower.algebraMap (AT := BTField) k (k + 2) (by omega) x =


### PR DESCRIPTION
`AlgebraTower` requires its maps to compose coherently, but composition alone permits nonidentity self-maps. The constant family `GF(2) × GF(2)` with every map `(x,y) ↦ (x,x)` satisfies that condition while changing `(0,1)` at the same level.

Require the self-map law `algebraMap_self'` and expose `algebraMap_self` and `algebraMap_self_apply`. Both binary tower constructors use their existing identity proofs; their maps and the preorder/commutative-semiring assumptions are preserved. External constructors must supply the new field.

The regression tests check simplification, exclude the nonidentity projection, construct a valid tower over the same non-field carrier, and check symbolic self-maps, canonical adjacent embeddings, and skipped-level embeddings for both binary towers. Declaration and module docstrings describe the contract; migration notes remain here.

Implements B1 of #322; the broader roadmap remains open.

Validation on Lean 4.33.1:

- `lake build --wfail`, `lake test`, style/import/docs checks, and `lake exe axiomsweep --check` passed, with no admitted or nonstandard-axiom dependencies in CompPoly.
- Independent statement and regression reviews passed.
- Selected ArkLib consumers built at `bcddd0897dc1b602a44f964c21e76fa6a5b29440` with the candidate CompPoly dependency and other pins unchanged: `ArkLib.ProofSystem.RingSwitching.Packing.{Prelude,BatchingPhase}` and `ArkLib.ProofSystem.Binius.{BinaryBasefold,FRIBinius}.General`. Existing Binius `sorryAx` remains; this is compatibility evidence, not protocol proof closure.
