### PR TITLE
refactor(binary-tower): separate concrete construction imports from the abstract tower

### DIFF
--- a/CompPoly.lean
+++ b/CompPoly.lean
@@ -77,6 +77,8 @@ public import CompPoly.Data.Polynomial.MonomialBasis
 public import CompPoly.Data.Polynomial.Rabin
 public import CompPoly.Data.Polynomial.RabinCertificate
 public import CompPoly.Data.RingTheory.AlgebraTower
+public import CompPoly.Data.RingTheory.AlgebraTower.Basis
+public import CompPoly.Data.RingTheory.AlgebraTower.Coordinates
 public import CompPoly.Data.RingTheory.CanonicalEuclideanDomain
 public import CompPoly.Data.Vector.Basic
 public import CompPoly.Fields.BLS12_377

--- a/CompPoly/Data/RingTheory/AlgebraTower.lean
+++ b/CompPoly/Data/RingTheory/AlgebraTower.lean
@@ -5,6 +5,7 @@ Authors: Chung Thai Nguyen, Quang Dao
 -/
 module
 
+public import Mathlib.Data.Nat.Init
 public import Mathlib.LinearAlgebra.Matrix.Reindex
 
 /-!
@@ -14,6 +15,9 @@ An `AlgebraTower` is a preorder-indexed family of commutative semirings with rin
 homomorphisms between comparable levels. Self-maps are identities, and the maps compose
 along chains of indices. Each map induces an algebra structure on its target, and
 composition gives compatible scalar actions across three levels.
+
+`AlgebraTower.ofNatStep` constructs a natural-number-indexed tower by composing chosen
+homomorphisms between adjacent levels. These homomorphisms need not be injective.
 
 An `AlgebraTowerEquiv` consists of ring equivalences at each level that commute with
 the tower maps.
@@ -38,6 +42,48 @@ class AlgebraTower {ι : Type*} [Preorder ι] (AT : ι → Type*)
   coherence' : ∀ (i j k : ι) (h1 : i ≤ j) (h2 : j ≤ k),
     algebraMap i k (h1.trans h2) =
       (algebraMap j k h2).comp (algebraMap i j h1)
