### PR TITLE
feat(algebra): construct towers from adjacent maps

### DIFF
--- a/CompPoly/Data/RingTheory/AlgebraTower.lean
+++ b/CompPoly/Data/RingTheory/AlgebraTower.lean
@@ -5,6 +5,7 @@ Authors: Chung Thai Nguyen, Quang Dao
 -/
 module
 
+public import Mathlib.Data.Nat.Init
 public import Mathlib.LinearAlgebra.Matrix.Reindex
 
 /-!
@@ -14,6 +15,9 @@ An `AlgebraTower` is a preorder-indexed family of commutative semirings with rin
 homomorphisms between comparable levels. Self-maps are identities, and the maps compose
 along chains of indices. Each map induces an algebra structure on its target, and
 composition gives compatible scalar actions across three levels.
+
+`AlgebraTower.ofNatStep` constructs a natural-number-indexed tower by composing chosen
+homomorphisms between adjacent levels. These homomorphisms need not be injective.
 
 An `AlgebraTowerEquiv` consists of ring equivalences at each level that commute with
 the tower maps.
@@ -38,6 +42,48 @@ class AlgebraTower {ι : Type*} [Preorder ι] (AT : ι → Type*)
   coherence' : ∀ (i j k : ι) (h1 : i ≤ j) (h2 : j ≤ k),
     algebraMap i k (h1.trans h2) =
       (algebraMap j k h2).comp (algebraMap i j h1)
