### PR TITLE
doc(bench): clarify validation timing and sink behavior

### DIFF
--- a/bench/CompPolyBench/Common.lean
+++ b/bench/CompPolyBench/Common.lean
@@ -1097,9 +1097,9 @@ private def validationRow (group : BenchGroup) : String :=
 
 /-- Render the report for a `--validate-only` run.
 
-Deliberately not the timing table: a validation run collects no samples, so
-every duration would be zero. What it has to say is whether each group's
-implementations agree, and on what digest. -/
+Show whether each group's implementations agree on a digest. Ordinary workloads
+are untimed; harness checks may retain samples through `forceTiming`. This report
+omits timing values, including any harness samples. -/
 def renderValidationMarkdown (preset : BenchPreset) (groups : Array BenchGroup) : String :=
   let mismatches := checksumMismatchGroups groups
   String.intercalate "\n" ([
@@ -1110,9 +1110,10 @@ def renderValidationMarkdown (preset : BenchPreset) (groups : Array BenchGroup) 
     "- Groups checked: `" ++ toString groups.size ++ "`",
     "- Mismatched groups: `" ++ toString mismatches.length ++ "`",
     "",
-    "No timings were collected. Every implementation in a group is run over the",
-    "same inputs and must agree on a digest; a disagreement means one of them is",
-    "wrong. Run the benchmark workflow for timings.",
+    "Ordinary workloads were not timed; harness checks may still record samples.",
+    "Every implementation in a group is run over the same inputs and must agree",
+    "on a digest; a disagreement means one of them is wrong. Run the benchmark",
+    "workflow for workload timings.",
     "",
     "| Group | Rows | Implementations | Digest |",
     "| ----- | ---: | --------------- | ------ |"

--- a/bench/CompPolyBench/Harness/Sink.lean
+++ b/bench/CompPolyBench/Harness/Sink.lean
@@ -22,9 +22,9 @@ namespace CompPolyBench
 
 /-- Fold one result word into a running sink accumulator.
 
-Kept `@[noinline]` so the fold survives optimisation; the `harness-floor` group
-measures what this costs and `harness-canary` fails the run if it stops costing
-anything. -/
+The inline fold makes the next accumulator depend on the result word. Callers
+must keep the accumulator live through the timed region and consume it afterward.
+Inspect the compiled timing path to check that the benchmark work is retained. -/
 @[inline] def sinkStep (acc x : UInt64) : UInt64 :=
   let mixed := (acc ^^^ x) * 0x9E3779B97F4A7C15
   (mixed <<< 27) ||| (mixed >>> 37)

--- a/bench/CompPolyBench/Harness/Timer.lean
+++ b/bench/CompPolyBench/Harness/Timer.lean
@@ -24,9 +24,9 @@ namespace CompPolyBench
 
 /-- Whether this process is running in validation-only mode.
 
-Set once from the command line rather than threaded through `runTimed`, whose
-226 call sites all pass their arguments positionally. Read by `runTimed`, which
-skips sample collection entirely when it is set. -/
+Set from the command line and read by `runTimed`. When set, ordinary workloads
+run their checksum validation without warmup or timed samples. Harness checks
+that pass `forceTiming := true` still collect samples. -/
 initialize validateOnlyRef : IO.Ref Bool ← IO.mkRef false
 
 /-- Elapsed time for one timed sample, with the sink accumulator it produced. -/


### PR DESCRIPTION
Clarify validation reports and docstrings: ordinary workloads skip calibration and sampling,
while forced harness controls retain both. Describe the sink's actual inline accumulator
dependency and the need to inspect the compiled timing path.

Only comments and the validation report's explanatory text change. Arithmetic, calibration
and sampling policy, sinks, digests, and report data are unchanged. Related to #322.

Validation: seven fresh benchmark modules, style/import/documentation checks, and an actual
report-rendering client passed. Ordinary rows retain zero calibration and timing samples;
the forced floor and canary controls each retain ten samples. The client also checks checksum
mismatch reporting. Source-identical library dependencies were reused read-only for this
focused validation.