+
+namespace AlgebraTower
+
+section Nat
+
+variable {A : ℕ → Type*} [∀ k, CommSemiring (A k)]
+
+/-- Construct a tower by composing chosen ring homomorphisms between adjacent levels.
+
+The map from a level to itself is the identity. The map from `i` to `j + 1`, for `i ≤ j`,
+is `step j` composed with the map from `i` to `j`. No injectivity assumption is required. -/
+@[instance_reducible]
+def ofNatStep (step : ∀ k, A k →+* A (k + 1)) : AlgebraTower A where
+  algebraMap i _ h :=
+    Nat.leRec (motive := fun j _ => A i →+* A j) (RingHom.id _)
+      (fun {_} _ f => (step _).comp f) h
+  algebraMap_self' _ := Nat.leRec_self _ _
+  commutes' _ _ _ r x := mul_comm _ _
+  coherence' _ _ _ hij hjk := by
+    induction hjk with
+    | refl => rw [Nat.leRec_self, RingHom.id_comp]
+    | @step k h ih =>
+      rw [Nat.leRec_succ _ _ (hij.trans h), Nat.leRec_succ _ _ h, ih, RingHom.comp_assoc]
+
+/-- Extending a constructed tower map by one level composes it with the chosen next map. -/
+theorem ofNatStep_algebraMap_succ_right (step : ∀ k, A k →+* A (k + 1))
+    {i j : ℕ} (h : i ≤ j) :
+    (ofNatStep step).algebraMap i (j + 1) (h.trans (Nat.le_succ j)) =
+      (step j).comp ((ofNatStep step).algebraMap i j h) :=
+  Nat.leRec_succ _ _ h
+
+/-- The map between adjacent levels is the homomorphism supplied to the constructor. -/
+@[simp]
+theorem ofNatStep_algebraMap_succ (step : ∀ k, A k →+* A (k + 1))
+    (i : ℕ) (h : i ≤ i + 1) :
+    (ofNatStep step).algebraMap i (i + 1) h = step i := by
+  rw [ofNatStep_algebraMap_succ_right step (Nat.le_refl i),
+    (ofNatStep step).algebraMap_self', RingHom.comp_id]
+
+end Nat
+
+end AlgebraTower
 
 variable {ι : Type*} [Preorder ι]
   {A : ι → Type*} [∀ i, CommSemiring (A i)] [AlgebraTower A]

--- a/CompPoly/Data/RingTheory/AlgebraTower/Basis.lean
+++ b/CompPoly/Data/RingTheory/AlgebraTower/Basis.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: CompPoly Contributors
+-/
+module
+
+public import CompPoly.Data.RingTheory.AlgebraTower.Coordinates
+public import Mathlib.LinearAlgebra.Basis.Defs
+public import Mathlib.RingTheory.AlgebraTower
+
+/-!
+# Bases from adjacent tower coordinates
+
+`AlgebraTower.natBasis` is the basis determined by the executable equivalence
+`AlgebraTower.natCoordinates`. Its `repr` is the coordinate map, and its vectors equal the
+executable `AlgebraTower.natBasisVector` values.
+
+The successor basis agrees with `Module.Basis.smulTower'`, reindexed by `finProdFinEquiv`.
+The old coordinate index varies fastest. Each vector is the embedded old basis vector
+multiplied by the corresponding new successor basis vector. No normalization of that
+successor vector is assumed.
+
+The construction uses `Module.Basis.ofEquivFun` and the scalar-tower basis equations from
+Mathlib's `Mathlib.RingTheory.AlgebraTower` module.
+-/
+
+public section
+
+namespace AlgebraTower
+
+variable {A : ℕ → Type*} [∀ k, CommSemiring (A k)] [t : AlgebraTower A]
+  {d : ℕ → ℕ}
+  (step : ∀ k, letI := t.toAlgebra (Nat.le_succ k)
+    A (k + 1) ≃ₗ[A k] (Fin (d k) → A k))
+
+/-- The basis whose coordinates are `natCoordinates`, over the action of the given tower map. -/
+noncomputable def natBasis (i n : ℕ) :
+    letI := t.toAlgebra (Nat.le_add_right i n)
+    Module.Basis (Fin (coordinateSize d i n)) (A i) (A (i + n)) := by
+  letI := t.toAlgebra (Nat.le_add_right i n)
+  exact Module.Basis.ofEquivFun (natCoordinates step i n)
+
+/-- The mathematical basis representation is the executable coordinate map. -/
+@[simp]
+theorem natBasis_repr (i n : ℕ) (x : A (i + n)) (j : Fin (coordinateSize d i n)) :
+    letI := t.toAlgebra (Nat.le_add_right i n)
+    (natBasis step i n).repr x j = natCoordinates step i n x j := by
+  rfl
+
+/-- Packing a unit coordinate vector gives the corresponding mathematical basis vector. -/
+theorem natBasisVector_eq_natBasis (i n : ℕ) (j : Fin (coordinateSize d i n)) :
+    natBasisVector step i n j = natBasis step i n j := by
+  let := t.toAlgebra (Nat.le_add_right i n)
+  apply (natBasis step i n).repr.injective
+  ext idx
+  rw [natBasis_repr, congrFun (natCoordinates_natBasisVector step i n j) idx,
+    Module.Basis.repr_self]
+  simp only [Pi.single_apply, Finsupp.single_apply, eq_comm]
+
+/-- The next relative basis is the scalar-tower composition of the previous basis and the
+next successor basis, with the old index varying fastest. -/
+theorem natBasis_succ (i n : ℕ) :
+    letI := t.toAlgebra (Nat.le_add_right i n)
+    letI := t.toAlgebra (Nat.le_succ (i + n))
+    letI := t.toAlgebra (Nat.le_add_right i (n + 1))
+    letI := toIsScalarTower t (Nat.le_add_right i n) (Nat.le_succ (i + n))
+    natBasis step i (n + 1) =
+      ((natBasis step i n).smulTower' (Module.Basis.ofEquivFun (step (i + n)))).reindex
+        finProdFinEquiv := by
+  let := t.toAlgebra (Nat.le_add_right i n)
+  let := t.toAlgebra (Nat.le_succ (i + n))
+  let := t.toAlgebra (Nat.le_add_right i (n + 1))
+  let := toIsScalarTower t (Nat.le_add_right i n) (Nat.le_succ (i + n))
+  apply Module.Basis.repr_injective
+  ext x j
+  exact natCoordinates_succ step i n x j
+
+/-- At flattened index `oldIndex + oldSize * newIndex`, the vector is the embedded old
+vector multiplied by the new successor vector. -/
+theorem natBasisVector_succ (i n : ℕ) (b : Fin (d (i + n)))
+    (j : Fin (coordinateSize d i n)) :
+    natBasisVector step i (n + 1) (finProdFinEquiv (b, j)) =
+      t.algebraMap (i + n) (i + n + 1) (Nat.le_succ (i + n)) (natBasisVector step i n j) *
+        (step (i + n)).symm (Pi.single b 1) := by
+  let := t.toAlgebra (Nat.le_add_right i n)
+  let := t.toAlgebra (Nat.le_succ (i + n))
+  let := t.toAlgebra (Nat.le_add_right i (n + 1))
+  let := toIsScalarTower t (Nat.le_add_right i n) (Nat.le_succ (i + n))
+  rw [natBasisVector_eq_natBasis, natBasis_succ]
+  simp only [Module.Basis.reindex_apply, Equiv.symm_apply_apply, Module.Basis.smulTower'_apply]
+  rw [natBasisVector_eq_natBasis, Module.Basis.coe_ofEquivFun]
+  rfl
+
+end AlgebraTower

--- a/CompPoly/Data/RingTheory/AlgebraTower/Basis.lean
+++ b/CompPoly/Data/RingTheory/AlgebraTower/Basis.lean
@@ -16,6 +16,10 @@ public import Mathlib.RingTheory.AlgebraTower
 `AlgebraTower.natCoordinates`. Its `repr` is the coordinate map, and its vectors equal the
 executable `AlgebraTower.natBasisVector` values.
 
+`AlgebraTower.natBasisOfLE` provides the same basis at arbitrary endpoints `i ≤ j`,
+with vectors in `A j` and coefficients in `A i`. Its representation agrees with
+`AlgebraTower.natCoordinatesOfLE`, and `AlgebraTower.natBasisVectorOfLE` computes its vectors.
+
 The successor basis agrees with `Module.Basis.smulTower'`, reindexed by `finProdFinEquiv`.
 The old coordinate index varies fastest. Each vector is the embedded old basis vector
 multiplied by the corresponding new successor basis vector. No normalization of that
@@ -91,5 +95,45 @@ theorem natBasisVector_succ (i n : ℕ) (b : Fin (d (i + n)))
   simp only [Module.Basis.reindex_apply, Equiv.symm_apply_apply, Module.Basis.smulTower'_apply]
   rw [natBasisVector_eq_natBasis, Module.Basis.coe_ofEquivFun]
   rfl
+
+/-- The basis at arbitrary comparable endpoints, over the action of the given tower map. -/
+noncomputable def natBasisOfLE {i j : ℕ} (h : i ≤ j) :
+    letI := t.toAlgebra h
+    Module.Basis (Fin (coordinateSize d i (j - i))) (A i) (A j) := by
+  letI := t.toAlgebra h
+  exact Module.Basis.ofEquivFun (natCoordinatesOfLE step h)
+
+/-- The endpoint basis representation is the executable endpoint coordinate map. -/
+@[simp]
+theorem natBasisOfLE_repr {i j : ℕ} (h : i ≤ j) (x : A j)
+    (idx : Fin (coordinateSize d i (j - i))) :
+    letI := t.toAlgebra h
+    (natBasisOfLE step h).repr x idx = natCoordinatesOfLE step h x idx := by
+  rfl
+
+/-- Packing a unit coordinate vector computes the corresponding endpoint basis vector. -/
+theorem natBasisVectorOfLE_eq_natBasisOfLE {i j : ℕ} (h : i ≤ j)
+    (idx : Fin (coordinateSize d i (j - i))) :
+    natBasisVectorOfLE step h idx = natBasisOfLE step h idx := by
+  let := t.toAlgebra h
+  apply (natBasisOfLE step h).repr.injective
+  ext pos
+  rw [natBasisOfLE_repr, congrFun (natCoordinatesOfLE_natBasisVectorOfLE step h idx) pos,
+    Module.Basis.repr_self]
+  simp only [Pi.single_apply, Finsupp.single_apply, eq_comm]
+
+/-- Endpoint basis vectors agree with the height-indexed basis after identifying the endpoints. -/
+theorem natBasisOfLE_apply {i j : ℕ} (h : i ≤ j)
+    (idx : Fin (coordinateSize d i (j - i))) :
+    natBasisOfLE step h idx =
+      cast (congrArg A (Nat.add_sub_of_le h)) (natBasis step i (j - i) idx) := by
+  rw [← natBasisVectorOfLE_eq_natBasisOfLE, natBasisVectorOfLE_eq_natBasisVector,
+    natBasisVector_eq_natBasis]
+
+/-- At equal endpoints the unique basis vector is one. -/
+@[simp]
+theorem natBasisOfLE_self (i : ℕ) (idx : Fin (coordinateSize d i (i - i))) :
+    natBasisOfLE step (Nat.le_refl i) idx = 1 := by
+  rw [← natBasisVectorOfLE_eq_natBasisOfLE, natBasisVectorOfLE_self]
 
 end AlgebraTower

--- a/CompPoly/Data/RingTheory/AlgebraTower/Coordinates.lean
+++ b/CompPoly/Data/RingTheory/AlgebraTower/Coordinates.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: CompPoly Contributors
+-/
+module
+
+public import CompPoly.Data.RingTheory.AlgebraTower
+import Mathlib.LinearAlgebra.Pi
+public import Mathlib.Logic.Equiv.Fin.Basic
+
+/-!
+# Coordinates along a natural-number-indexed algebra tower
+
+Given linear coordinate equivalences between adjacent levels of an `AlgebraTower`,
+`AlgebraTower.natCoordinates` gives coordinates at level `i + n` over level `i`. Each scalar
+action is induced by the corresponding map of the given tower. The number of successor
+coordinates may vary with the level, and may be zero when such an equivalence exists.
+
+The old coordinate index varies fastest: a pair `(newIndex, oldIndex)` has flattened index
+`oldIndex + oldSize * newIndex`. Constant successor coordinate count two gives the usual
+least-significant-bit-first order.
+
+`AlgebraTower.natPack` is the inverse coordinate map. `AlgebraTower.natBasisVector` packs
+a unit coordinate vector. Both are executable, with no enumeration of the tower carriers.
+The corresponding mathematical basis is constructed in
+`CompPoly.Data.RingTheory.AlgebraTower.Basis`.
+
+The construction uses `LinearEquiv.restrictScalars`, `LinearEquiv.piCongrRight`,
+`LinearEquiv.curry`, and `finProdFinEquiv`.
+-/
+
+public section
+
+namespace AlgebraTower
+
+private def composeCoordinates {R S T : Type*}
+    [CommSemiring R] [CommSemiring S] [CommSemiring T]
+    [Algebra R S] [Algebra S T] [Algebra R T] [IsScalarTower R S T]
+    {m n : ℕ} (e : S ≃ₗ[R] (Fin m → R)) (f : T ≃ₗ[S] (Fin n → S)) :
+    T ≃ₗ[R] (Fin (n * m) → R) :=
+  (f.restrictScalars R).trans
+    ((LinearEquiv.piCongrRight fun _ : Fin n => e).trans
+      ((LinearEquiv.curry R R (Fin n) (Fin m)).symm.trans
+        (LinearEquiv.funCongrLeft R R finProdFinEquiv.symm)))
+
+/-- The number of coordinates from level `i` through `n` steps with chosen coordinate counts `d`.
+The next step contributes a new outer block of coordinates. -/
+abbrev coordinateSize (d : ℕ → ℕ) (i n : ℕ) : ℕ :=
+  Nat.rec 1 (fun k size => d (i + k) * size) n
+
+/-- An interval with no successor steps has one coordinate. -/
+@[simp]
+theorem coordinateSize_zero (d : ℕ → ℕ) (i : ℕ) : coordinateSize d i 0 = 1 := rfl
+
+/-- The number of coordinates is multiplied by the next successor coordinate count. -/
+@[simp]
+theorem coordinateSize_succ (d : ℕ → ℕ) (i n : ℕ) :
+    coordinateSize d i (n + 1) = d (i + n) * coordinateSize d i n := rfl
+
+/-- A constant successor coordinate count `r` gives `r ^ n` coordinates over `n` steps. -/
+theorem coordinateSize_const (r i n : ℕ) :
+    coordinateSize (fun _ => r) i n = r ^ n := by
+  induction n with
+  | zero => rfl
+  | succ n ih => rw [coordinateSize_succ, ih, pow_succ, Nat.mul_comm]
+
+variable {A : ℕ → Type*} [∀ k, CommSemiring (A k)] [t : AlgebraTower A]
+  {d : ℕ → ℕ}
+  (step : ∀ k, letI := t.toAlgebra (Nat.le_succ k)
+    A (k + 1) ≃ₗ[A k] (Fin (d k) → A k))
+
+/-- Coordinates of `A (i + n)` over `A i`, obtained by composing adjacent equivalences.
+
+The scalar action is induced by the given tower map from `i` to `i + n`. At each step,
+the old index varies fastest, so `(b, j)` is placed at `j + oldSize * b`. -/
+def natCoordinates (i : ℕ) : (n : ℕ) →
+    letI := t.toAlgebra (Nat.le_add_right i n)
+    A (i + n) ≃ₗ[A i] (Fin (coordinateSize d i n) → A i)
+  | 0 => by
+      -- Capture the coefficient action before installing the chosen self action.
+      letI : Module (A i) (Fin (coordinateSize d i 0) → A i) := inferInstance
+      letI : Module (A i) (A i) := (t.toAlgebra (Nat.le_add_right i 0)).toModule
+      let z : Fin (coordinateSize d i 0) := ⟨0, by change 0 < 1; decide⟩
+      exact {
+        toFun := fun x _ => x
+        invFun := fun c => c z
+        map_add' := fun _ _ => rfl
+        map_smul' := fun a x => by
+          funext j
+          change t.algebraMap i i (Nat.le_add_right i 0) a * x = a * x
+          rw [algebraMap_self_apply]
+        left_inv := fun _ => rfl
+        right_inv := fun c => by
+          funext j
+          have hj : j = z := Fin.ext (by
+            have h : j.val < 1 := j.isLt
+            change j.val = 0
+            omega)
+          subst j
+          rfl }
+  | n + 1 => by
+      letI := t.toAlgebra (Nat.le_add_right i n)
+      letI := t.toAlgebra (Nat.le_succ (i + n))
+      letI := t.toAlgebra (Nat.le_add_right i (n + 1))
+      letI := toIsScalarTower t (Nat.le_add_right i n) (Nat.le_succ (i + n))
+      exact composeCoordinates (natCoordinates i n) (step (i + n))
+
+/-- At height zero the single coordinate is the original element. -/
+@[simp]
+theorem natCoordinates_zero (i : ℕ) (x : A i) (j : Fin (coordinateSize d i 0)) :
+    natCoordinates step i 0 x j = x := by
+  rfl
+
+/-- Read the new outer coordinate, then the old inner coordinate.
+Division selects the outer block and remainder selects the position within that block. -/
+theorem natCoordinates_succ (i n : ℕ) (x : A (i + (n + 1)))
+    (j : Fin (coordinateSize d i (n + 1))) :
+    natCoordinates step i (n + 1) x j =
+      natCoordinates step i n (step (i + n) x j.divNat) j.modNat := by
+  rfl
+
+/-- Pack coordinates in the order used by `natCoordinates`, using the inverse successor maps. -/
+def natPack (i n : ℕ) (c : Fin (coordinateSize d i n) → A i) : A (i + n) :=
+  (natCoordinates step i n).symm c
+
+/-- At height zero packing returns the single input coefficient. -/
+@[simp]
+theorem natPack_zero (i : ℕ) (c : Fin (coordinateSize d i 0) → A i) :
+    natPack step i 0 c = c ⟨0, by simp only [coordinateSize_zero]; decide⟩ := by
+  rfl
+
+/-- Pack each old coordinate block, then apply the inverse of the next successor map. -/
+theorem natPack_succ (i n : ℕ) (c : Fin (coordinateSize d i (n + 1)) → A i) :
+    natPack step i (n + 1) c =
+      (step (i + n)).symm
+        (fun b => natPack step i n (fun j => c (finProdFinEquiv (b, j)))) := by
+  rfl
+
+/-- Reading back packed coordinates recovers the input coefficients. -/
+@[simp]
+theorem natCoordinates_natPack (i n : ℕ) (c : Fin (coordinateSize d i n) → A i) :
+    natCoordinates step i n (natPack step i n c) = c :=
+  (natCoordinates step i n).apply_symm_apply c
+
+/-- Packing the coordinates of an element recovers that element. -/
+@[simp]
+theorem natPack_natCoordinates (i n : ℕ) (x : A (i + n)) :
+    natPack step i n (natCoordinates step i n x) = x :=
+  (natCoordinates step i n).symm_apply_apply x
+
+/-- The executable vector whose coordinate at `j` is one and whose other coordinates are zero. -/
+def natBasisVector (i n : ℕ) (j : Fin (coordinateSize d i n)) : A (i + n) :=
+  natPack step i n (Pi.single j 1)
+
+/-- A basis vector reads back as its unit coordinate vector. -/
+@[simp]
+theorem natCoordinates_natBasisVector (i n : ℕ) (j : Fin (coordinateSize d i n)) :
+    natCoordinates step i n (natBasisVector step i n j) = Pi.single j 1 :=
+  natCoordinates_natPack step i n (Pi.single j 1)
+
+end AlgebraTower

--- a/CompPoly/Data/RingTheory/AlgebraTower/Coordinates.lean
+++ b/CompPoly/Data/RingTheory/AlgebraTower/Coordinates.lean
@@ -26,8 +26,13 @@ a unit coordinate vector. Both are executable, with no enumeration of the tower 
 The corresponding mathematical basis is constructed in
 `CompPoly.Data.RingTheory.AlgebraTower.Basis`.
 
+For arbitrary endpoints `h : i ≤ j`, `AlgebraTower.natCoordinatesOfLE` and its packing
+and vector companions accept elements of `A j` directly. `AlgebraTower.natCoordinatesConstOfLE`
+also presents constant successor coordinate count `r` as `Fin (r ^ (j - i))`.
+
 The construction uses `LinearEquiv.restrictScalars`, `LinearEquiv.piCongrRight`,
-`LinearEquiv.curry`, and `finProdFinEquiv`.
+`LinearEquiv.curry`, and `finProdFinEquiv`. Endpoint and coordinate-count identifications use
+`LinearEquiv.cast`, `LinearEquiv.funCongrLeft`, and `finCongr`.
 -/
 
 public section
@@ -158,5 +163,131 @@ def natBasisVector (i n : ℕ) (j : Fin (coordinateSize d i n)) : A (i + n) :=
 theorem natCoordinates_natBasisVector (i n : ℕ) (j : Fin (coordinateSize d i n)) :
     natCoordinates step i n (natBasisVector step i n j) = Pi.single j 1 :=
   natCoordinates_natPack step i n (Pi.single j 1)
+
+private theorem natCoordinates_cast_apply (i : ℕ) {n m : ℕ} (h : n = m)
+    (x : A (i + n)) (idx : Fin (coordinateSize d i m)) :
+    natCoordinates step i m (cast (congrArg (fun k => A (i + k)) h) x) idx =
+      natCoordinates step i n x (Fin.cast (congrArg (coordinateSize d i) h.symm) idx) := by
+  cases h
+  rfl
+
+/-- Coordinates of `A j` over `A i` for comparable endpoints, with the given tower action.
+The coordinate count and order are those of the `j - i` successor steps starting at `i`. -/
+def natCoordinatesOfLE {i j : ℕ} (h : i ≤ j) :
+    letI := t.toAlgebra h
+    A j ≃ₗ[A i] (Fin (coordinateSize d i (j - i)) → A i) := by
+  letI := t.toAlgebra h
+  letI : ∀ k : {k : ℕ // i ≤ k}, Module (A i) (A k.val) :=
+    fun k => (t.toAlgebra k.property).toModule
+  let e : (⟨j, h⟩ : {k : ℕ // i ≤ k}) =
+      ⟨i + (j - i), Nat.le_add_right i (j - i)⟩ :=
+    Subtype.ext (Nat.add_sub_of_le h).symm
+  exact (LinearEquiv.cast (R := A i) (M := fun k : {k : ℕ // i ≤ k} => A k.val) e).trans
+    (natCoordinates step i (j - i))
+
+/-- Endpoint coordinates are height coordinates after identifying `j` with `i + (j - i)`.
+The coordinate index is unchanged. -/
+theorem natCoordinatesOfLE_apply {i j : ℕ} (h : i ≤ j) (x : A j)
+    (idx : Fin (coordinateSize d i (j - i))) :
+    natCoordinatesOfLE step h x idx =
+      natCoordinates step i (j - i) (cast (congrArg A (Nat.add_sub_of_le h).symm) x) idx := by
+  rfl
+
+/-- With equal endpoints the single coordinate is the original element. -/
+@[simp]
+theorem natCoordinatesOfLE_self (i : ℕ) (x : A i)
+    (idx : Fin (coordinateSize d i (i - i))) :
+    natCoordinatesOfLE step (Nat.le_refl i) x idx = x := by
+  rw [natCoordinatesOfLE_apply,
+    natCoordinates_cast_apply step i (Nat.sub_self i).symm, natCoordinates_zero]
+
+/-- Pack coordinates into `A j`, inverting the coordinate map over the given tower action. -/
+def natPackOfLE {i j : ℕ} (h : i ≤ j) (c : Fin (coordinateSize d i (j - i)) → A i) : A j :=
+  (natCoordinatesOfLE step h).symm c
+
+/-- Endpoint packing is height packing followed by the identification `i + (j - i) = j`. -/
+theorem natPackOfLE_eq_natPack {i j : ℕ} (h : i ≤ j)
+    (c : Fin (coordinateSize d i (j - i)) → A i) :
+    natPackOfLE step h c = cast (congrArg A (Nat.add_sub_of_le h)) (natPack step i (j - i) c) := by
+  rfl
+
+/-- Packing at equal endpoints returns the single coefficient. -/
+@[simp]
+theorem natPackOfLE_self (i : ℕ) (c : Fin (coordinateSize d i (i - i)) → A i) :
+    natPackOfLE step (Nat.le_refl i) c =
+      c ⟨0, by simp only [Nat.sub_self, coordinateSize_zero]; decide⟩ := by
+  exact (natCoordinatesOfLE_self step i (natPackOfLE step (Nat.le_refl i) c) _).symm.trans
+    (congrFun ((natCoordinatesOfLE step (Nat.le_refl i)).apply_symm_apply c) _)
+
+/-- Reading packed endpoint coordinates recovers the input coefficients. -/
+@[simp]
+theorem natCoordinatesOfLE_natPackOfLE {i j : ℕ} (h : i ≤ j)
+    (c : Fin (coordinateSize d i (j - i)) → A i) :
+    natCoordinatesOfLE step h (natPackOfLE step h c) = c :=
+  (natCoordinatesOfLE step h).apply_symm_apply c
+
+/-- Packing the endpoint coordinates of an element recovers that element. -/
+@[simp]
+theorem natPackOfLE_natCoordinatesOfLE {i j : ℕ} (h : i ≤ j) (x : A j) :
+    natPackOfLE step h (natCoordinatesOfLE step h x) = x :=
+  (natCoordinatesOfLE step h).symm_apply_apply x
+
+/-- The executable endpoint vector with coordinate one at `idx` and zero elsewhere. -/
+def natBasisVectorOfLE {i j : ℕ} (h : i ≤ j) (idx : Fin (coordinateSize d i (j - i))) : A j :=
+  natPackOfLE step h (Pi.single idx 1)
+
+/-- Endpoint vectors agree with height vectors under the canonical endpoint identification. -/
+theorem natBasisVectorOfLE_eq_natBasisVector {i j : ℕ} (h : i ≤ j)
+    (idx : Fin (coordinateSize d i (j - i))) :
+    natBasisVectorOfLE step h idx =
+      cast (congrArg A (Nat.add_sub_of_le h)) (natBasisVector step i (j - i) idx) :=
+  natPackOfLE_eq_natPack step h (Pi.single idx 1)
+
+/-- An endpoint vector reads back as its unit coordinate vector. -/
+@[simp]
+theorem natCoordinatesOfLE_natBasisVectorOfLE {i j : ℕ} (h : i ≤ j)
+    (idx : Fin (coordinateSize d i (j - i))) :
+    natCoordinatesOfLE step h (natBasisVectorOfLE step h idx) = Pi.single idx 1 :=
+  natCoordinatesOfLE_natPackOfLE step h (Pi.single idx 1)
+
+/-- At equal endpoints the unique executable basis vector is one. -/
+@[simp]
+theorem natBasisVectorOfLE_self (i : ℕ) (idx : Fin (coordinateSize d i (i - i))) :
+    natBasisVectorOfLE step (Nat.le_refl i) idx = 1 := by
+  rw [natBasisVectorOfLE, natPackOfLE_self]
+  have hidx : idx = ⟨0, by simp only [Nat.sub_self, coordinateSize_zero]; decide⟩ := by
+    apply Fin.ext
+    have := idx.isLt
+    simp only [Nat.sub_self, coordinateSize_zero] at this
+    exact Nat.eq_zero_of_le_zero (Nat.le_of_lt_succ this)
+  simp only [hidx, Pi.single_eq_same]
+
+variable {r : ℕ}
+  (constantStep : ∀ k, letI := t.toAlgebra (Nat.le_succ k)
+    A (k + 1) ≃ₗ[A k] (Fin r → A k))
+
+/-- Endpoint coordinates with constant successor coordinate count `r`, indexed by `Fin (r^(j-i))`.
+Only the coordinate count is identified with a power; each index retains its numeric value. -/
+def natCoordinatesConstOfLE {i j : ℕ} (h : i ≤ j) :
+    letI := t.toAlgebra h
+    A j ≃ₗ[A i] (Fin (r ^ (j - i)) → A i) := by
+  letI := t.toAlgebra h
+  exact (natCoordinatesOfLE (d := fun _ => r) constantStep h).trans
+    (LinearEquiv.funCongrLeft (A i) (A i)
+      (finCongr (coordinateSize_const r i (j - i))).symm)
+
+/-- Constant-count coordinates read the same numeric index in the endpoint coordinate map. -/
+theorem natCoordinatesConstOfLE_apply {i j : ℕ} (h : i ≤ j) (x : A j)
+    (idx : Fin (r ^ (j - i))) :
+    natCoordinatesConstOfLE constantStep h x idx =
+      natCoordinatesOfLE constantStep h x
+        (Fin.cast (coordinateSize_const r i (j - i)).symm idx) := by
+  rfl
+
+/-- Constant-count coordinates at equal endpoints consist of the original element. -/
+@[simp]
+theorem natCoordinatesConstOfLE_self (i : ℕ) (x : A i) (idx : Fin (r ^ (i - i))) :
+    natCoordinatesConstOfLE constantStep (Nat.le_refl i) x idx = x := by
+  rw [natCoordinatesConstOfLE_apply, natCoordinatesOfLE_self]
 
 end AlgebraTower

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -75,6 +75,8 @@ scripts/              repo utilities and validation helpers
   use `CompPoly/Data/RingTheory/AlgebraTower/Coordinates.lean`. Its executable packing and
   coordinate vectors correspond to the basis in
   `CompPoly/Data/RingTheory/AlgebraTower/Basis.lean`; successor coordinate counts may vary.
+  Both leaves support arbitrary comparable endpoints, with constant-count coordinates also
+  presented on a `Fin` type whose size is a power of the successor count.
 - Adding regression coverage: start in `tests/` and mirror the source namespace when
   possible.
 - Updating benchmark coverage or reports: start in `bench/`.

--- a/docs/wiki/repo-map.md
+++ b/docs/wiki/repo-map.md
@@ -71,6 +71,10 @@ scripts/              repo utilities and validation helpers
   `CompPoly/LinearAlgebra/`.
 - Moving a reusable support lemma that should not live next to one specific feature:
   start in `CompPoly/Data/` or `CompPoly/ToMathlib/`.
+- Composing chosen finite coordinates along a natural-number-indexed algebra tower:
+  use `CompPoly/Data/RingTheory/AlgebraTower/Coordinates.lean`. Its executable packing and
+  coordinate vectors correspond to the basis in
+  `CompPoly/Data/RingTheory/AlgebraTower/Basis.lean`; successor coordinate counts may vary.
 - Adding regression coverage: start in `tests/` and mirror the source namespace when
   possible.
 - Updating benchmark coverage or reports: start in `bench/`.

--- a/tests/CompPolyTests.lean
+++ b/tests/CompPolyTests.lean
@@ -25,6 +25,7 @@ public import CompPolyTests.Bivariate.WeightedDegree
 public import CompPolyTests.Data.MvPolynomial.Notation
 public import CompPolyTests.Data.Polynomial.RabinCertificate
 public import CompPolyTests.Data.RingTheory.AlgebraTower
+public import CompPolyTests.Data.RingTheory.AlgebraTower.Coordinates
 public import CompPolyTests.Fields.BLS12_377.Fast
 public import CompPolyTests.Fields.BLS12_381.Fast
 public import CompPolyTests.Fields.BN254.Fast

--- a/tests/CompPolyTests/Data/RingTheory/AlgebraTower.lean
+++ b/tests/CompPolyTests/Data/RingTheory/AlgebraTower.lean
@@ -9,12 +9,16 @@ import CompPoly.Data.RingTheory.AlgebraTower
 import Mathlib.Data.ZMod.Basic
 
 /-!
-# Algebra tower identity regression tests
+# Algebra tower identity and adjacent-map regression tests
 
 The projection `(x, y) ↦ (x, x)` on `GF(2) × GF(2)` is an idempotent ring endomorphism.
 Using it between every pair of levels gives coherent maps whose self-maps are not identities.
 The identity law excludes this family of maps. Identity maps on the same carrier give a valid
 tower over a commutative semiring that is not a field.
+
+Using the projection only as the adjacent step gives a valid tower via `AlgebraTower.ofNatStep`.
+Symbolic clients check composition and recover any existing natural-number-indexed tower
+from its adjacent maps.
 -/
 
 namespace CompPolyTests.AlgebraTower
@@ -33,6 +37,53 @@ example (i : ι) (h : i ≤ i) (x : A i) :
   simp only [AlgebraTower.algebraMap_self_apply]
 
 end Generic
+
+section NatStep
+
+variable {A : ℕ → Type*} [∀ k, CommSemiring (A k)]
+  (step : ∀ k, A k →+* A (k + 1))
+
+example (i : ℕ) (h : i ≤ i) :
+    (AlgebraTower.ofNatStep step).algebraMap i i h = RingHom.id (A i) :=
+  (AlgebraTower.ofNatStep step).algebraMap_self' i
+
+example (i : ℕ) (h : i ≤ i + 1) :
+    (AlgebraTower.ofNatStep step).algebraMap i (i + 1) h = step i := by
+  simp
+
+example {i j : ℕ} (h h' : i ≤ j) :
+    (AlgebraTower.ofNatStep step).algebraMap i j h =
+      (AlgebraTower.ofNatStep step).algebraMap i j h' := rfl
+
+example {i j k : ℕ} (hij : i ≤ j) (hjk : j ≤ k) (x : A i) :
+    (AlgebraTower.ofNatStep step).algebraMap i k (hij.trans hjk) x =
+      (AlgebraTower.ofNatStep step).algebraMap j k hjk
+        ((AlgebraTower.ofNatStep step).algebraMap i j hij x) :=
+  congrArg (fun f : A i →+* A k => f x)
+    ((AlgebraTower.ofNatStep step).coherence' i j k hij hjk)
+
+example {i j k : ℕ} (hij : i ≤ j) (hjk : j ≤ k) :
+    letI := AlgebraTower.ofNatStep step
+    letI := AlgebraTower.toAlgebra (A := A) hij
+    letI := AlgebraTower.toAlgebra (A := A) hjk
+    letI := AlgebraTower.toAlgebra (A := A) (hij.trans hjk)
+    IsScalarTower (A i) (A j) (A k) :=
+  AlgebraTower.toIsScalarTower (AlgebraTower.ofNatStep step) hij hjk
+
+-- Reconstructing an existing tower from its adjacent maps preserves every comparable map.
+example [t : AlgebraTower A] {i j : ℕ} (h : i ≤ j) :
+    (AlgebraTower.ofNatStep (fun k => t.algebraMap k (k + 1) (Nat.le_succ k))).algebraMap
+      i j h = t.algebraMap i j h := by
+  induction h with
+  | refl =>
+    exact ((AlgebraTower.ofNatStep (fun k =>
+      t.algebraMap k (k + 1) (Nat.le_succ k))).algebraMap_self' i).trans
+        (t.algebraMap_self' i).symm
+  | @step j h ih =>
+    rw [AlgebraTower.ofNatStep_algebraMap_succ_right _ h, ih,
+      t.coherence' i j (j + 1) h (Nat.le_succ j)]
+
+end NatStep
 
 private abbrev R := ZMod 2 × ZMod 2
 
@@ -70,5 +121,25 @@ private abbrev constantTower : AlgebraTower (fun _ : ℕ => R) where
   coherence' _ _ _ _ _ := rfl
 
 example (x : R) : constantTower.algebraMap 0 2 (by decide) x = x := rfl
+
+/-- A valid tower with noninjective adjacent maps on the same non-field carrier. -/
+private abbrev projectionTower : AlgebraTower (fun _ : ℕ => R) :=
+  AlgebraTower.ofNatStep (fun _ => diagonal)
+
+example (k : ℕ) : projectionTower.algebraMap k k le_rfl (0, 1) = (0, 1) := by
+  rw [projectionTower.algebraMap_self']
+  rfl
+
+example : projectionTower.algebraMap 0 2 (by decide) (0, 1) = (0, 0) := by
+  rw [AlgebraTower.ofNatStep_algebraMap_succ_right _ (show 0 ≤ 1 by decide),
+    AlgebraTower.ofNatStep_algebraMap_succ]
+  rfl
+
+example (k : ℕ) :
+    ¬ Function.Injective (projectionTower.algebraMap k (k + 1) (Nat.le_succ k)) := by
+  rw [AlgebraTower.ofNatStep_algebraMap_succ]
+  intro h
+  have he := h (show diagonal (0, 1) = diagonal (0, 0) from rfl)
+  exact one_ne_zero (congrArg Prod.snd he)
 
 end CompPolyTests.AlgebraTower

--- a/tests/CompPolyTests/Data/RingTheory/AlgebraTower/Coordinates.lean
+++ b/tests/CompPolyTests/Data/RingTheory/AlgebraTower/Coordinates.lean
@@ -16,6 +16,10 @@ functions as the tower maps. A rectangular two-step example distinguishes the tw
 orders. Rank zero, rank one, and height zero exercise the boundary cases without field or
 nontriviality assumptions. Symbolic clients check the selected scalar action and the actual
 basis representation.
+
+Endpoint clients accept unrelated `i`, `j` and `h : i ≤ j` without client-side casts. Constant
+coordinate counts zero, one and two exercise the normalized index type. A zero intermediate
+count gives an explicitly noninjective tower map from a nontrivial source.
 -/
 
 namespace CompPolyTests.AlgebraTower.Coordinates
@@ -127,6 +131,74 @@ example (x : FunctionTower (fun _ => 0) 2) :
 example (r i n : ℕ) : coordinateSize (fun _ => r) i n = r ^ n :=
   coordinateSize_const r i n
 
+-- Endpoint transport preserves the independently specified rectangular order.
+#guard List.ofFn (show Fin 6 → ℕ from
+    natCoordinatesOfLE (functionCoordinates ranks) (show 0 ≤ 2 by decide)
+    rectangular) == [10, 11, 20, 21, 30, 31]
+#guard (show ℕ from natPackOfLE (functionCoordinates ranks) (show 0 ≤ 2 by decide)
+    ![10, 11, 20, 21, 30, 31] 2 0) == 30
+
+example (x : FunctionTower ranks 1) (idx : Fin 2) :
+    natCoordinatesOfLE (functionCoordinates ranks) (show 0 ≤ 1 by decide) x idx = x idx := by
+  rw [natCoordinatesOfLE_apply, natCoordinates_succ, natCoordinates_zero]
+  change x ⟨idx.val / 1, _⟩ = x idx
+  congr 1
+  exact Fin.ext (Nat.div_one idx.val)
+
+example : natBasisVectorOfLE (functionCoordinates ranks) (show 0 ≤ 2 by decide) 4 =
+    natBasisVector (functionCoordinates ranks) 0 2 4 :=
+  natBasisVectorOfLE_eq_natBasisVector _ _ _
+
+private def shiftedBinary : FunctionTower (fun _ => 2) 3 :=
+  ![![![10, 11], ![20, 21]], ![![30, 31], ![40, 41]]]
+
+-- Four coefficients over level one retain both entries of each lower-level element.
+#guard List.ofFn (fun idx => List.ofFn (show Fin 2 → ℕ from
+    natCoordinatesConstOfLE (functionCoordinates (fun _ => 2)) (show 1 ≤ 3 by decide)
+      shiftedBinary idx)) == [[10, 11], [20, 21], [30, 31], [40, 41]]
+#guard (show ℕ from (natCoordinatesConstOfLE (functionCoordinates (fun _ => 2))
+    (show 1 ≤ 3 by decide)).symm ![![10, 11], ![20, 21], ![30, 31], ![40, 41]]
+      1 0 1) == 31
+
+private abbrev zeroMiddle : ℕ → ℕ
+  | 0 => 2
+  | 1 => 0
+  | _ => 1
+
+example : (0 : FunctionTower zeroMiddle 1) ≠ 1 := by
+  intro h
+  exact Nat.zero_ne_one (congrFun h 0)
+
+-- The distinct source elements above have the same image in the zero function ring.
+example : (functionTower zeroMiddle).algebraMap 1 2 (by decide) 0 =
+    (functionTower zeroMiddle).algebraMap 1 2 (by decide) 1 := by
+  funext idx
+  exact Fin.elim0 idx
+
+example (x : FunctionTower zeroMiddle 3) :
+    natPackOfLE (functionCoordinates zeroMiddle) (show 1 ≤ 3 by decide)
+      (natCoordinatesOfLE (functionCoordinates zeroMiddle) (show 1 ≤ 3 by decide) x) = x :=
+  natPackOfLE_natCoordinatesOfLE _ _ _
+
+-- Zero successors give no coordinates at positive height, but one at height zero.
+example (x : FunctionTower (fun _ => 0) 2) :
+    (natCoordinatesConstOfLE (functionCoordinates (fun _ => 0)) (show 0 ≤ 2 by decide)).symm
+      (fun idx : Fin 0 => Fin.elim0 idx) = x := by
+  apply (natCoordinatesConstOfLE (functionCoordinates (fun _ => 0))
+    (show 0 ≤ 2 by decide)).injective
+  rw [LinearEquiv.apply_symm_apply]
+  funext idx
+  exact Fin.elim0 idx
+
+#guard List.ofFn (show Fin 1 → ℕ from
+    natCoordinatesConstOfLE (functionCoordinates (fun _ => 0))
+    (Nat.le_refl 0) 37) == [37]
+
+example {i j : ℕ} (h : i ≤ j) (x : FunctionTower (fun _ => 1) j) :
+    (natCoordinatesConstOfLE (functionCoordinates (fun _ => 1)) h).symm
+      (natCoordinatesConstOfLE (functionCoordinates (fun _ => 1)) h x) = x :=
+  LinearEquiv.symm_apply_apply _ _
+
 section Generic
 
 variable {A : ℕ → Type*} [∀ k, CommSemiring (A k)] [t : AlgebraTower A]
@@ -155,6 +227,62 @@ example (i n : ℕ) (c : Fin (coordinateSize d i n) → A i) :
     funext j
     rw [natBasis_repr, congrFun (natCoordinates_natPack step i n c) j]
   simpa only [hc] using (natBasis step i n).sum_repr (natPack step i n c)
+
+-- These endpoint types contain neither a client-side carrier cast nor a rewritten endpoint.
+example {i j : ℕ} (h : i ≤ j) (x : A j) :
+    natPackOfLE step h (natCoordinatesOfLE step h x) = x :=
+  natPackOfLE_natCoordinatesOfLE _ _ _
+
+example {i j : ℕ} (h : i ≤ j) (a : A i) (x : A j) :
+    natCoordinatesOfLE step h (t.algebraMap i j h a * x) =
+      a • natCoordinatesOfLE step h x := by
+  let := t.toAlgebra h
+  exact (natCoordinatesOfLE step h).map_smul a x
+
+example {i j : ℕ} (h h' : i ≤ j) : natCoordinatesOfLE step h = natCoordinatesOfLE step h' :=
+  rfl
+
+example {i j : ℕ} (h h' : i ≤ j) (c : Fin (coordinateSize d i (j - i)) → A i) :
+    natPackOfLE step h c = natPackOfLE step h' c := rfl
+
+example {i j : ℕ} (h h' : i ≤ j) :
+    natBasisVectorOfLE step h = natBasisVectorOfLE step h' := rfl
+
+example {i j : ℕ} (h h' : i ≤ j) : natBasisOfLE step h = natBasisOfLE step h' := rfl
+
+example {i j : ℕ} (h : i ≤ j) (c : Fin (coordinateSize d i (j - i)) → A i) :
+    letI := t.toAlgebra h
+    (natBasisOfLE step h).repr (natPackOfLE step h c) = c := by
+  let := t.toAlgebra h
+  funext idx
+  rw [natBasisOfLE_repr, congrFun (natCoordinatesOfLE_natPackOfLE step h c) idx]
+
+example {i j : ℕ} (h : i ≤ j) (c : Fin (coordinateSize d i (j - i)) → A i) :
+    letI := t.toAlgebra h
+    ∑ idx, c idx • natBasisOfLE step h idx = natPackOfLE step h c := by
+  let := t.toAlgebra h
+  have hc : (natBasisOfLE step h).repr (natPackOfLE step h c) = c := by
+    funext idx
+    rw [natBasisOfLE_repr, congrFun (natCoordinatesOfLE_natPackOfLE step h c) idx]
+  simpa only [hc] using (natBasisOfLE step h).sum_repr (natPackOfLE step h c)
+
+example {i j : ℕ} (h : i ≤ j) (idx : Fin (coordinateSize d i (j - i))) :
+    natBasisOfLE step h idx =
+      cast (congrArg A (Nat.add_sub_of_le h)) (natBasis step i (j - i) idx) :=
+  natBasisOfLE_apply _ _ _
+
+variable {r : ℕ}
+  (constantStep : ∀ k, letI := t.toAlgebra (Nat.le_succ k)
+    A (k + 1) ≃ₗ[A k] (Fin r → A k))
+
+example {i j : ℕ} (h h' : i ≤ j) :
+    natCoordinatesConstOfLE constantStep h = natCoordinatesConstOfLE constantStep h' := rfl
+
+example {i j : ℕ} (h : i ≤ j) (a : A i) (x : A j) :
+    natCoordinatesConstOfLE constantStep h (t.algebraMap i j h a * x) =
+      a • natCoordinatesConstOfLE constantStep h x := by
+  let := t.toAlgebra h
+  exact (natCoordinatesConstOfLE constantStep h).map_smul a x
 
 end Generic
 

--- a/tests/CompPolyTests/Data/RingTheory/AlgebraTower/Coordinates.lean
+++ b/tests/CompPolyTests/Data/RingTheory/AlgebraTower/Coordinates.lean
@@ -1,0 +1,161 @@
+/-
+Copyright (c) 2026 CompPoly Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: CompPoly Contributors
+-/
+module
+
+import CompPoly.Data.RingTheory.AlgebraTower.Basis
+meta import CompPoly.Data.RingTheory.AlgebraTower.Coordinates
+
+/-!
+# Finite-product tower coordinate tests
+
+Successive function rings give towers with arbitrary finite step ranks, using constant
+functions as the tower maps. A rectangular two-step example distinguishes the two index
+orders. Rank zero, rank one, and height zero exercise the boundary cases without field or
+nontriviality assumptions. Symbolic clients check the selected scalar action and the actual
+basis representation.
+-/
+
+namespace CompPolyTests.AlgebraTower.Coordinates
+
+open _root_.AlgebraTower
+
+private def FunctionTower (d : ℕ → ℕ) : ℕ → Type
+  | 0 => ℕ
+  | k + 1 => Fin (d k) → FunctionTower d k
+
+private instance functionTowerCommSemiring (d : ℕ → ℕ) :
+    (k : ℕ) → CommSemiring (FunctionTower d k)
+  | 0 => inferInstanceAs (CommSemiring ℕ)
+  | k + 1 =>
+      letI := functionTowerCommSemiring d k
+      inferInstanceAs (CommSemiring (Fin (d k) → FunctionTower d k))
+
+private def functionStep (d : ℕ → ℕ) (k : ℕ) :
+    FunctionTower d k →+* FunctionTower d (k + 1) :=
+  Pi.constRingHom (Fin (d k)) (FunctionTower d k)
+
+private instance functionTower (d : ℕ → ℕ) : AlgebraTower (FunctionTower d) :=
+  ofNatStep (functionStep d)
+
+private def functionCoordinates (d : ℕ → ℕ) (k : ℕ) :
+    letI := (functionTower d).toAlgebra (Nat.le_succ k)
+    FunctionTower d (k + 1) ≃ₗ[FunctionTower d k] (Fin (d k) → FunctionTower d k) := by
+  letI := (functionTower d).toAlgebra (Nat.le_succ k)
+  exact {
+    toFun := id
+    invFun := id
+    left_inv := fun _ => rfl
+    right_inv := fun _ => rfl
+    map_add' := fun _ _ => rfl
+    map_smul' := fun a x => by
+      funext b
+      change (((ofNatStep (functionStep d)).algebraMap k (k + 1) (Nat.le_succ k) a) * x) b =
+        a * x b
+      rw [ofNatStep_algebraMap_succ]
+      rfl }
+
+private abbrev ranks : ℕ → ℕ
+  | 0 => 2
+  | 1 => 3
+  | _ => 1
+
+private def rectangular : FunctionTower ranks 2 := ![![10, 11], ![20, 21], ![30, 31]]
+
+-- Compiled execution uses the coordinate maps and packing, without the noncomputable Basis.
+#guard List.ofFn (show Fin 6 → ℕ from
+    natCoordinates (functionCoordinates ranks) 0 2 rectangular) ==
+  [10, 11, 20, 21, 30, 31]
+#guard (show ℕ from natPack (functionCoordinates ranks) 0 2
+    ![10, 11, 20, 21, 30, 31] 2 0) == 30
+#guard List.ofFn (show Fin 6 → ℕ from natCoordinates (functionCoordinates ranks) 0 2
+    (natBasisVector (functionCoordinates ranks) 0 2 4)) == [0, 0, 0, 0, 1, 0]
+
+private theorem rectangular_pack :
+    natPack (functionCoordinates ranks) 0 2 ![10, 11, 20, 21, 30, 31] = rectangular := by
+  simp only [natPack_succ, natPack_zero]
+  funext b j
+  fin_cases b <;> fin_cases j <;> rfl
+
+-- The preceding-level coordinate varies fastest, even when the next rank differs.
+example : natCoordinates (functionCoordinates ranks) 0 2 rectangular =
+    ![10, 11, 20, 21, 30, 31] := by
+  rw [← rectangular_pack, natCoordinates_natPack]
+
+-- The transposed order is still a bijection, but gives a different second coefficient.
+example : natCoordinates (functionCoordinates ranks) 0 2 rectangular 1 ≠
+    rectangular ((finProdFinEquiv.symm (1 : Fin (2 * 3))).2)
+      ((finProdFinEquiv.symm (1 : Fin (2 * 3))).1) := by
+  conv_lhs => rw [← rectangular_pack]
+  change natCoordinates (functionCoordinates ranks) 0 2
+    (natPack (functionCoordinates ranks) 0 2 ![10, 11, 20, 21, 30, 31]) 1 ≠ rectangular 1 0
+  rw [congrFun (natCoordinates_natPack (functionCoordinates ranks) 0 2
+    ![10, 11, 20, 21, 30, 31]) 1]
+  change (11 : ℕ) ≠ 20
+  decide
+
+example (x : ℕ) : natCoordinates (functionCoordinates ranks) 0 0 x 0 = x :=
+  natCoordinates_zero _ _ _ _
+
+-- A legitimate first basis vector need not be one in the target ring.
+example : natBasisVector (functionCoordinates ranks) 0 1 0 ≠
+    (1 : FunctionTower ranks 1) := by
+  intro h
+  have hone : natCoordinates (functionCoordinates ranks) 0 1
+      (1 : FunctionTower ranks 1) 1 = 1 := by
+    rw [natCoordinates_succ, natCoordinates_zero]
+    rfl
+  have hc := congrArg (fun x : FunctionTower ranks 1 =>
+    natCoordinates (functionCoordinates ranks) 0 1 x 1) h
+  rw [congrFun (natCoordinates_natBasisVector (functionCoordinates ranks) 0 1 0) 1,
+    hone] at hc
+  exact Nat.zero_ne_one hc
+
+example (x : FunctionTower (fun _ => 1) 3) :
+    natPack (functionCoordinates (fun _ => 1)) 1 2
+      (natCoordinates (functionCoordinates (fun _ => 1)) 1 2 x) = x :=
+  natPack_natCoordinates _ _ _ _
+
+-- A zero successor rank is a valid free presentation of a zero function ring.
+example (x : FunctionTower (fun _ => 0) 2) :
+    natPack (functionCoordinates (fun _ => 0)) 0 2
+      (natCoordinates (functionCoordinates (fun _ => 0)) 0 2 x) = x :=
+  natPack_natCoordinates _ _ _ _
+
+example (r i n : ℕ) : coordinateSize (fun _ => r) i n = r ^ n :=
+  coordinateSize_const r i n
+
+section Generic
+
+variable {A : ℕ → Type*} [∀ k, CommSemiring (A k)] [t : AlgebraTower A]
+  {d : ℕ → ℕ}
+  (step : ∀ k, letI := t.toAlgebra (Nat.le_succ k)
+    A (k + 1) ≃ₗ[A k] (Fin (d k) → A k))
+
+example (i n : ℕ) (a : A i) (x : A (i + n)) :
+    natCoordinates step i n (t.algebraMap i (i + n) (Nat.le_add_right i n) a * x) =
+      a • natCoordinates step i n x := by
+  let := t.toAlgebra (Nat.le_add_right i n)
+  exact (natCoordinates step i n).map_smul a x
+
+example (i n : ℕ) (c : Fin (coordinateSize d i n) → A i) :
+    letI := t.toAlgebra (Nat.le_add_right i n)
+    (natBasis step i n).repr (natPack step i n c) = c := by
+  let := t.toAlgebra (Nat.le_add_right i n)
+  funext j
+  rw [natBasis_repr, congrFun (natCoordinates_natPack step i n c) j]
+
+example (i n : ℕ) (c : Fin (coordinateSize d i n) → A i) :
+    letI := t.toAlgebra (Nat.le_add_right i n)
+    ∑ j, c j • natBasis step i n j = natPack step i n c := by
+  let := t.toAlgebra (Nat.le_add_right i n)
+  have hc : (natBasis step i n).repr (natPack step i n c) = c := by
+    funext j
+    rw [natBasis_repr, congrFun (natCoordinates_natPack step i n c) j]
+  simpa only [hc] using (natBasis step i n).sum_repr (natPack step i n c)
+
+end Generic
+
+end CompPolyTests.AlgebraTower.Coordinates


### PR DESCRIPTION
The concrete tower core imports the abstract multilinear basis even though its declarations use only shared support. Replace that dependency with `Support.DefiningPoly`, and declare the remaining dependencies where they are used: irreducibility support in concrete `Field`, generic `AlgebraTower` in concrete `Algebra`, and the abstract basis in the `Equiv` bridge.

Every production declaration, proof, and operation remains unchanged. A regression imports the complete concrete basis-coordinate API and rejects any loaded abstract tower module; the existing equivalence bridge and aggregate still expose both constructions. The wiki records the boundary.

Validation: full library build, tests, axiom sweep, and style/import/documentation checks pass. The sweep reports 9,969 declarations with zero admitted or nonstandard-axiom dependencies. Concrete coordinate/basis clients and the abstract/concrete bridge compile, and reintroducing an abstract import triggers the new regression.

Advances the construction dependency boundary in #322; no construction rewrite or timing improvement is claimed.