+
+namespace AlgebraTower
+
+section Nat
+
+variable {A : ℕ → Type*} [∀ k, CommSemiring (A k)]
+
+/-- Construct a tower by composing chosen ring homomorphisms between adjacent levels.
+
+The map from a level to itself is the identity. The map from `i` to `j + 1`, for `i ≤ j`,
+is `step j` composed with the map from `i` to `j`. No injectivity assumption is required. -/
+@[instance_reducible]
+def ofNatStep (step : ∀ k, A k →+* A (k + 1)) : AlgebraTower A where
+  algebraMap i _ h :=
+    Nat.leRec (motive := fun j _ => A i →+* A j) (RingHom.id _)
+      (fun {_} _ f => (step _).comp f) h
+  algebraMap_self' _ := Nat.leRec_self _ _
+  commutes' _ _ _ r x := mul_comm _ _
+  coherence' _ _ _ hij hjk := by
+    induction hjk with
+    | refl => rw [Nat.leRec_self, RingHom.id_comp]
+    | @step k h ih =>
+      rw [Nat.leRec_succ _ _ (hij.trans h), Nat.leRec_succ _ _ h, ih, RingHom.comp_assoc]
+
+/-- Extending a constructed tower map by one level composes it with the chosen next map. -/
+theorem ofNatStep_algebraMap_succ_right (step : ∀ k, A k →+* A (k + 1))
+    {i j : ℕ} (h : i ≤ j) :
+    (ofNatStep step).algebraMap i (j + 1) (h.trans (Nat.le_succ j)) =
+      (step j).comp ((ofNatStep step).algebraMap i j h) :=
+  Nat.leRec_succ _ _ h
+
+/-- The map between adjacent levels is the homomorphism supplied to the constructor. -/
+@[simp]
+theorem ofNatStep_algebraMap_succ (step : ∀ k, A k →+* A (k + 1))
+    (i : ℕ) (h : i ≤ i + 1) :
+    (ofNatStep step).algebraMap i (i + 1) h = step i := by
+  rw [ofNatStep_algebraMap_succ_right step (Nat.le_refl i),
+    (ofNatStep step).algebraMap_self', RingHom.comp_id]
+
+end Nat
+
+end AlgebraTower
 
 variable {ι : Type*} [Preorder ι]
   {A : ι → Type*} [∀ i, CommSemiring (A i)] [AlgebraTower A]

--- a/tests/CompPolyTests/Data/RingTheory/AlgebraTower.lean
+++ b/tests/CompPolyTests/Data/RingTheory/AlgebraTower.lean
@@ -9,12 +9,16 @@ import CompPoly.Data.RingTheory.AlgebraTower
 import Mathlib.Data.ZMod.Basic
 
 /-!
-# Algebra tower identity regression tests
+# Algebra tower identity and adjacent-map regression tests
 
 The projection `(x, y) ↦ (x, x)` on `GF(2) × GF(2)` is an idempotent ring endomorphism.
 Using it between every pair of levels gives coherent maps whose self-maps are not identities.
 The identity law excludes this family of maps. Identity maps on the same carrier give a valid
 tower over a commutative semiring that is not a field.
+
+Using the projection only as the adjacent step gives a valid tower via `AlgebraTower.ofNatStep`.
+Symbolic clients check composition and recover any existing natural-number-indexed tower
+from its adjacent maps.
 -/
 
 namespace CompPolyTests.AlgebraTower
@@ -33,6 +37,53 @@ example (i : ι) (h : i ≤ i) (x : A i) :
   simp only [AlgebraTower.algebraMap_self_apply]
 
 end Generic
+
+section NatStep
+
+variable {A : ℕ → Type*} [∀ k, CommSemiring (A k)]
+  (step : ∀ k, A k →+* A (k + 1))
+
+example (i : ℕ) (h : i ≤ i) :
+    (AlgebraTower.ofNatStep step).algebraMap i i h = RingHom.id (A i) :=
+  (AlgebraTower.ofNatStep step).algebraMap_self' i
+
+example (i : ℕ) (h : i ≤ i + 1) :
+    (AlgebraTower.ofNatStep step).algebraMap i (i + 1) h = step i := by
+  simp
+
+example {i j : ℕ} (h h' : i ≤ j) :
+    (AlgebraTower.ofNatStep step).algebraMap i j h =
+      (AlgebraTower.ofNatStep step).algebraMap i j h' := rfl
+
+example {i j k : ℕ} (hij : i ≤ j) (hjk : j ≤ k) (x : A i) :
+    (AlgebraTower.ofNatStep step).algebraMap i k (hij.trans hjk) x =
+      (AlgebraTower.ofNatStep step).algebraMap j k hjk
+        ((AlgebraTower.ofNatStep step).algebraMap i j hij x) :=
+  congrArg (fun f : A i →+* A k => f x)
+    ((AlgebraTower.ofNatStep step).coherence' i j k hij hjk)
+
+example {i j k : ℕ} (hij : i ≤ j) (hjk : j ≤ k) :
+    letI := AlgebraTower.ofNatStep step
+    letI := AlgebraTower.toAlgebra (A := A) hij
+    letI := AlgebraTower.toAlgebra (A := A) hjk
+    letI := AlgebraTower.toAlgebra (A := A) (hij.trans hjk)
+    IsScalarTower (A i) (A j) (A k) :=
+  AlgebraTower.toIsScalarTower (AlgebraTower.ofNatStep step) hij hjk
+
+-- Reconstructing an existing tower from its adjacent maps preserves every comparable map.
+example [t : AlgebraTower A] {i j : ℕ} (h : i ≤ j) :
+    (AlgebraTower.ofNatStep (fun k => t.algebraMap k (k + 1) (Nat.le_succ k))).algebraMap
+      i j h = t.algebraMap i j h := by
+  induction h with
+  | refl =>
+    exact ((AlgebraTower.ofNatStep (fun k =>
+      t.algebraMap k (k + 1) (Nat.le_succ k))).algebraMap_self' i).trans
+        (t.algebraMap_self' i).symm
+  | @step j h ih =>
+    rw [AlgebraTower.ofNatStep_algebraMap_succ_right _ h, ih,
+      t.coherence' i j (j + 1) h (Nat.le_succ j)]
+
+end NatStep
 
 private abbrev R := ZMod 2 × ZMod 2
 
@@ -70,5 +121,25 @@ private abbrev constantTower : AlgebraTower (fun _ : ℕ => R) where
   coherence' _ _ _ _ _ := rfl
 
 example (x : R) : constantTower.algebraMap 0 2 (by decide) x = x := rfl
+
+/-- A valid tower with noninjective adjacent maps on the same non-field carrier. -/
+private abbrev projectionTower : AlgebraTower (fun _ : ℕ => R) :=
+  AlgebraTower.ofNatStep (fun _ => diagonal)
+
+example (k : ℕ) : projectionTower.algebraMap k k le_rfl (0, 1) = (0, 1) := by
+  rw [projectionTower.algebraMap_self']
+  rfl
+
+example : projectionTower.algebraMap 0 2 (by decide) (0, 1) = (0, 0) := by
+  rw [AlgebraTower.ofNatStep_algebraMap_succ_right _ (show 0 ≤ 1 by decide),
+    AlgebraTower.ofNatStep_algebraMap_succ]
+  rfl
+
+example (k : ℕ) :
+    ¬ Function.Injective (projectionTower.algebraMap k (k + 1) (Nat.le_succ k)) := by
+  rw [AlgebraTower.ofNatStep_algebraMap_succ]
+  intro h
+  have he := h (show diagonal (0, 1) = diagonal (0, 0) from rfl)
+  exact one_ne_zero (congrArg Prod.snd he)
 
 end CompPolyTests.AlgebraTower


### PR DESCRIPTION
Construct natural-number-indexed algebra towers from chosen adjacent ring homomorphisms. `AlgebraTower.ofNatStep` uses identity self-maps and composes each next step with the preceding map, with public adjacent and right-successor equations. It requires only commutative semirings and adds no global instance.

Regressions reconstruct every map of an arbitrary existing Nat-indexed tower, check the chosen scalar actions, and use valid noninjective steps on `GF(2) × GF(2)` to distinguish the required identity law from an unnecessary injectivity assumption.

Validation: independent statement/source review and fresh boundary probes; full build/tests, warning-fatal build, style/import/docs checks, the curated benchmark correctness gate, and the axiom sweep (9,876 declarations, zero admitted or nonstandard-axiom taint). The new constructor and equations use only `propext` and `Quot.sound`.

Tracks #322 and uses the identity-law repair in merged #324.
